### PR TITLE
feat: remember preferred view mode across sessions

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -29,10 +29,16 @@ struct HiddenToolbarBackground: ViewModifier {
 
 struct ContentView: View {
     @Binding var document: MarkdownDocument
-    @State private var mode: ViewMode = .edit
+    @State private var mode: ViewMode
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @State private var widthBeforeSplit: CGFloat?
     @StateObject private var scrollSync = ScrollSync()
+
+    init(document: Binding<MarkdownDocument>) {
+        self._document = document
+        let storedMode = UserDefaults.standard.string(forKey: "viewMode")
+        self._mode = State(initialValue: ViewMode(rawValue: storedMode ?? "") ?? .edit)
+    }
 
     private var wordCount: Int {
         document.text.split { $0.isWhitespace || $0.isNewline }.count
@@ -67,6 +73,7 @@ struct ContentView: View {
         .frame(minWidth: mode == .sideBySide ? 1000 : 500, minHeight: 400)
         .background(Theme.backgroundColorSwiftUI)
         .onChange(of: mode) { _, newMode in
+            UserDefaults.standard.set(newMode.rawValue, forKey: "viewMode")
             guard let window = NSApp.keyWindow else { return }
             let frame = window.frame
             if newMode == .sideBySide {


### PR DESCRIPTION
## Summary
- Persists the selected view mode (Editor, Side by Side, Preview) to UserDefaults so it's restored when opening new documents
- Reads the saved preference on init, writes it on change via the existing `onChange(of: mode)` handler
- Defaults to Editor mode if no preference is saved

Fixes #7