### PR TITLE
feat: add text formatting context menu and math rendering

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -47,6 +47,11 @@ struct ClearlyApp: App {
                 }
                 .keyboardShortcut("i", modifiers: .command)
 
+                Button("Strikethrough") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleStrikethrough(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("x", modifiers: [.command, .shift])
+
                 Button("Heading") {
                     NSApp.sendAction(#selector(ClearlyTextView.insertHeading(_:)), to: nil, from: nil)
                 }
@@ -58,6 +63,58 @@ struct ClearlyApp: App {
                     NSApp.sendAction(#selector(ClearlyTextView.insertLink(_:)), to: nil, from: nil)
                 }
                 .keyboardShortcut("k", modifiers: .command)
+
+                Button("Image...") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertImage(_:)), to: nil, from: nil)
+                }
+
+                Divider()
+
+                Button("Bullet List") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleBulletList(_:)), to: nil, from: nil)
+                }
+
+                Button("Numbered List") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleNumberedList(_:)), to: nil, from: nil)
+                }
+
+                Button("Todo") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleTodoList(_:)), to: nil, from: nil)
+                }
+
+                Divider()
+
+                Button("Quote") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleBlockquote(_:)), to: nil, from: nil)
+                }
+
+                Button("Horizontal Rule") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertHorizontalRule(_:)), to: nil, from: nil)
+                }
+
+                Button("Table") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertMarkdownTable(_:)), to: nil, from: nil)
+                }
+
+                Divider()
+
+                Button("Code") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleInlineCode(_:)), to: nil, from: nil)
+                }
+
+                Button("Code Block") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertCodeBlock(_:)), to: nil, from: nil)
+                }
+
+                Divider()
+
+                Button("Math") {
+                    NSApp.sendAction(#selector(ClearlyTextView.toggleInlineMath(_:)), to: nil, from: nil)
+                }
+
+                Button("Math Block") {
+                    NSApp.sendAction(#selector(ClearlyTextView.insertMathBlock(_:)), to: nil, from: nil)
+                }
 
                 Divider()
 

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -72,13 +72,178 @@ final class ClearlyTextView: NSTextView {
         insertText(newLine, replacementRange: lineRange)
     }
 
+    @objc func toggleStrikethrough(_ sender: Any?) {
+        wrapSelection(prefix: "~~", suffix: "~~", placeholder: "strikethrough text")
+    }
+
+    @objc func insertImage(_ sender: Any?) {
+        let range = selectedRange()
+        let selected = (string as NSString).substring(with: range)
+        if selected.isEmpty {
+            insertText("![alt text](url)", replacementRange: range)
+            let urlStart = range.location + "![alt text](".utf16.count
+            setSelectedRange(NSRange(location: urlStart, length: "url".utf16.count))
+        } else {
+            insertText("![\(selected)](url)", replacementRange: range)
+            let urlStart = range.location + "![\(selected)](".utf16.count
+            setSelectedRange(NSRange(location: urlStart, length: "url".utf16.count))
+        }
+    }
+
+    @objc func toggleBulletList(_ sender: Any?) {
+        toggleLinePrefix(prefix: "- ", placeholder: "list item")
+    }
+
+    @objc func toggleNumberedList(_ sender: Any?) {
+        let range = selectedRange()
+        let selected = (string as NSString).substring(with: range)
+        if selected.isEmpty {
+            insertText("1. list item", replacementRange: range)
+            let start = range.location + "1. ".utf16.count
+            setSelectedRange(NSRange(location: start, length: "list item".utf16.count))
+            return
+        }
+        let lineRange = (string as NSString).lineRange(for: range)
+        let block = (string as NSString).substring(with: lineRange)
+        let lines = block.components(separatedBy: "\n")
+        var result: [String] = []
+        var num = 1
+        for line in lines {
+            if line.isEmpty {
+                result.append(line)
+            } else {
+                result.append("\(num). \(line)")
+                num += 1
+            }
+        }
+        insertText(result.joined(separator: "\n"), replacementRange: lineRange)
+    }
+
+    @objc func toggleTodoList(_ sender: Any?) {
+        toggleLinePrefix(prefix: "- [ ] ", placeholder: "task")
+    }
+
+    @objc func toggleBlockquote(_ sender: Any?) {
+        toggleLinePrefix(prefix: "> ", placeholder: "quote")
+    }
+
+    @objc func insertHorizontalRule(_ sender: Any?) {
+        let range = selectedRange()
+        insertText("\n\n---\n\n", replacementRange: range)
+    }
+
+    @objc func insertMarkdownTable(_ sender: Any?) {
+        let range = selectedRange()
+        let table = "| Column 1 | Column 2 | Column 3 |\n| --- | --- | --- |\n| Cell | Cell | Cell |"
+        insertText(table, replacementRange: range)
+    }
+
+    @objc func toggleInlineCode(_ sender: Any?) {
+        wrapSelection(prefix: "`", suffix: "`", placeholder: "code")
+    }
+
+    @objc func insertCodeBlock(_ sender: Any?) {
+        let range = selectedRange()
+        let selected = (string as NSString).substring(with: range)
+        if selected.isEmpty {
+            let snippet = "```\ncode\n```"
+            insertText(snippet, replacementRange: range)
+            let start = range.location + "```\n".utf16.count
+            setSelectedRange(NSRange(location: start, length: "code".utf16.count))
+        } else {
+            insertText("```\n\(selected)\n```", replacementRange: range)
+        }
+    }
+
+    @objc func toggleInlineMath(_ sender: Any?) {
+        wrapSelection(prefix: "$", suffix: "$", placeholder: "math")
+    }
+
+    @objc func insertMathBlock(_ sender: Any?) {
+        let range = selectedRange()
+        let selected = (string as NSString).substring(with: range)
+        if selected.isEmpty {
+            let snippet = "$$\nmath\n$$"
+            insertText(snippet, replacementRange: range)
+            let start = range.location + "$$\n".utf16.count
+            setSelectedRange(NSRange(location: start, length: "math".utf16.count))
+        } else {
+            insertText("$$\n\(selected)\n$$", replacementRange: range)
+        }
+    }
+
     @objc func insertPageBreak(_ sender: Any?) {
         let range = selectedRange()
         let snippet = "\n\n<div class=\"page-break\"></div>\n\n"
         insertText(snippet, replacementRange: range)
     }
 
+    // MARK: - Context Menu
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = super.menu(for: event) ?? NSMenu()
+
+        let formatMenu = NSMenu(title: "Text Format")
+
+        formatMenu.addItem(withTitle: "Headers", action: #selector(insertHeading(_:)), keyEquivalent: "")
+        formatMenu.addItem(.separator())
+
+        let boldItem = formatMenu.addItem(withTitle: "Bold", action: #selector(toggleBold(_:)), keyEquivalent: "b")
+        boldItem.keyEquivalentModifierMask = .command
+        let italicItem = formatMenu.addItem(withTitle: "Italic", action: #selector(toggleItalic(_:)), keyEquivalent: "i")
+        italicItem.keyEquivalentModifierMask = .command
+        let strikeItem = formatMenu.addItem(withTitle: "Strikethrough", action: #selector(toggleStrikethrough(_:)), keyEquivalent: "x")
+        strikeItem.keyEquivalentModifierMask = [.command, .shift]
+        formatMenu.addItem(.separator())
+
+        formatMenu.addItem(withTitle: "Insert Link", action: #selector(insertLink(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Insert Image", action: #selector(insertImage(_:)), keyEquivalent: "")
+        formatMenu.addItem(.separator())
+
+        formatMenu.addItem(withTitle: "List", action: #selector(toggleBulletList(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Ordered List", action: #selector(toggleNumberedList(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Todo", action: #selector(toggleTodoList(_:)), keyEquivalent: "")
+        formatMenu.addItem(.separator())
+
+        formatMenu.addItem(withTitle: "Quote", action: #selector(toggleBlockquote(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Horizontal Rule", action: #selector(insertHorizontalRule(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Table", action: #selector(insertMarkdownTable(_:)), keyEquivalent: "")
+        formatMenu.addItem(.separator())
+
+        formatMenu.addItem(withTitle: "Code", action: #selector(toggleInlineCode(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Code Block", action: #selector(insertCodeBlock(_:)), keyEquivalent: "")
+        formatMenu.addItem(.separator())
+
+        formatMenu.addItem(withTitle: "Math", action: #selector(toggleInlineMath(_:)), keyEquivalent: "")
+        formatMenu.addItem(withTitle: "Math Block", action: #selector(insertMathBlock(_:)), keyEquivalent: "")
+
+        let formatItem = NSMenuItem(title: "Text Format", action: nil, keyEquivalent: "")
+        formatItem.submenu = formatMenu
+
+        menu.insertItem(.separator(), at: 0)
+        menu.insertItem(formatItem, at: 0)
+
+        return menu
+    }
+
     // MARK: - Helpers
+
+    private func toggleLinePrefix(prefix: String, placeholder: String) {
+        let range = selectedRange()
+        let selected = (string as NSString).substring(with: range)
+        if selected.isEmpty {
+            let text = "\(prefix)\(placeholder)"
+            insertText(text, replacementRange: range)
+            let start = range.location + prefix.utf16.count
+            setSelectedRange(NSRange(location: start, length: placeholder.utf16.count))
+            return
+        }
+        let lineRange = (string as NSString).lineRange(for: range)
+        let block = (string as NSString).substring(with: lineRange)
+        let lines = block.components(separatedBy: "\n")
+        let result = lines.map { $0.isEmpty ? $0 : "\(prefix)\($0)" }
+        insertText(result.joined(separator: "\n"), replacementRange: lineRange)
+    }
 
     private func wrapSelection(prefix: String, suffix: String, placeholder: String) {
         let range = selectedRange()

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -57,6 +57,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         <style>\(PreviewCSS.css(fontSize: fontSize, forExport: !isPrint))</style>
         </head>
         <body>\(htmlBody)</body>
+        \(MathSupport.scriptHTML(for: htmlBody))
         </html>
         """
         wv.loadHTMLString(html, baseURL: nil)

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -183,6 +183,7 @@ struct PreviewView: NSViewRepresentable {
         });
         \(scrollJS)
         </script>
+        \(MathSupport.scriptHTML(for: htmlBody))
         \(MermaidSupport.scriptHTML)
         </html>
         """

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -23,6 +23,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             <style>\(PreviewCSS.css())</style>
             </head>
             <body>\(htmlBody)</body>
+            \(MathSupport.scriptHTML(for: htmlBody))
             \(MermaidSupport.scriptHTML)
             </html>
             """

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -6,18 +6,105 @@ enum MarkdownRenderer {
         guard !markdown.isEmpty else { return "" }
         let len = markdown.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS)
+        var html: String
         // Try GFM renderer first (tables, strikethrough, task lists, autolinks)
         if let buf = cmark_gfm_markdown_to_html(markdown, len, options) {
-            let html = String(cString: buf)
+            html = String(cString: buf)
             free(buf)
-            return html
-        }
-        // Fallback to basic CommonMark
-        if let buf = cmark_markdown_to_html(markdown, len, options) {
-            let html = String(cString: buf)
+        } else if let buf = cmark_markdown_to_html(markdown, len, options) {
+            // Fallback to basic CommonMark
+            html = String(cString: buf)
             free(buf)
-            return html
+        } else {
+            return ""
         }
-        return ""
+        html = processMath(html)
+        return html
+    }
+
+    /// Convert $...$ and $$...$$ in rendered HTML to KaTeX-compatible spans/divs.
+    /// Only transforms text nodes outside protected <code>/<pre> regions.
+    private static func processMath(_ html: String) -> String {
+        let (protectedHTML, protectedSegments) = protectCodeRegions(in: html)
+        guard let tagRegex = try? NSRegularExpression(pattern: #"<[^>]+>"#) else {
+            return restoreProtectedSegments(in: processMathText(protectedHTML), segments: protectedSegments)
+        }
+
+        var result = ""
+        var lastLocation = 0
+        let fullRange = NSRange(protectedHTML.startIndex..., in: protectedHTML)
+
+        for match in tagRegex.matches(in: protectedHTML, range: fullRange) {
+            let textRange = NSRange(location: lastLocation, length: match.range.location - lastLocation)
+            if let range = Range(textRange, in: protectedHTML) {
+                result += processMathText(String(protectedHTML[range]))
+            }
+            if let range = Range(match.range, in: protectedHTML) {
+                result += protectedHTML[range]
+            }
+            lastLocation = match.range.location + match.range.length
+        }
+
+        if lastLocation < fullRange.length {
+            let tailRange = NSRange(location: lastLocation, length: fullRange.length - lastLocation)
+            if let range = Range(tailRange, in: protectedHTML) {
+                result += processMathText(String(protectedHTML[range]))
+            }
+        }
+
+        return restoreProtectedSegments(in: result, segments: protectedSegments)
+    }
+
+    private static func processMathText(_ text: String) -> String {
+        var result = text
+        if let blockRegex = try? NSRegularExpression(pattern: #"\$\$(.+?)\$\$"#, options: .dotMatchesLineSeparators) {
+            result = blockRegex.stringByReplacingMatches(
+                in: result,
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: #"<div class="math-block">$1</div>"#
+            )
+        }
+        if let inlineRegex = try? NSRegularExpression(pattern: #"(?<![\\$])\$(?!\$)(.+?)(?<![\\$])\$"#) {
+            result = inlineRegex.stringByReplacingMatches(
+                in: result,
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: #"<span class="math-inline">$1</span>"#
+            )
+        }
+        return result
+    }
+
+    private static func protectCodeRegions(in html: String) -> (html: String, segments: [String]) {
+        guard let codeRegex = try? NSRegularExpression(
+            pattern: #"<(pre|code)\b[^>]*>[\s\S]*?<\/\1>"#,
+            options: [.caseInsensitive]
+        ) else {
+            return (html, [])
+        }
+
+        var protectedHTML = html
+        var segments: [String] = []
+        let matches = codeRegex.matches(in: html, range: NSRange(html.startIndex..., in: html)).reversed()
+
+        for match in matches {
+            guard let range = Range(match.range, in: protectedHTML) else { continue }
+            let segment = String(protectedHTML[range])
+            let token = "__CLEARLY_PROTECTED_CODE_\(segments.count)__"
+            segments.append(segment)
+            protectedHTML.replaceSubrange(range, with: token)
+        }
+
+        return (protectedHTML, segments)
+    }
+
+    private static func restoreProtectedSegments(in html: String, segments: [String]) -> String {
+        var restored = html
+        for (index, segment) in segments.enumerated() {
+            restored = restored.replacingOccurrences(
+                of: "__CLEARLY_PROTECTED_CODE_\(index)__",
+                with: segment
+            )
+        }
+        return restored
     }
 }

--- a/Shared/MermaidSupport.swift
+++ b/Shared/MermaidSupport.swift
@@ -37,3 +37,26 @@ enum MermaidSupport {
     </script>
     """
 }
+
+enum MathSupport {
+    static func scriptHTML(for htmlBody: String) -> String {
+        guard htmlBody.contains("math-inline") || htmlBody.contains("math-block") else {
+            return ""
+        }
+
+        return """
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+        <script>
+        if (window.katex) {
+            document.querySelectorAll('.math-block').forEach(function(el) {
+                katex.render(el.textContent, el, { displayMode: true, throwOnError: false });
+            });
+            document.querySelectorAll('.math-inline').forEach(function(el) {
+                katex.render(el.textContent, el, { displayMode: false, throwOnError: false });
+            });
+        }
+        </script>
+        """
+    }
+}

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -249,6 +249,16 @@ enum PreviewCSS {
         }
     }
 
+    .math-block {
+        text-align: center;
+        margin: 1em 0;
+        overflow-x: auto;
+    }
+
+    .math-inline {
+        display: inline;
+    }
+
     img {
         max-width: 100%;
         height: auto;


### PR DESCRIPTION
## Summary
- Adds a right-click "Text Format" context menu with formatting options: bold, italic, strikethrough, headings, lists (bullet, numbered, todo), blockquote, horizontal rule, table, code/code block, math/math block, links, images, and page break
- Mirrors all formatting options in the app's Format menu bar for parity
- Adds KaTeX-based math rendering for inline (`$...$`) and block (`$$...$$`) math expressions in preview
- Adds math-related CSS styling for proper display in both app preview and QuickLook extension

Fixes #9