### PR TITLE
Fix Appearance setting not applying dark/light mode

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -23,9 +23,18 @@ struct ClearlyApp: App {
         #endif
     }
 
+    private var resolvedColorScheme: ColorScheme? {
+        switch themePreference {
+        case "light": return .light
+        case "dark": return .dark
+        default: return nil
+        }
+    }
+
     var body: some Scene {
         DocumentGroup(newDocument: MarkdownDocument()) { file in
             ContentView(document: file.$document, fileURL: file.fileURL)
+                .preferredColorScheme(resolvedColorScheme)
         }
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 720, height: 900)
@@ -157,8 +166,10 @@ struct ClearlyApp: App {
         Settings {
             #if canImport(Sparkle)
             SettingsView(updater: updaterController.updater)
+                .preferredColorScheme(resolvedColorScheme)
             #else
             SettingsView()
+                .preferredColorScheme(resolvedColorScheme)
             #endif
         }
     }


### PR DESCRIPTION
## Summary
- The Appearance picker in Settings stored the preference but never applied it — the app always followed the system setting
- Adds `.preferredColorScheme()` modifier to both the DocumentGroup and Settings scenes, mapping the stored `themePreference` to a `ColorScheme?`
- SwiftUI propagates the override to all child views, including the editor, WKWebView preview, and the settings window itself

Fixes #47