### PR TITLE
feat: show full file paths in Open Recent menu

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -4,6 +4,7 @@ import Sparkle
 @main
 struct ClearlyApp: App {
     @AppStorage("themePreference") private var themePreference = "system"
+    private let recentMenuHelper = RecentMenuHelper()
     private let updaterController: SPUStandardUpdaterController
 
     init() {

--- a/Clearly/RecentFilesMenuHelper.swift
+++ b/Clearly/RecentFilesMenuHelper.swift
@@ -1,0 +1,40 @@
+import AppKit
+
+class RecentMenuHelper: NSObject {
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(menuDidBeginTracking(_:)),
+            name: NSMenu.didBeginTrackingNotification,
+            object: nil
+        )
+    }
+
+    @objc private func menuDidBeginTracking(_ notification: Notification) {
+        guard let menu = notification.object as? NSMenu else { return }
+        for item in menu.items {
+            if let recentMenu = item.submenu,
+               recentMenu.items.contains(where: { $0.action == #selector(NSDocumentController.clearRecentDocuments(_:)) }) {
+                rewriteRecentMenuTitles(recentMenu)
+                return
+            }
+        }
+    }
+
+    private func rewriteRecentMenuTitles(_ menu: NSMenu) {
+        let recentURLs = NSDocumentController.shared.recentDocumentURLs
+        var urlIndex = 0
+        for item in menu.items {
+            if item.isSeparatorItem || item.action == #selector(NSDocumentController.clearRecentDocuments(_:)) {
+                continue
+            }
+            guard urlIndex < recentURLs.count else { break }
+            let url = recentURLs[urlIndex]
+            let filename = url.lastPathComponent
+            let dir = (url.deletingLastPathComponent().path as NSString).abbreviatingWithTildeInPath
+            item.title = "\(filename) — \(dir)"
+            urlIndex += 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `RecentMenuHelper` that observes menu tracking notifications and rewrites Open Recent menu item titles to show `filename — ~/path/to/dir` instead of just the filename
- Uses a non-invasive approach (notification observer, no delegate or AppDelegate) to avoid interfering with `DocumentGroup`'s document handling

## Test plan
- [x] Open several markdown files from different directories
- [x] Verify File > Open Recent shows full paths
- [x] Verify clicking a recent item opens the correct file
- [x] Verify "Clear Menu" still works

Fixes #28