### PR TITLE
Add Mac App Store download link to marketing site

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -54,6 +54,7 @@
 
         .buttons {
             display: flex;
+            flex-wrap: wrap;
             gap: 12px;
             justify-content: center;
             margin-bottom: 16px;
@@ -168,7 +169,8 @@
         <h1>Clearly Markdown</h1>
         <p class="subtitle">A clean, native markdown editor for Mac. Write with syntax highlighting, preview instantly, and get back to what matters.</p>
         <div class="buttons">
-            <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg" class="btn primary"><svg width="16" height="16" viewBox="0 0 814 1000" fill="currentColor"><path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57.8-155.5-127.4c-58.5-81.7-105.3-209-105.3-329.1 0-193.1 125.6-295.7 249.2-295.7 65.7 0 120.5 43.2 161.7 43.2 39.2 0 100.4-45.8 174.5-45.8 28.2 0 129.3 2.6 196.3 99.8zm-135.5-183.1c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.2 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg> Download for macOS</a>
+            <a href="https://apps.apple.com/app/clearly-markdown/id6760669470" class="btn primary"><svg width="16" height="16" viewBox="0 0 814 1000" fill="currentColor"><path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57.8-155.5-127.4c-58.5-81.7-105.3-209-105.3-329.1 0-193.1 125.6-295.7 249.2-295.7 65.7 0 120.5 43.2 161.7 43.2 39.2 0 100.4-45.8 174.5-45.8 28.2 0 129.3 2.6 196.3 99.8zm-135.5-183.1c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.2 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg> Mac App Store</a>
+            <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg" class="btn secondary">Direct Download</a>
             <a href="https://github.com/Shpigford/clearly" class="btn secondary">GitHub</a>
         </div>
         <p class="requires">v1.7.0 &middot; Requires macOS Sonoma or later</p>


### PR DESCRIPTION
## Summary
- Adds Mac App Store as the primary download button on the marketing site, linking to https://apps.apple.com/app/clearly-markdown/id6760669470
- Demotes the direct DMG download to a secondary button
- Adds `flex-wrap: wrap` to the button container for clean mobile wrapping with three buttons