### PR TITLE
fix: reduce QuickLook font size in Finder column preview

### DIFF
--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -20,7 +20,13 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             <html>
             <head>
             <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
             <style>\(PreviewCSS.css())</style>
+            <style>
+            @media (max-width: 400px) {
+                body { font-size: 14px; padding: 10px 20px 20px; }
+            }
+            </style>
             </head>
             <body>\(htmlBody)</body>
             \(MathSupport.scriptHTML(for: htmlBody))


### PR DESCRIPTION
## Summary
- Adds a viewport meta tag and responsive CSS media query to the QuickLook extension
- In Finder's narrow column preview (≤400px), text drops from 18px to 14px with tighter padding
- Full-size Space-bar QuickLook preview remains unchanged at 18px