### PR TITLE
Fix feature grid balance on marketing site

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -214,7 +214,7 @@
                     <h3>Math &amp; Frontmatter</h3>
                     <p>KaTeX math expressions render beautifully. YAML frontmatter is formatted cleanly in both editor and preview.</p>
                 </div>
-                <div class="feature" style="grid-column: 1 / -1;">
+                <div class="feature">
                     <h3>Open Source</h3>
                     <p>Free and open source on <a href="https://github.com/Shpigford/clearly" style="color: #ccc; text-decoration: underline;">GitHub</a>. See how it works, file issues, contribute.</p>
                 </div>


### PR DESCRIPTION
## Summary
- Remove `grid-column: 1 / -1` from the Open Source feature card so it no longer spans full width
- With 10 cards total (even number), all cards now sit in balanced 2-column rows with no orphaned card