### PR TITLE
docs: add KaTeX math and frontmatter to README and marketing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Write with syntax highlighting, preview instantly, and get back to what matters.
 ## Features
 
 - **Syntax highlighting** — headings, bold, italic, links, code blocks, and more
-- **Instant preview** — rendered GitHub Flavored Markdown, including Mermaid diagrams
+- **Instant preview** — rendered GitHub Flavored Markdown, including Mermaid diagrams and KaTeX math
+- **Frontmatter support** — YAML frontmatter is formatted cleanly in both editor and preview
 - **Side-by-side** — edit and preview simultaneously with synchronized scrolling
 - **PDF export** — export to PDF or print directly from the app
 - **Format shortcuts** — Cmd+B, Cmd+I, Cmd+K for bold, italic, and links

--- a/website/index.html
+++ b/website/index.html
@@ -188,7 +188,7 @@
                 </div>
                 <div class="feature">
                     <h3>Instant Preview</h3>
-                    <p>Full GitHub Flavored Markdown support, including Mermaid diagrams.</p>
+                    <p>Full GitHub Flavored Markdown support, including Mermaid diagrams and KaTeX math.</p>
                 </div>
                 <div class="feature">
                     <h3>Side-by-Side</h3>
@@ -209,6 +209,10 @@
                 <div class="feature">
                     <h3>Light &amp; Dark</h3>
                     <p>Follows your system appearance or set it manually. Looks great either way.</p>
+                </div>
+                <div class="feature">
+                    <h3>Math &amp; Frontmatter</h3>
+                    <p>KaTeX math expressions render beautifully. YAML frontmatter is formatted cleanly in both editor and preview.</p>
                 </div>
                 <div class="feature" style="grid-column: 1 / -1;">
                     <h3>Open Source</h3>


### PR DESCRIPTION
## Summary
- Adds KaTeX math rendering and frontmatter support to the README feature list and marketing site feature grid
- Updates the "Instant Preview" descriptions to mention KaTeX math alongside Mermaid diagrams
- Adds a new "Math & Frontmatter" feature card to the marketing site

These features shipped recently but weren't reflected in docs or the landing page.