### PR TITLE
Support public markdown document types

### DIFF
--- a/Clearly/Info.plist
+++ b/Clearly/Info.plist
@@ -26,6 +26,7 @@
 			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
+				<string>public.markdown</string>
 				<string>net.daringfireball.markdown</string>
 				<string>public.plain-text</string>
 			</array>

--- a/Clearly/MarkdownDocument.swift
+++ b/Clearly/MarkdownDocument.swift
@@ -2,12 +2,13 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension UTType {
-    static let markdown = UTType(importedAs: "net.daringfireball.markdown", conformingTo: .plainText)
+    static let publicMarkdown = UTType(importedAs: "public.markdown", conformingTo: .plainText)
+    static let daringFireballMarkdown = UTType(importedAs: "net.daringfireball.markdown", conformingTo: .plainText)
 }
 
 struct MarkdownDocument: FileDocument {
-    static var readableContentTypes: [UTType] { [.markdown, .plainText] }
-    static var writableContentTypes: [UTType] { [.markdown] }
+    static var readableContentTypes: [UTType] { [.publicMarkdown, .daringFireballMarkdown, .plainText] }
+    static var writableContentTypes: [UTType] { [.daringFireballMarkdown] }
 
     var text: String
 


### PR DESCRIPTION
- add `public.markdown` to the app document type bindings in `Info.plist` so LaunchServices can route those files to Clearly
- add a concrete `public.markdown` `UTType` in `MarkdownDocument` and include it in `readableContentTypes`
- keep writes on `net.daringfireball.markdown` so existing `.md` save behavior stays unchanged
- verification: `xcodebuild -scheme Clearly -configuration Debug build`

Fixes #17