### PR TITLE
feat: synchronized scroll and fix editor font size

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     @State private var mode: ViewMode = .edit
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @State private var widthBeforeSplit: CGFloat?
+    @StateObject private var scrollSync = ScrollSync()
 
     private var wordCount: Int {
         document.text.split { $0.isWhitespace || $0.isNewline }.count
@@ -53,14 +54,14 @@ struct ContentView: View {
         Group {
             switch mode {
             case .edit:
-                EditorView(text: $document.text)
+                EditorView(text: $document.text, fontSize: CGFloat(fontSize))
             case .sideBySide:
                 HSplitView {
-                    EditorView(text: $document.text)
-                    PreviewView(markdown: document.text)
+                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync)
+                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync)
                 }
             case .preview:
-                PreviewView(markdown: document.text)
+                PreviewView(markdown: document.text, fontSize: CGFloat(fontSize))
             }
         }
         .frame(minWidth: mode == .sideBySide ? 1000 : 500, minHeight: 400)

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -3,6 +3,8 @@ import AppKit
 
 struct EditorView: NSViewRepresentable {
     @Binding var text: String
+    var fontSize: CGFloat = 16
+    var scrollSync: ScrollSync?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -49,6 +51,7 @@ struct EditorView: NSViewRepresentable {
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
         textView.textContainer?.widthTracksTextView = true
+        textView.layoutManager?.allowsNonContiguousLayout = true
 
         // Insertion point color
         textView.insertionPointColor = Theme.textColor
@@ -67,6 +70,17 @@ struct EditorView: NSViewRepresentable {
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
+        context.coordinator.scrollSync = scrollSync
+        scrollSync?.editorScrollView = scrollView
+
+        // Observe scroll position for sync
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.scrollViewDidScroll(_:)),
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
 
         return scrollView
     }
@@ -87,8 +101,15 @@ struct EditorView: NSViewRepresentable {
             .paragraphStyle: paragraph
         ]
 
-        // Re-highlight to pick up new colors
-        context.coordinator.highlighter?.highlightAll(textView.textStorage!)
+        // Re-highlight when appearance or font size changes
+        let currentScheme = colorScheme
+        let currentFontSize = fontSize
+        if context.coordinator.lastColorScheme != currentScheme || context.coordinator.lastFontSize != currentFontSize {
+            context.coordinator.lastColorScheme = currentScheme
+            context.coordinator.lastFontSize = currentFontSize
+            textView.font = Theme.editorFont
+            context.coordinator.highlighter?.highlightAll(textView.textStorage!)
+        }
 
         // Only update text if it changed externally (not from user typing)
         if !context.coordinator.isUpdating && textView.string != text {
@@ -106,6 +127,10 @@ struct EditorView: NSViewRepresentable {
         var isUpdating = false
         var highlighter: MarkdownSyntaxHighlighter?
         weak var textView: NSTextView?
+        var scrollSync: ScrollSync?
+        var lastColorScheme: ColorScheme?
+        var lastFontSize: CGFloat?
+        private var lastScrollTime: TimeInterval = 0
 
         init(_ parent: EditorView) {
             self.parent = parent
@@ -116,6 +141,43 @@ struct EditorView: NSViewRepresentable {
             isUpdating = true
             parent.text = textView.string
             isUpdating = false
+        }
+
+        @objc func scrollViewDidScroll(_ notification: Notification) {
+            guard let clipView = notification.object as? NSClipView,
+                  let scrollView = clipView.enclosingScrollView,
+                  let textView = scrollView.documentView as? NSTextView,
+                  let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+
+            // Throttle to ~60fps
+            let now = CACurrentMediaTime()
+            guard now - lastScrollTime >= 0.016 else { return }
+            lastScrollTime = now
+
+            // Find the character at the CENTER of the visible area
+            let centerY = clipView.bounds.origin.y + clipView.bounds.height / 2
+            let adjustedY = centerY + textView.textContainerInset.height
+            let glyphIndex = layoutManager.glyphIndex(for: NSPoint(x: 0, y: adjustedY), in: textContainer)
+            let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+
+            // Count line number at that character position
+            let text = textView.string
+            var line = 1
+            var i = text.startIndex
+            let limit = text.index(text.startIndex, offsetBy: min(charIndex, text.count))
+            while i < limit {
+                if text[i] == "\n" { line += 1 }
+                i = text.index(after: i)
+            }
+
+            // Compute fractional progress within the current line's visual height
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            let lineTop = lineRect.origin.y - textView.textContainerInset.height
+            let lineHeight = lineRect.height
+            let frac = lineHeight > 0 ? min(1, max(0, (centerY - lineTop) / lineHeight)) : 0
+
+            scrollSync?.editorDidScroll(line: Double(line) + frac)
         }
     }
 }

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -3,6 +3,8 @@ import WebKit
 
 struct PreviewView: NSViewRepresentable {
     let markdown: String
+    var fontSize: CGFloat = 18
+    var scrollSync: ScrollSync?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -11,32 +13,161 @@ struct PreviewView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
+        if scrollSync != nil {
+            config.userContentController.add(context.coordinator, name: "scrollSync")
+        }
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.underPageBackgroundColor = Theme.backgroundColor
         webView.alphaValue = 0 // hidden until content loads
-        loadHTML(in: webView)
+        context.coordinator.scrollSync = scrollSync
+        scrollSync?.previewWebView = webView
+        loadHTML(in: webView, context: context)
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         webView.underPageBackgroundColor = Theme.backgroundColor
-        loadHTML(in: webView)
+        context.coordinator.scrollSync = scrollSync
+        scrollSync?.previewWebView = webView
+
+        let key = "\(markdown)__\(fontSize)"
+        if context.coordinator.lastContentKey != key {
+            loadHTML(in: webView, context: context)
+        }
     }
 
-    private func loadHTML(in webView: WKWebView) {
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        if coordinator.scrollSync != nil {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
+        }
+    }
+
+    private func loadHTML(in webView: WKWebView, context: Context) {
+        context.coordinator.lastContentKey = "\(markdown)__\(fontSize)"
         let htmlBody = MarkdownRenderer.renderHTML(markdown)
+        let scrollJS = scrollSync != nil ? """
+        // Keep block positions fresh when the preview reflows.
+        window._spCache = [];
+        window._cacheRebuildPending = false;
+        window._parseSourcePos = function(sp) {
+            var match = /^(\\d+):(\\d+)-(\\d+):(\\d+)$/.exec(sp || '');
+            if (!match) return null;
+            return {
+                startLine: parseInt(match[1], 10),
+                startColumn: parseInt(match[2], 10),
+                endLine: parseInt(match[3], 10),
+                endColumn: parseInt(match[4], 10)
+            };
+        };
+        window._rebuildSpCache = function() {
+            window._spCache = [];
+            document.querySelectorAll('[data-sourcepos]').forEach(function(el) {
+                var pos = window._parseSourcePos(el.getAttribute('data-sourcepos'));
+                if (!pos) return;
+                var rect = el.getBoundingClientRect();
+                window._spCache.push({
+                    startLine: pos.startLine,
+                    startColumn: pos.startColumn,
+                    endLine: pos.endLine,
+                    endColumn: pos.endColumn,
+                    top: rect.top + window.scrollY,
+                    bottom: rect.bottom + window.scrollY
+                });
+            });
+        };
+        window._scheduleCacheRebuild = function() {
+            if (window._cacheRebuildPending) return;
+            window._cacheRebuildPending = true;
+            requestAnimationFrame(function() {
+                window._cacheRebuildPending = false;
+                window._rebuildSpCache();
+            });
+        };
+        window._rebuildSpCache();
+
+        if (window.ResizeObserver) {
+            window._resizeObserver = new ResizeObserver(function() {
+                window._scheduleCacheRebuild();
+            });
+            window._resizeObserver.observe(document.body);
+        }
+
+        // Smooth scroll loop — decouples async evaluateJavaScript from actual scrolling
+        window._targetScrollY = window.scrollY;
+        window._syncFromEditor = false;
+        (function syncLoop() {
+            if (window._syncFromEditor) {
+                var diff = window._targetScrollY - window.scrollY;
+                if (Math.abs(diff) > 0.5) {
+                    window.scrollTo(0, window.scrollY + diff * 0.45);
+                } else {
+                    window._syncFromEditor = false;
+                }
+            }
+            requestAnimationFrame(syncLoop);
+        })();
+
+        // Preview scroll listener for preview→editor sync
+        var _scrollTicking = false;
+        window.addEventListener('scroll', function() {
+            if (window._syncFromEditor) return;
+            if (_scrollTicking) return;
+            _scrollTicking = true;
+            requestAnimationFrame(function() {
+                var c = window._spCache;
+                var sy = window.scrollY + window.innerHeight / 2;
+                if (!c || !c.length) {
+                    window.webkit.messageHandlers.scrollSync.postMessage({
+                        startLine: 1,
+                        startColumn: 1,
+                        endLine: 1,
+                        endColumn: 1,
+                        progress: 0
+                    });
+                    _scrollTicking = false;
+                    return;
+                }
+                var anchor = {
+                    startLine: 1,
+                    startColumn: 1,
+                    endLine: 1,
+                    endColumn: 1,
+                    progress: 0
+                };
+                for (var i = 0; i < c.length; i++) {
+                    if (c[i].top > sy) break;
+                    anchor = c[i];
+                }
+                var height = Math.max(1, anchor.bottom - anchor.top);
+                var progress = Math.max(0, Math.min(1, (sy - anchor.top) / height));
+                window.webkit.messageHandlers.scrollSync.postMessage({
+                    startLine: anchor.startLine,
+                    startColumn: anchor.startColumn,
+                    endLine: anchor.endLine,
+                    endColumn: anchor.endColumn,
+                    progress: progress
+                });
+                _scrollTicking = false;
+            });
+        });
+        """ : ""
         let html = """
         <!DOCTYPE html>
         <html>
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css)</style>
+        <style>\(PreviewCSS.css(fontSize: fontSize))</style>
         </head>
         <body>\(htmlBody)</body>
         <script>
         document.querySelectorAll('img').forEach(function(img) {
+            if (!img.complete) {
+                img.addEventListener('load', function() {
+                    window._scheduleCacheRebuild && window._scheduleCacheRebuild();
+                }, { once: true });
+            }
             img.addEventListener('error', function() {
                 var el = document.createElement('div');
                 el.className = 'img-placeholder';
@@ -44,17 +175,45 @@ struct PreviewView: NSViewRepresentable {
                 el.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>' + (label ? '<span>' + label + '</span>' : '');
                 if (img.width) el.style.width = img.width + 'px';
                 img.replaceWith(el);
+                window._scheduleCacheRebuild && window._scheduleCacheRebuild();
             });
         });
+        \(scrollJS)
         </script>
         </html>
         """
         webView.loadHTMLString(html, baseURL: nil)
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        var scrollSync: ScrollSync?
+        var lastContentKey: String?
+        var didInitialLoad = false
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            webView.alphaValue = 1
+            if !didInitialLoad {
+                webView.alphaValue = 1
+                didInitialLoad = true
+            }
+            scrollSync?.syncPreview()
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == "scrollSync",
+                  let body = message.body as? [String: Any],
+                  let startLine = (body["startLine"] as? NSNumber)?.intValue,
+                  let startColumn = (body["startColumn"] as? NSNumber)?.intValue,
+                  let endLine = (body["endLine"] as? NSNumber)?.intValue,
+                  let endColumn = (body["endColumn"] as? NSNumber)?.intValue,
+                  let progress = (body["progress"] as? NSNumber)?.doubleValue else { return }
+
+            scrollSync?.previewDidScroll(anchor: PreviewSourceAnchor(
+                startLine: startLine,
+                startColumn: startColumn,
+                endLine: endLine,
+                endColumn: endColumn,
+                progress: progress
+            ))
         }
     }
 }

--- a/Clearly/ScrollSync.swift
+++ b/Clearly/ScrollSync.swift
@@ -1,0 +1,208 @@
+import Foundation
+import WebKit
+
+struct PreviewSourceAnchor {
+    let startLine: Int
+    let startColumn: Int
+    let endLine: Int
+    let endColumn: Int
+    let progress: Double
+
+    var approximateLine: Double {
+        let span = max(0, endLine - startLine)
+        return Double(startLine) + (Double(span) * progress)
+    }
+}
+
+class ScrollSync: ObservableObject {
+    enum ScrollSource { case none, editor, preview }
+
+    var scrollSource: ScrollSource = .none
+    var topLine: Double = 1
+    weak var previewWebView: WKWebView?
+    weak var editorScrollView: NSScrollView?
+    private var lastPreviewAnchor: PreviewSourceAnchor?
+
+    private func resetSource(_ expected: ScrollSource) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            if self?.scrollSource == expected { self?.scrollSource = .none }
+        }
+    }
+
+    func editorDidScroll(line: Double) {
+        guard scrollSource != .preview else { return }
+        scrollSource = .editor
+        topLine = line
+        lastPreviewAnchor = nil
+        syncPreviewToLine(line)
+        resetSource(.editor)
+    }
+
+    func previewDidScroll(anchor: PreviewSourceAnchor) {
+        guard scrollSource != .editor else { return }
+        scrollSource = .preview
+        topLine = anchor.approximateLine
+        lastPreviewAnchor = anchor
+        syncEditorToAnchor(anchor)
+        resetSource(.preview)
+    }
+
+    func syncPreviewToLine(_ line: Double) {
+        // Compute target Y from cached positions and hand off to the RAF lerp loop.
+        // The loop smoothly interpolates at the browser's frame rate, so uneven
+        // evaluateJavaScript arrival times don't cause jitter.
+        let js = """
+        (function() {
+            var c = window._spCache;
+            if (!c || !c.length) return;
+            var current = c[0], next = null;
+            for (var i = 0; i < c.length; i++) {
+                if (c[i].startLine <= \(line)) {
+                    current = c[i];
+                } else {
+                    next = c[i];
+                    break;
+                }
+            }
+            var y;
+            if (\(line) >= current.startLine && \(line) <= current.endLine && current.endLine > current.startLine) {
+                var blockFrac = (\(line) - current.startLine) / (current.endLine - current.startLine);
+                y = current.top + blockFrac * (current.bottom - current.top);
+            } else if (next) {
+                var currentEnd = Math.max(current.startLine, current.endLine);
+                if (next.startLine > currentEnd && \(line) > currentEnd) {
+                    var gapFrac = (\(line) - currentEnd) / (next.startLine - currentEnd);
+                    y = current.bottom + Math.max(0, Math.min(1, gapFrac)) * (next.top - current.bottom);
+                } else {
+                    y = current.top;
+                }
+            } else {
+                y = current.bottom;
+            }
+            window._targetScrollY = Math.max(0, y - window.innerHeight / 2);
+            window._syncFromEditor = true;
+        })();
+        """
+        previewWebView?.evaluateJavaScript(js)
+    }
+
+    func syncPreviewToAnchor(_ anchor: PreviewSourceAnchor) {
+        let js = """
+        (function() {
+            var c = window._spCache;
+            if (!c || !c.length) return;
+            var match = null;
+            for (var i = 0; i < c.length; i++) {
+                if (
+                    c[i].startLine === \(anchor.startLine) &&
+                    c[i].startColumn === \(anchor.startColumn) &&
+                    c[i].endLine === \(anchor.endLine) &&
+                    c[i].endColumn === \(anchor.endColumn)
+                ) {
+                    match = c[i];
+                    break;
+                }
+            }
+            var y;
+            if (match) {
+                y = match.top + Math.max(0, Math.min(1, \(anchor.progress))) * (match.bottom - match.top);
+            } else {
+                var line = \(anchor.approximateLine);
+                var current = c[0], next = null;
+                for (var i = 0; i < c.length; i++) {
+                    if (c[i].startLine <= line) {
+                        current = c[i];
+                    } else {
+                        next = c[i];
+                        break;
+                    }
+                }
+                if (line >= current.startLine && line <= current.endLine && current.endLine > current.startLine) {
+                    var blockFrac = (line - current.startLine) / (current.endLine - current.startLine);
+                    y = current.top + blockFrac * (current.bottom - current.top);
+                } else if (next) {
+                    var currentEnd = Math.max(current.startLine, current.endLine);
+                    if (next.startLine > currentEnd && line > currentEnd) {
+                        var gapFrac = (line - currentEnd) / (next.startLine - currentEnd);
+                        y = current.bottom + Math.max(0, Math.min(1, gapFrac)) * (next.top - current.bottom);
+                    } else {
+                        y = current.top;
+                    }
+                } else {
+                    y = current.bottom;
+                }
+            }
+            window._targetScrollY = Math.max(0, y - window.innerHeight / 2);
+            window._syncFromEditor = true;
+        })();
+        """
+        previewWebView?.evaluateJavaScript(js)
+    }
+
+    func syncPreview() {
+        if let lastPreviewAnchor {
+            syncPreviewToAnchor(lastPreviewAnchor)
+        } else {
+            syncPreviewToLine(topLine)
+        }
+    }
+
+    func syncEditorToAnchor(_ anchor: PreviewSourceAnchor) {
+        guard let scrollView = editorScrollView,
+              let textView = scrollView.documentView as? NSTextView,
+              let layoutManager = textView.layoutManager else { return }
+
+        let text = textView.string as NSString
+        guard text.length > 0 else {
+            scrollView.contentView.setBoundsOrigin(.zero)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            return
+        }
+
+        let startOffset = utf16Offset(in: text, line: anchor.startLine, column: anchor.startColumn)
+        let endOffset = utf16Offset(in: text, line: anchor.endLine, column: anchor.endColumn)
+        let lower = min(startOffset, endOffset)
+        let upper = max(startOffset, endOffset)
+        let targetOffset = lower + Int(round(Double(upper - lower) * max(0, min(1, anchor.progress))))
+        let safeOffset = min(max(0, targetOffset), max(0, text.length - 1))
+
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: safeOffset)
+        let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+
+        let halfViewport = scrollView.contentView.bounds.height / 2
+        let y = max(0, lineRect.origin.y - halfViewport)
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: y))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    private func utf16Offset(in text: NSString, line: Int, column: Int) -> Int {
+        let targetLine = max(1, line)
+        var currentLine = 1
+        var lineStart = 0
+
+        while currentLine < targetLine && lineStart < text.length {
+            let nextLineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            lineStart = NSMaxRange(nextLineRange)
+            currentLine += 1
+        }
+
+        if lineStart >= text.length {
+            return text.length
+        }
+
+        let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+        var lineEnd = NSMaxRange(lineRange)
+        while lineEnd > lineRange.location {
+            let scalar = text.character(at: lineEnd - 1)
+            if scalar == 10 || scalar == 13 {
+                lineEnd -= 1
+            } else {
+                break
+            }
+        }
+
+        let clampedColumn = max(1, column)
+        let offsetInLine = min(clampedColumn - 1, max(0, lineEnd - lineStart))
+        return min(text.length, lineStart + offsetInLine)
+    }
+}

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -20,7 +20,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             <html>
             <head>
             <meta charset="utf-8">
-            <style>\(PreviewCSS.css)</style>
+            <style>\(PreviewCSS.css())</style>
             </head>
             <body>\(htmlBody)</body>
             </html>

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -5,7 +5,7 @@ enum MarkdownRenderer {
     static func renderHTML(_ markdown: String) -> String {
         guard !markdown.isEmpty else { return "" }
         let len = markdown.utf8.count
-        let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE)
+        let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS)
         // Try GFM renderer first (tables, strikethrough, task lists, autolinks)
         if let buf = cmark_gfm_markdown_to_html(markdown, len, options) {
             let html = String(cString: buf)

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 enum PreviewCSS {
-    static let css = """
+    static func css(fontSize: CGFloat = 18) -> String {
+    """
     * {
         margin: 0;
         padding: 0;
@@ -10,7 +11,7 @@ enum PreviewCSS {
 
     body {
         font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-        font-size: 18px;
+        font-size: \(Int(fontSize))px;
         line-height: 1.6;
         max-width: 42em;
         margin: 0 auto;
@@ -223,4 +224,5 @@ enum PreviewCSS {
         }
     }
     """
+    }
 }


### PR DESCRIPTION
## Summary

Adds real-time scroll synchronization between editor and preview modes, and fixes the editor to properly respond to font size changes. Font size now updates responsively in both editor and preview instead of only affecting the preview.

## Changes

- Pass fontSize setting to both editor and preview views for consistent updates
- Implement precise scroll synchronization in side-by-side mode using line-level anchors
- Fix editor to detect and apply font size changes via SwiftUI parameter passing
- Update preview CSS to respect the fontSize setting
- Add source position tracking to HTML for accurate scroll mapping
- Fix WKUserContentController cleanup to prevent crashes in preview-only mode

## Testing

- [x] Font size changes update editor in real-time
- [x] Font size changes update preview in real-time  
- [x] Scroll position syncs between editor and preview in side-by-side mode
- [x] Preview-only mode (⌘3) doesn't crash
- [x] Both modes maintain correct formatting and colors

Fixes #2