### PR TITLE
fix: center text and cursor vertically in editor lines

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -3,6 +3,28 @@ import AppKit
 final class ClearlyTextView: NSTextView {
     var documentURL: URL?
 
+    // MARK: - Cursor
+
+    // Hide the macOS 14+ system insertion indicator so our custom drawInsertionPoint is visible
+    override func didAddSubview(_ subview: NSView) {
+        super.didAddSubview(subview)
+        if let indicator = subview as? NSTextInsertionIndicator {
+            indicator.displayMode = .hidden
+        }
+    }
+
+    override func drawInsertionPoint(in rect: NSRect, color: NSColor, turnedOn flag: Bool) {
+        var adjusted = rect
+        adjusted.size.width = 2
+        super.drawInsertionPoint(in: adjusted, color: color, turnedOn: flag)
+    }
+
+    override func setNeedsDisplay(_ rect: NSRect, avoidAdditionalLayout flag: Bool) {
+        var rect = rect
+        rect.size.width += 2
+        super.setNeedsDisplay(rect, avoidAdditionalLayout: flag)
+    }
+
     // MARK: - Print
 
     override func printView(_ sender: Any?) {

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -33,14 +33,17 @@ struct EditorView: NSViewRepresentable {
         textView.textColor = Theme.textColor
         textView.backgroundColor = Theme.backgroundColor
 
-        // Paragraph style with line height
+        // Paragraph style with line height — use min/max line height + baselineOffset
+        // so text is vertically centered in each line (not top-aligned like lineSpacing)
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = Theme.lineSpacing
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
         textView.defaultParagraphStyle = paragraph
         textView.typingAttributes = [
             .font: Theme.editorFont,
             .foregroundColor: Theme.textColor,
-            .paragraphStyle: paragraph
+            .paragraphStyle: paragraph,
+            .baselineOffset: Theme.editorBaselineOffset
         ]
 
         // Insets
@@ -97,11 +100,13 @@ struct EditorView: NSViewRepresentable {
 
         // Update typing attributes for new text
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = Theme.lineSpacing
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
         textView.typingAttributes = [
             .font: Theme.editorFont,
             .foregroundColor: Theme.textColor,
-            .paragraphStyle: paragraph
+            .paragraphStyle: paragraph,
+            .baselineOffset: Theme.editorBaselineOffset
         ]
 
         // Re-highlight when appearance or font size changes

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -95,12 +95,14 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
 
         // Reset to default style
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = Theme.lineSpacing
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
 
         textStorage.addAttributes([
             .font: Theme.editorFont,
             .foregroundColor: Theme.textColor,
-            .paragraphStyle: paragraph
+            .paragraphStyle: paragraph,
+            .baselineOffset: Theme.editorBaselineOffset
         ], range: fullRange)
 
         // Track code block ranges to skip inner highlighting

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -18,6 +18,19 @@ enum Theme {
     // MARK: - Line Spacing
     static let lineSpacing: CGFloat = 8
 
+    /// Desired line height = font natural height + lineSpacing
+    static var editorLineHeight: CGFloat {
+        let font = editorFont
+        return ceil(font.ascender - font.descender + font.leading) + lineSpacing
+    }
+
+    /// Baseline offset to vertically center text within the line height
+    static var editorBaselineOffset: CGFloat {
+        let font = editorFont
+        let naturalHeight = ceil(font.ascender - font.descender + font.leading)
+        return (editorLineHeight - naturalHeight) / 2
+    }
+
     // MARK: - Dynamic Colors (auto-resolve for light/dark)
 
     static let backgroundColor = NSColor(name: "themeBackground") { appearance in


### PR DESCRIPTION
## Summary
- Replaced `paragraph.lineSpacing` with `minimumLineHeight`/`maximumLineHeight` plus `.baselineOffset` so text is vertically centered within each line instead of top-aligned with padding below.
- Added a 2pt-wide custom cursor by hiding the macOS 14+ `NSTextInsertionIndicator` and overriding `drawInsertionPoint` in `ClearlyTextView`.
- Added `setNeedsDisplay(_:avoidAdditionalLayout:)` override to prevent cursor ghosting artifacts.

## Test plan
- [ ] Open a markdown file and verify text is vertically centered within line selection highlights
- [ ] Verify cursor is ~2pt wide and vertically centered with the text
- [ ] Test with different font sizes to confirm cursor and text centering adapts
- [ ] Test heading lines (larger font) to confirm cursor height matches