### PR TITLE
feat: image paste support and local image preview rendering

### DIFF
--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -8,6 +8,10 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.print</key>

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -16,7 +16,7 @@ struct ClearlyApp: App {
 
     var body: some Scene {
         DocumentGroup(newDocument: MarkdownDocument()) { file in
-            ContentView(document: file.$document)
+            ContentView(document: file.$document, fileURL: file.fileURL)
         }
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 720, height: 900)
@@ -192,12 +192,13 @@ struct CheckForUpdatesView: View {
 
 struct ExportPDFCommand: View {
     @FocusedValue(\.documentText) var text
+    @FocusedValue(\.documentFileURL) var fileURL
     @AppStorage("editorFontSize") private var fontSize: Double = 16
 
     var body: some View {
         Button("Export as PDF…") {
             guard let text else { return }
-            PDFExporter().exportPDF(markdown: text, fontSize: CGFloat(fontSize))
+            PDFExporter().exportPDF(markdown: text, fontSize: CGFloat(fontSize), fileURL: fileURL)
         }
         .disabled(text == nil)
         .keyboardShortcut("e", modifiers: [.command, .shift])
@@ -206,12 +207,13 @@ struct ExportPDFCommand: View {
 
 struct PrintCommand: View {
     @FocusedValue(\.documentText) var text
+    @FocusedValue(\.documentFileURL) var fileURL
     @AppStorage("editorFontSize") private var fontSize: Double = 16
 
     var body: some View {
         Button("Print…") {
             guard let text else { return }
-            PDFExporter().printHTML(markdown: text, fontSize: CGFloat(fontSize))
+            PDFExporter().printHTML(markdown: text, fontSize: CGFloat(fontSize), fileURL: fileURL)
         }
         .disabled(text == nil)
         .keyboardShortcut("p", modifiers: .command)

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -1,12 +1,52 @@
 import AppKit
 
 final class ClearlyTextView: NSTextView {
+    var documentURL: URL?
 
     // MARK: - Print
 
     override func printView(_ sender: Any?) {
         let fontSize = UserDefaults.standard.double(forKey: "editorFontSize")
-        PDFExporter().printHTML(markdown: string, fontSize: CGFloat(fontSize > 0 ? fontSize : 16))
+        PDFExporter().printHTML(
+            markdown: string,
+            fontSize: CGFloat(fontSize > 0 ? fontSize : 16),
+            fileURL: documentURL
+        )
+    }
+
+    // MARK: - Paste
+
+    private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "svg", "tiff", "tif", "bmp", "heic"]
+
+    private static func encodeImagePath(_ path: String) -> String {
+        path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+    }
+
+    override func paste(_ sender: Any?) {
+        let pasteboard = NSPasteboard.general
+
+        // Check for file URLs on the pasteboard
+        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true
+        ]) as? [URL], !urls.isEmpty {
+            let imageURLs = urls.filter { Self.imageExtensions.contains($0.pathExtension.lowercased()) }
+            if !imageURLs.isEmpty {
+                let markdown = imageURLs.map { "![](\(Self.encodeImagePath($0.path)))" }.joined(separator: "\n")
+                insertText(markdown, replacementRange: selectedRange())
+                return
+            }
+        }
+
+        // Fallback: check if pasted string looks like an image file path
+        if let text = pasteboard.string(forType: .string)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           text.hasPrefix("/"),
+           !text.contains("\n"),
+           Self.imageExtensions.contains((text as NSString).pathExtension.lowercased()) {
+            insertText("![](\(Self.encodeImagePath(text)))", replacementRange: selectedRange())
+            return
+        }
+
+        super.paste(sender)
     }
 
     // MARK: - Find

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -14,6 +14,10 @@ struct DocumentTextKey: FocusedValueKey {
     typealias Value = String
 }
 
+struct DocumentFileURLKey: FocusedValueKey {
+    typealias Value = URL
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -22,6 +26,10 @@ extension FocusedValues {
     var documentText: String? {
         get { self[DocumentTextKey.self] }
         set { self[DocumentTextKey.self] = newValue }
+    }
+    var documentFileURL: URL? {
+        get { self[DocumentFileURLKey.self] }
+        set { self[DocumentFileURLKey.self] = newValue }
     }
 }
 
@@ -37,13 +45,15 @@ struct HiddenToolbarBackground: ViewModifier {
 
 struct ContentView: View {
     @Binding var document: MarkdownDocument
+    let fileURL: URL?
     @State private var mode: ViewMode
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @State private var widthBeforeSplit: CGFloat?
     @StateObject private var scrollSync = ScrollSync()
 
-    init(document: Binding<MarkdownDocument>) {
+    init(document: Binding<MarkdownDocument>, fileURL: URL? = nil) {
         self._document = document
+        self.fileURL = fileURL
         let storedMode = UserDefaults.standard.string(forKey: "viewMode")
         self._mode = State(initialValue: ViewMode(rawValue: storedMode ?? "") ?? .edit)
     }
@@ -68,14 +78,14 @@ struct ContentView: View {
         Group {
             switch mode {
             case .edit:
-                EditorView(text: $document.text, fontSize: CGFloat(fontSize))
+                EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL)
             case .sideBySide:
                 HSplitView {
-                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync)
-                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync)
+                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, scrollSync: scrollSync)
+                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync, fileURL: fileURL)
                 }
             case .preview:
-                PreviewView(markdown: document.text, fontSize: CGFloat(fontSize))
+                PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), fileURL: fileURL)
             }
         }
         .frame(minWidth: mode == .sideBySide ? 1000 : 500, minHeight: 400)
@@ -150,5 +160,6 @@ struct ContentView: View {
         .animation(nil, value: mode)
         .focusedSceneValue(\.viewMode, $mode)
         .focusedSceneValue(\.documentText, document.text)
+        .focusedSceneValue(\.documentFileURL, fileURL)
     }
 }

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -4,6 +4,7 @@ import AppKit
 struct EditorView: NSViewRepresentable {
     @Binding var text: String
     var fontSize: CGFloat = 16
+    var fileURL: URL?
     var scrollSync: ScrollSync?
     @Environment(\.colorScheme) private var colorScheme
 
@@ -55,6 +56,7 @@ struct EditorView: NSViewRepresentable {
 
         // Insertion point color
         textView.insertionPointColor = Theme.textColor
+        textView.documentURL = fileURL
 
         // Delegate
         textView.delegate = context.coordinator
@@ -86,11 +88,12 @@ struct EditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? NSTextView else { return }
+        guard let textView = scrollView.documentView as? ClearlyTextView else { return }
 
         // Always refresh colors (handles appearance changes via @Environment colorScheme)
         textView.backgroundColor = Theme.backgroundColor
         textView.insertionPointColor = Theme.textColor
+        textView.documentURL = fileURL
 
         // Update typing attributes for new text
         let paragraph = NSMutableParagraphStyle()

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -10,9 +10,10 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
     private var webView: WKWebView?
     private var hiddenWindow: NSWindow?
     private var exportURL: URL?
+    private var documentURL: URL?
     private var isPrint = false
 
-    func exportPDF(markdown: String, fontSize: CGFloat) {
+    func exportPDF(markdown: String, fontSize: CGFloat, fileURL: URL? = nil) {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.pdf]
         panel.nameFieldStringValue = "Untitled.pdf"
@@ -20,13 +21,15 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
 
         PDFExporter.current = self
         exportURL = url
+        documentURL = fileURL
         isPrint = false
         loadHTML(markdown: markdown, fontSize: fontSize)
     }
 
-    func printHTML(markdown: String, fontSize: CGFloat) {
+    func printHTML(markdown: String, fontSize: CGFloat, fileURL: URL? = nil) {
         PDFExporter.current = self
         exportURL = nil
+        documentURL = fileURL
         isPrint = true
         loadHTML(markdown: markdown, fontSize: fontSize)
     }
@@ -34,6 +37,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
     private func loadHTML(markdown: String, fontSize: CGFloat) {
         let renderWidth = isPrint ? Self.pageSize.width : Self.contentWidth
         let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         let wv = WKWebView(frame: NSRect(x: 0, y: 0, width: renderWidth, height: Self.pageSize.height), configuration: config)
         wv.navigationDelegate = self
         self.webView = wv
@@ -48,7 +52,8 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         window.orderBack(nil)
         self.hiddenWindow = window
 
-        let htmlBody = MarkdownRenderer.renderHTML(markdown)
+        let rawBody = MarkdownRenderer.renderHTML(markdown)
+        let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: documentURL)
         let html = """
         <!DOCTYPE html>
         <html>
@@ -60,25 +65,31 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         \(MathSupport.scriptHTML(for: htmlBody))
         </html>
         """
-        wv.loadHTMLString(html, baseURL: nil)
+        wv.loadHTMLString(html, baseURL: documentURL?.deletingLastPathComponent())
     }
 
     // MARK: - WKNavigationDelegate
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        if isPrint {
-            let printInfo = makePrintInfo()
-            let op = webView.printOperation(with: printInfo)
-            op.showsPrintPanel = true
-            op.showsProgressPanel = true
-            if let window = NSApp.mainWindow {
-                op.runModal(for: window, delegate: self, didRun: #selector(operationDidRun(_:success:contextInfo:)), contextInfo: nil)
-            } else {
-                _ = op.run()
-                cleanup()
+        Task { @MainActor in
+            do {
+                try await waitForImages(in: webView)
+            } catch {
+                // If image waiting JS fails, continue with export/print instead of blocking.
             }
-        } else {
-            Task { @MainActor in
+
+            if isPrint {
+                let printInfo = makePrintInfo()
+                let op = webView.printOperation(with: printInfo)
+                op.showsPrintPanel = true
+                op.showsProgressPanel = true
+                if let window = NSApp.mainWindow {
+                    op.runModal(for: window, delegate: self, didRun: #selector(operationDidRun(_:success:contextInfo:)), contextInfo: nil)
+                } else {
+                    _ = op.run()
+                    cleanup()
+                }
+            } else {
                 do {
                     guard let exportURL else {
                         cleanup()
@@ -105,6 +116,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         webView = nil
         hiddenWindow = nil
         exportURL = nil
+        documentURL = nil
         PDFExporter.current = nil
     }
 
@@ -143,6 +155,35 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         let value = try await webView.evaluateJavaScript(js)
         guard let positions = value as? [NSNumber] else { return [] }
         return positions.map { CGFloat($0.doubleValue) }
+    }
+
+    private func waitForImages(in webView: WKWebView) async throws {
+        _ = try await webView.callAsyncJavaScript(
+            """
+            const pendingImages = Array.from(document.images).filter(img => !img.complete);
+            if (pendingImages.length) {
+                await Promise.all(
+                    pendingImages.map(img => new Promise(resolve => {
+                        let settled = false;
+                        const finish = () => {
+                            if (settled) return;
+                            settled = true;
+                            clearTimeout(timeout);
+                            resolve(null);
+                        };
+                        const timeout = setTimeout(finish, 1000);
+                        img.addEventListener('load', finish, { once: true });
+                        img.addEventListener('error', finish, { once: true });
+                    }))
+                );
+            }
+            await new Promise(resolve => setTimeout(resolve, 50));
+            return true;
+            """,
+            arguments: [:],
+            in: nil,
+            contentWorld: .page
+        )
     }
 
     private func tallPDFData(in webView: WKWebView, height: CGFloat) async throws -> Data {

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -5,10 +5,11 @@ struct PreviewView: NSViewRepresentable {
     let markdown: String
     var fontSize: CGFloat = 18
     var scrollSync: ScrollSync?
+    var fileURL: URL?
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(colorScheme == .dark ? "dark" : "light")"
+        "\(markdown)__\(fontSize)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))"
     }
 
     func makeCoordinator() -> Coordinator {
@@ -17,6 +18,7 @@ struct PreviewView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         if scrollSync != nil {
             config.userContentController.add(context.coordinator, name: "scrollSync")
         }
@@ -48,7 +50,8 @@ struct PreviewView: NSViewRepresentable {
 
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
-        let htmlBody = MarkdownRenderer.renderHTML(markdown)
+        let rawBody = MarkdownRenderer.renderHTML(markdown)
+        let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
         let scrollJS = scrollSync != nil ? """
         // Keep block positions fresh when the preview reflows.
         window._spCache = [];

--- a/Shared/LocalImageSupport.swift
+++ b/Shared/LocalImageSupport.swift
@@ -1,0 +1,99 @@
+import Foundation
+import WebKit
+
+enum LocalImageSupport {
+    static let scheme = "clearly-file"
+
+    static func fileURLKeyFragment(_ fileURL: URL?) -> String {
+        fileURL?.path ?? ""
+    }
+
+    static func resolveImageSources(in html: String, relativeTo documentURL: URL?) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"(<img\s[^>]*?src\s*=\s*")([^"]+)("[^>]*?>)"#,
+            options: .caseInsensitive
+        ) else { return html }
+
+        let ns = html as NSString
+        let matches = regex.matches(in: html, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return html }
+
+        var result = html
+        for match in matches.reversed() {
+            guard match.numberOfRanges == 4,
+                  let prefixRange = Range(match.range(at: 1), in: result),
+                  let srcRange = Range(match.range(at: 2), in: result),
+                  let suffixRange = Range(match.range(at: 3), in: result) else { continue }
+
+            let src = String(result[srcRange])
+            guard let absolutePath = absolutePath(for: src, relativeTo: documentURL) else { continue }
+
+            let encoded = absolutePath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? absolutePath
+            let newSrc = "\(scheme)://localhost\(encoded)"
+            let fullRange = prefixRange.lowerBound..<suffixRange.upperBound
+            result.replaceSubrange(fullRange, with: "\(result[prefixRange])\(newSrc)\(result[suffixRange])")
+        }
+
+        return result
+    }
+
+    private static func absolutePath(for source: String, relativeTo documentURL: URL?) -> String? {
+        if source.hasPrefix("http://") || source.hasPrefix("https://") ||
+           source.hasPrefix("data:") || source.hasPrefix("\(scheme)://") {
+            return nil
+        }
+
+        var filePath = source
+        if filePath.hasPrefix("file://") {
+            filePath = String(filePath.dropFirst("file://".count))
+        }
+        filePath = filePath.removingPercentEncoding ?? filePath
+
+        if filePath.hasPrefix("/") {
+            return filePath
+        }
+
+        guard let documentDirectory = documentURL?.deletingLastPathComponent() else {
+            return nil
+        }
+
+        return documentDirectory.appendingPathComponent(filePath).path
+    }
+}
+
+final class LocalImageSchemeHandler: NSObject, WKURLSchemeHandler {
+    private static let mimeTypes: [String: String] = [
+        "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg",
+        "gif": "image/gif", "webp": "image/webp", "svg": "image/svg+xml",
+        "tiff": "image/tiff", "tif": "image/tiff", "bmp": "image/bmp",
+        "heic": "image/heic"
+    ]
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(URLError(.badURL))
+            return
+        }
+
+        let path = url.path.removingPercentEncoding ?? url.path
+        guard !path.isEmpty,
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+
+        let ext = (path as NSString).pathExtension.lowercased()
+        let mime = Self.mimeTypes[ext] ?? "application/octet-stream"
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": mime, "Content-Length": "\(data.count)"]
+        )!
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {}
+}


### PR DESCRIPTION
## Summary
- Pasting an image file path (e.g. from CleanShot) auto-wraps it in `![](path)` markdown syntax with proper percent-encoding for spaces
- Local images referenced in markdown now render in the preview pane and PDF export via a custom `WKURLSchemeHandler` that reads files in the app process
- Adds shared `LocalImageSupport` module with image path resolution and scheme handler, used by both PreviewView and PDFExporter
- Adds `com.apple.security.temporary-exception.files.home-relative-path.read-only` entitlement so the sandboxed app can read sibling image files
- Threads `fileURL` from DocumentGroup through the view hierarchy to enable relative path resolution

## Test plan
- [ ] Open a saved .md file, paste an image file path → should insert as `![](encoded-path)`
- [ ] Add `![](image.jpeg)` with an image file next to the .md file → should render in preview
- [ ] Verify PDF export includes local images
- [ ] Verify mermaid diagrams and math rendering still work
- [ ] Verify remote HTTP/HTTPS images still load in preview

Fixes #23