### PR TITLE
Fix .md files greyed out in Open panel on some systems

### DIFF
--- a/Clearly/MarkdownDocument.swift
+++ b/Clearly/MarkdownDocument.swift
@@ -2,11 +2,16 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension UTType {
-    static let daringFireballMarkdown = UTType(importedAs: "net.daringfireball.markdown", conformingTo: .plainText)
+    /// Resolve the markdown UTType from the system rather than using `importedAs`,
+    /// which can return a different app's claimed type (e.g. app.markedit.md).
+    static let daringFireballMarkdown: UTType = UTType("net.daringfireball.markdown") ?? UTType(filenameExtension: "md") ?? .plainText
 }
 
 struct MarkdownDocument: FileDocument {
-    static var readableContentTypes: [UTType] { [.daringFireballMarkdown, .plainText] }
+    // Include .text because on some systems net.daringfireball.markdown conforms
+    // to public.text rather than public.plain-text, and the Open panel needs an
+    // ancestor type that actually matches.
+    static var readableContentTypes: [UTType] { [.daringFireballMarkdown, .plainText, .text] }
     static var writableContentTypes: [UTType] { [.daringFireballMarkdown] }
 
     var text: String


### PR DESCRIPTION
## Summary
- `UTType(importedAs:)` can resolve to a different app's claimed type (e.g. `app.markedit.md`) instead of `net.daringfireball.markdown`, causing the Open panel to not recognize `.md` files
- On some systems `net.daringfireball.markdown` conforms to `public.text` rather than `public.plain-text`, so neither type in `readableContentTypes` matched
- Uses direct `UTType` lookup instead of `importedAs`, and adds `.text` as a fallback readable content type

## Test plan
- [ ] Install another markdown editor (e.g. MarkEdit) that claims the `net.daringfireball.markdown` UTType
- [ ] Verify `.md` files appear selectable (not greyed out) in the Open panel
- [ ] Verify opening `.md` files via double-click and drag-and-drop still works
- [ ] Verify saving `.md` files preserves the correct file extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)