### PR TITLE
feat: add Cmd+/Cmd- keyboard shortcuts for font size

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -27,6 +27,9 @@ struct ClearlyApp: App {
             CommandGroup(after: .textEditing) {
                 ViewModeCommands()
             }
+            CommandGroup(after: .textFormatting) {
+                FontSizeCommands()
+            }
             CommandMenu("Format") {
                 Button("Bold") {
                     NSApp.sendAction(#selector(ClearlyTextView.toggleBold(_:)), to: nil, from: nil)
@@ -76,6 +79,24 @@ struct ViewModeCommands: View {
             mode?.wrappedValue = .preview
         }
         .keyboardShortcut("3", modifiers: .command)
+    }
+}
+
+// MARK: - Font Size Commands
+
+struct FontSizeCommands: View {
+    @AppStorage("editorFontSize") private var fontSize: Double = 16
+
+    var body: some View {
+        Button("Increase Font Size") {
+            fontSize = min(fontSize + 1, 24)
+        }
+        .keyboardShortcut("+", modifiers: .command)
+
+        Button("Decrease Font Size") {
+            fontSize = max(fontSize - 1, 12)
+        }
+        .keyboardShortcut("-", modifiers: .command)
     }
 }
 

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -162,13 +162,15 @@ struct EditorView: NSViewRepresentable {
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
 
             // Count line number at that character position
-            let text = textView.string
+            let text = textView.string as NSString
+            let safeCharIndex = min(charIndex, text.length)
             var line = 1
-            var i = text.startIndex
-            let limit = text.index(text.startIndex, offsetBy: min(charIndex, text.count))
-            while i < limit {
-                if text[i] == "\n" { line += 1 }
-                i = text.index(after: i)
+            var position = 0
+            while position < safeCharIndex {
+                let lineRange = text.lineRange(for: NSRange(location: position, length: 0))
+                if NSMaxRange(lineRange) > safeCharIndex { break }
+                line += 1
+                position = NSMaxRange(lineRange)
             }
 
             // Compute fractional progress within the current line's visual height

--- a/Clearly/ScrollSync.swift
+++ b/Clearly/ScrollSync.swift
@@ -56,6 +56,8 @@ class ScrollSync: ObservableObject {
             var c = window._spCache;
             if (!c || !c.length) return;
             var current = c[0], next = null;
+            var wholeLine = Math.floor(\(line));
+            var fractional = Math.max(0, Math.min(1, \(line) - wholeLine));
             for (var i = 0; i < c.length; i++) {
                 if (c[i].startLine <= \(line)) {
                     current = c[i];
@@ -68,6 +70,8 @@ class ScrollSync: ObservableObject {
             if (\(line) >= current.startLine && \(line) <= current.endLine && current.endLine > current.startLine) {
                 var blockFrac = (\(line) - current.startLine) / (current.endLine - current.startLine);
                 y = current.top + blockFrac * (current.bottom - current.top);
+            } else if (current.startLine === current.endLine && wholeLine === current.startLine) {
+                y = current.top + fractional * (current.bottom - current.top);
             } else if (next) {
                 var currentEnd = Math.max(current.startLine, current.endLine);
                 if (next.startLine > currentEnd && \(line) > currentEnd) {
@@ -109,6 +113,8 @@ class ScrollSync: ObservableObject {
             } else {
                 var line = \(anchor.approximateLine);
                 var current = c[0], next = null;
+                var wholeLine = Math.floor(line);
+                var fractional = Math.max(0, Math.min(1, line - wholeLine));
                 for (var i = 0; i < c.length; i++) {
                     if (c[i].startLine <= line) {
                         current = c[i];
@@ -120,6 +126,8 @@ class ScrollSync: ObservableObject {
                 if (line >= current.startLine && line <= current.endLine && current.endLine > current.startLine) {
                     var blockFrac = (line - current.startLine) / (current.endLine - current.startLine);
                     y = current.top + blockFrac * (current.bottom - current.top);
+                } else if (current.startLine === current.endLine && wholeLine === current.startLine) {
+                    y = current.top + fractional * (current.bottom - current.top);
                 } else if (next) {
                     var currentEnd = Math.max(current.startLine, current.endLine);
                     if (next.startLine > currentEnd && line > currentEnd) {


### PR DESCRIPTION
## Summary
- Adds Cmd+ and Cmd- keyboard shortcuts to increase/decrease editor font size (12–24pt range), matching the existing Settings slider bounds
- Fixes scroll sync line counting to use NSString `lineRange` for more robust line number calculation
- Improves scroll sync accuracy for single-line blocks by interpolating with fractional line position

Fixes #8