### PR TITLE
fix: remove non-standard UTI and add bookmark entitlement for MDM

### DIFF
--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Clearly/Info.plist
+++ b/Clearly/Info.plist
@@ -26,7 +26,6 @@
 			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.markdown</string>
 				<string>net.daringfireball.markdown</string>
 				<string>public.plain-text</string>
 			</array>

--- a/Clearly/MarkdownDocument.swift
+++ b/Clearly/MarkdownDocument.swift
@@ -2,12 +2,11 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension UTType {
-    static let publicMarkdown = UTType(importedAs: "public.markdown", conformingTo: .plainText)
     static let daringFireballMarkdown = UTType(importedAs: "net.daringfireball.markdown", conformingTo: .plainText)
 }
 
 struct MarkdownDocument: FileDocument {
-    static var readableContentTypes: [UTType] { [.publicMarkdown, .daringFireballMarkdown, .plainText] }
+    static var readableContentTypes: [UTType] { [.daringFireballMarkdown, .plainText] }
     static var writableContentTypes: [UTType] { [.daringFireballMarkdown] }
 
     var text: String

--- a/ClearlyQuickLook/Info.plist
+++ b/ClearlyQuickLook/Info.plist
@@ -25,7 +25,6 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>net.daringfireball.markdown</string>
-				<string>public.markdown</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<true/>


### PR DESCRIPTION
## Summary

- Removed the non-standard `public.markdown` UTI from Swift code, app Info.plist, and QuickLook Info.plist — `public.*` is Apple's reserved namespace and this UTI doesn't exist
- Added `com.apple.security.files.bookmarks.app-scope` entitlement to explicitly support security-scoped bookmark resolution, which `DocumentGroup` relies on internally via `NSDocumentController` — this may fix file access failures on MDM-managed machines with stricter TCC policies
- The real system UTI `net.daringfireball.markdown` and `public.plain-text` remain as the readable content types

Fixes #25