### PR TITLE
feat: PDF export, print, and page breaks

### DIFF
--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -24,6 +24,12 @@ struct ClearlyApp: App {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)
             }
+            CommandGroup(after: .importExport) {
+                ExportPDFCommand()
+            }
+            CommandGroup(replacing: .printItem) {
+                PrintCommand()
+            }
             CommandGroup(after: .textEditing) {
                 ViewModeCommands()
             }
@@ -52,6 +58,12 @@ struct ClearlyApp: App {
                     NSApp.sendAction(#selector(ClearlyTextView.insertLink(_:)), to: nil, from: nil)
                 }
                 .keyboardShortcut("k", modifiers: .command)
+
+                Divider()
+
+                Button("Page Break") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertPageBreak(_:)), to: nil, from: nil)
+                }
             }
         }
 
@@ -116,6 +128,36 @@ struct CheckForUpdatesView: View {
             updater.checkForUpdates()
         }
         .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
+    }
+}
+
+// MARK: - Export / Print Commands
+
+struct ExportPDFCommand: View {
+    @FocusedValue(\.documentText) var text
+    @AppStorage("editorFontSize") private var fontSize: Double = 16
+
+    var body: some View {
+        Button("Export as PDF…") {
+            guard let text else { return }
+            PDFExporter().exportPDF(markdown: text, fontSize: CGFloat(fontSize))
+        }
+        .disabled(text == nil)
+        .keyboardShortcut("e", modifiers: [.command, .shift])
+    }
+}
+
+struct PrintCommand: View {
+    @FocusedValue(\.documentText) var text
+    @AppStorage("editorFontSize") private var fontSize: Double = 16
+
+    var body: some View {
+        Button("Print…") {
+            guard let text else { return }
+            PDFExporter().printHTML(markdown: text, fontSize: CGFloat(fontSize))
+        }
+        .disabled(text == nil)
+        .keyboardShortcut("p", modifiers: .command)
     }
 }
 

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -2,6 +2,13 @@ import AppKit
 
 final class ClearlyTextView: NSTextView {
 
+    // MARK: - Print
+
+    override func printView(_ sender: Any?) {
+        let fontSize = UserDefaults.standard.double(forKey: "editorFontSize")
+        PDFExporter().printHTML(markdown: string, fontSize: CGFloat(fontSize > 0 ? fontSize : 16))
+    }
+
     // MARK: - Find
 
     @objc func showFindPanel(_ sender: Any?) {
@@ -63,6 +70,12 @@ final class ClearlyTextView: NSTextView {
         }
 
         insertText(newLine, replacementRange: lineRange)
+    }
+
+    @objc func insertPageBreak(_ sender: Any?) {
+        let range = selectedRange()
+        let snippet = "\n\n<div class=\"page-break\"></div>\n\n"
+        insertText(snippet, replacementRange: range)
     }
 
     // MARK: - Helpers

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -10,10 +10,18 @@ struct ViewModeKey: FocusedValueKey {
     typealias Value = Binding<ViewMode>
 }
 
+struct DocumentTextKey: FocusedValueKey {
+    typealias Value = String
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
         set { self[ViewModeKey.self] = newValue }
+    }
+    var documentText: String? {
+        get { self[DocumentTextKey.self] }
+        set { self[DocumentTextKey.self] = newValue }
     }
 }
 
@@ -141,5 +149,6 @@ struct ContentView: View {
         .modifier(HiddenToolbarBackground())
         .animation(nil, value: mode)
         .focusedSceneValue(\.viewMode, $mode)
+        .focusedSceneValue(\.documentText, document.text)
     }
 }

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -1,0 +1,237 @@
+import AppKit
+import WebKit
+
+final class PDFExporter: NSObject, WKNavigationDelegate {
+    private static var current: PDFExporter?
+    private static let pageSize = NSSize(width: 612, height: 792)
+    private static let margin: CGFloat = 54 // 0.75 inch
+    private static let contentWidth = pageSize.width - (margin * 2)
+
+    private var webView: WKWebView?
+    private var hiddenWindow: NSWindow?
+    private var exportURL: URL?
+    private var isPrint = false
+
+    func exportPDF(markdown: String, fontSize: CGFloat) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.pdf]
+        panel.nameFieldStringValue = "Untitled.pdf"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        PDFExporter.current = self
+        exportURL = url
+        isPrint = false
+        loadHTML(markdown: markdown, fontSize: fontSize)
+    }
+
+    func printHTML(markdown: String, fontSize: CGFloat) {
+        PDFExporter.current = self
+        exportURL = nil
+        isPrint = true
+        loadHTML(markdown: markdown, fontSize: fontSize)
+    }
+
+    private func loadHTML(markdown: String, fontSize: CGFloat) {
+        let renderWidth = isPrint ? Self.pageSize.width : Self.contentWidth
+        let config = WKWebViewConfiguration()
+        let wv = WKWebView(frame: NSRect(x: 0, y: 0, width: renderWidth, height: Self.pageSize.height), configuration: config)
+        wv.navigationDelegate = self
+        self.webView = wv
+
+        // WKWebView must be in a window for printOperation to work
+        let window = NSWindow(
+            contentRect: NSRect(x: -20000, y: -20000, width: renderWidth, height: Self.pageSize.height),
+            styleMask: .borderless, backing: .buffered, defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = wv
+        window.orderBack(nil)
+        self.hiddenWindow = window
+
+        let htmlBody = MarkdownRenderer.renderHTML(markdown)
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <style>\(PreviewCSS.css(fontSize: fontSize, forExport: !isPrint))</style>
+        </head>
+        <body>\(htmlBody)</body>
+        </html>
+        """
+        wv.loadHTMLString(html, baseURL: nil)
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if isPrint {
+            let printInfo = makePrintInfo()
+            let op = webView.printOperation(with: printInfo)
+            op.showsPrintPanel = true
+            op.showsProgressPanel = true
+            if let window = NSApp.mainWindow {
+                op.runModal(for: window, delegate: self, didRun: #selector(operationDidRun(_:success:contextInfo:)), contextInfo: nil)
+            } else {
+                _ = op.run()
+                cleanup()
+            }
+        } else {
+            Task { @MainActor in
+                do {
+                    guard let exportURL else {
+                        cleanup()
+                        return
+                    }
+                    let scrollHeight = try await documentHeight(in: webView)
+                    let breakPoints = try await pageBreakPositions(in: webView)
+                    let data = try await tallPDFData(in: webView, height: scrollHeight)
+                    try writePaginatedPDF(sourceData: data, breakPoints: breakPoints, to: exportURL)
+                } catch {
+                    showExportError(error)
+                }
+                cleanup()
+            }
+        }
+    }
+
+    @objc private func operationDidRun(_ op: NSPrintOperation, success: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        cleanup()
+    }
+
+    private func cleanup() {
+        hiddenWindow?.orderOut(nil)
+        webView = nil
+        hiddenWindow = nil
+        exportURL = nil
+        PDFExporter.current = nil
+    }
+
+    // MARK: - Print
+
+    private func makePrintInfo() -> NSPrintInfo {
+        let printInfo = NSPrintInfo.shared.copy() as! NSPrintInfo
+        printInfo.paperSize = Self.pageSize
+        printInfo.topMargin = Self.margin
+        printInfo.bottomMargin = Self.margin
+        printInfo.leftMargin = Self.margin
+        printInfo.rightMargin = Self.margin
+        printInfo.horizontalPagination = .automatic
+        printInfo.verticalPagination = .automatic
+        printInfo.isHorizontallyCentered = false
+        printInfo.isVerticallyCentered = false
+        return printInfo
+    }
+
+    // MARK: - Export helpers
+
+    private func documentHeight(in webView: WKWebView) async throws -> CGFloat {
+        let value = try await webView.evaluateJavaScript("document.documentElement.scrollHeight")
+        guard let number = value as? NSNumber else {
+            throw ExportError.invalidDocumentHeight
+        }
+        return CGFloat(number.doubleValue)
+    }
+
+    private func pageBreakPositions(in webView: WKWebView) async throws -> [CGFloat] {
+        let js = """
+        Array.from(document.querySelectorAll('.page-break, [style*=\"page-break\"]')).map(
+            el => el.getBoundingClientRect().top + window.scrollY
+        )
+        """
+        let value = try await webView.evaluateJavaScript(js)
+        guard let positions = value as? [NSNumber] else { return [] }
+        return positions.map { CGFloat($0.doubleValue) }
+    }
+
+    private func tallPDFData(in webView: WKWebView, height: CGFloat) async throws -> Data {
+        let config = WKPDFConfiguration()
+        config.rect = CGRect(x: 0, y: 0, width: Self.contentWidth, height: height)
+        return try await webView.pdf(configuration: config)
+    }
+
+    private func writePaginatedPDF(sourceData: Data, breakPoints: [CGFloat], to url: URL) throws {
+        guard let provider = CGDataProvider(data: sourceData as CFData),
+              let source = CGPDFDocument(provider),
+              let sourcePage = source.page(at: 1) else {
+            throw ExportError.invalidSourcePDF
+        }
+
+        let sourceBox = sourcePage.getBoxRect(.mediaBox)
+        let sourceHeight = sourceBox.height
+        let contentHeight = Self.pageSize.height - (Self.margin * 2)
+        let sortedBreaks = breakPoints.sorted()
+
+        // Build slice boundaries (Y offsets from top of source)
+        var sliceStarts: [CGFloat] = [0]
+        var y: CGFloat = 0
+        while y < sourceHeight {
+            var nextY = y + contentHeight
+
+            // Honor forced page breaks within this slice
+            for bp in sortedBreaks {
+                if bp > y && bp < nextY {
+                    nextY = bp
+                    break
+                }
+            }
+
+            nextY = min(nextY, sourceHeight)
+            if nextY <= y { break }
+            if nextY < sourceHeight {
+                sliceStarts.append(nextY)
+            }
+            y = nextY
+        }
+
+        // Create output PDF
+        var mediaBox = CGRect(origin: .zero, size: Self.pageSize)
+        guard let ctx = CGContext(url as CFURL, mediaBox: &mediaBox, nil) else {
+            throw ExportError.cannotCreateOutput
+        }
+
+        for (i, sliceY) in sliceStarts.enumerated() {
+            let nextSliceY = (i + 1 < sliceStarts.count) ? sliceStarts[i + 1] : sourceHeight
+
+            ctx.beginPage(mediaBox: &mediaBox)
+            ctx.saveGState()
+
+            // Clip to the content area (inside margins)
+            ctx.clip(to: CGRect(x: Self.margin, y: Self.margin, width: Self.contentWidth, height: contentHeight))
+
+            // Translate so this slice's top aligns with the top of the content area.
+            // In PDF coords (origin bottom-left): source top = sourceHeight.
+            // We want source Y = (sourceHeight - sliceY) to land at output Y = (margin + contentHeight).
+            let translateY = Self.margin + contentHeight - sourceHeight + sliceY
+            ctx.translateBy(x: Self.margin, y: translateY)
+            ctx.drawPDFPage(sourcePage)
+
+            ctx.restoreGState()
+            ctx.endPage()
+        }
+
+        ctx.closePDF()
+    }
+
+    private func showExportError(_ error: Error) {
+        let alert = NSAlert(error: error)
+        alert.runModal()
+    }
+}
+
+private enum ExportError: LocalizedError {
+    case invalidDocumentHeight
+    case invalidSourcePDF
+    case cannotCreateOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDocumentHeight:
+            return "Could not measure the document for PDF export."
+        case .invalidSourcePDF:
+            return "Could not generate the intermediate PDF for export."
+        case .cannotCreateOutput:
+            return "Could not create the exported PDF file."
+        }
+    }
+}

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -1,8 +1,59 @@
 import Foundation
 
 enum PreviewCSS {
-    static func css(fontSize: CGFloat = 18) -> String {
-    """
+    static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
+    let exportOverrides = forExport ? """
+    body {
+        color: #222222 !important;
+        background: white !important;
+        max-width: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    a { color: #3366AA !important; }
+    code {
+        background-color: #F0F0F0 !important;
+        color: #CC3333 !important;
+    }
+    pre {
+        background-color: #F5F5F5 !important;
+        border-color: #E0E0E0 !important;
+        color: #222222 !important;
+    }
+    pre code {
+        background: none !important;
+        color: #222222 !important;
+    }
+    blockquote {
+        border-left-color: #CCCCCC !important;
+        color: #666666 !important;
+    }
+    table th {
+        background-color: #F5F5F5 !important;
+        border-color: #DDDDDD !important;
+    }
+    table td {
+        border-color: #EEEEEE !important;
+    }
+    table tr:nth-child(even) {
+        background-color: #FAFAFA !important;
+    }
+    hr {
+        border-color: #DDDDDD !important;
+    }
+    .img-placeholder {
+        background-color: #F0F0F0 !important;
+        border-color: #CCCCCC !important;
+        color: #999999 !important;
+    }
+    .page-break {
+        height: 0 !important;
+        border: none !important;
+        margin: 0 !important;
+    }
+    """ : ""
+
+    return """
     * {
         margin: 0;
         padding: 0;
@@ -185,6 +236,19 @@ enum PreviewCSS {
         margin: 2em 0;
     }
 
+    .page-break {
+        display: block;
+        height: 0;
+        border-top: 2px dashed #CCCCCC;
+        margin: 2em 0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        .page-break {
+            border-top-color: #444444;
+        }
+    }
+
     img {
         max-width: 100%;
         height: auto;
@@ -223,6 +287,59 @@ enum PreviewCSS {
             color: #777777;
         }
     }
+
+    @media print {
+        body {
+            color: #222222 !important;
+            background-color: #FFFFFF !important;
+            max-width: none;
+            padding: 0;
+            margin: 0;
+        }
+        a { color: #3366AA !important; }
+        code {
+            background-color: #F0F0F0 !important;
+            color: #CC3333 !important;
+        }
+        pre {
+            background-color: #F5F5F5 !important;
+            border-color: #E0E0E0 !important;
+            color: #222222 !important;
+        }
+        pre code {
+            background: none !important;
+            color: #222222 !important;
+        }
+        blockquote {
+            border-left-color: #CCCCCC !important;
+            color: #666666 !important;
+        }
+        th {
+            background-color: #F5F5F5 !important;
+            border-color: #DDDDDD !important;
+        }
+        td {
+            border-color: #EEEEEE !important;
+        }
+        tr:nth-child(even) {
+            background-color: #FAFAFA !important;
+        }
+        hr {
+            border-color: #DDDDDD !important;
+        }
+        .img-placeholder {
+            background-color: #F0F0F0 !important;
+            border-color: #CCCCCC !important;
+            color: #999999 !important;
+        }
+        .page-break {
+            page-break-after: always;
+            break-after: page;
+            height: 0;
+            border: none;
+        }
+    }
+    \(exportOverrides)
     """
     }
 }


### PR DESCRIPTION
## Summary
- Adds **File > Export as PDF** (⇧⌘E) — renders markdown to a paginated letter-size PDF with 0.75" margins using WKWebView capture + CGContext pagination
- Adds **File > Print** (⌘P) — uses WKWebView's native print operation with proper margins and CSS page break support
- Adds **Format > Page Break** — inserts `<div class="page-break">` at cursor; shown as a dashed line in preview, honored as a forced break in both export and print
- Adds `com.apple.security.print` sandbox entitlement and `@media print` / `forExport` CSS overrides for light-mode colors
- Publishes document text via `FocusedValue` so export/print menu commands work in all view modes

## Test plan
- [ ] Open a markdown file, use ⇧⌘E to export as PDF — verify margins and content renders correctly
- [ ] Use ⌘P to print — verify print dialog appears with proper margins
- [ ] Insert a page break via Format > Page Break, export — verify page splits at the break
- [ ] Test in all three view modes (editor, side-by-side, preview)
- [ ] Verify release script still passes entitlement checks (`com.apple.security.print` is a standard sandbox entitlement, not a temporary-exception)

Fixes #15