### PR TITLE
Fix multi-document open hang with batched highlighting

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -63,16 +63,14 @@ struct EditorView: NSViewRepresentable {
         textView.insertionPointColor = Theme.textColor
         textView.documentURL = fileURL
 
-        // Delegate
-        textView.delegate = context.coordinator
-
-        // Set initial text BEFORE attaching the syntax highlighter delegate.
-        // This avoids triggering highlightAll during makeNSView — the first
-        // updateNSView call handles initial highlighting via the color-scheme check.
+        // Set initial text BEFORE attaching any delegates.
+        // This avoids triggering highlightAll or textDidChange during makeNSView —
+        // the first updateNSView call handles initial highlighting via the color-scheme check.
         let highlighter = MarkdownSyntaxHighlighter()
         context.coordinator.highlighter = highlighter
         textView.string = text
         textView.textStorage?.delegate = highlighter
+        textView.delegate = context.coordinator
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
@@ -100,29 +98,35 @@ struct EditorView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? ClearlyTextView else { return }
 
+        context.coordinator.updateCount += 1
+        let count = context.coordinator.updateCount
+        if count <= 5 || count % 100 == 0 {
+            DiagnosticLog.log("updateNSView #\(count)")
+        }
+
         // Always refresh colors (handles appearance changes via @Environment colorScheme)
         textView.backgroundColor = Theme.backgroundColor
         textView.insertionPointColor = Theme.textColor
         textView.documentURL = fileURL
 
-        // Update typing attributes for new text
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.minimumLineHeight = Theme.editorLineHeight
-        paragraph.maximumLineHeight = Theme.editorLineHeight
-        textView.typingAttributes = [
-            .font: Theme.editorFont,
-            .foregroundColor: Theme.textColor,
-            .paragraphStyle: paragraph,
-            .baselineOffset: Theme.editorBaselineOffset
-        ]
-
-        // Re-highlight when appearance or font size changes
+        // Re-highlight and update typing attributes when appearance or font size changes
         let currentScheme = colorScheme
         let currentFontSize = fontSize
         if context.coordinator.lastColorScheme != currentScheme || context.coordinator.lastFontSize != currentFontSize {
             context.coordinator.lastColorScheme = currentScheme
             context.coordinator.lastFontSize = currentFontSize
             textView.font = Theme.editorFont
+
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.minimumLineHeight = Theme.editorLineHeight
+            paragraph.maximumLineHeight = Theme.editorLineHeight
+            textView.typingAttributes = [
+                .font: Theme.editorFont,
+                .foregroundColor: Theme.textColor,
+                .paragraphStyle: paragraph,
+                .baselineOffset: Theme.editorBaselineOffset
+            ]
+
             context.coordinator.highlighter?.highlightAll(textView.textStorage!)
         }
 
@@ -146,6 +150,7 @@ struct EditorView: NSViewRepresentable {
         var scrollSync: ScrollSync?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?
+        var updateCount = 0
         private var lastScrollTime: TimeInterval = 0
 
         init(_ parent: EditorView) {
@@ -154,6 +159,7 @@ struct EditorView: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            DiagnosticLog.log("textDidChange (\(textView.string.count) chars)")
             isUpdating = true
             parent.text = textView.string
             isUpdating = false

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -101,6 +101,8 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
         isHighlighting = true
         defer { isHighlighting = false }
         let startTime = CACurrentMediaTime()
+
+        textStorage.beginEditing()
         let fullRange = NSRange(location: 0, length: textStorage.length)
         let text = textStorage.string
 
@@ -295,9 +297,9 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
             }
         }
 
+        textStorage.endEditing()
+
         let elapsed = (CACurrentMediaTime() - startTime) * 1000
-        if elapsed > 50 {
-            DiagnosticLog.log("highlightAll took \(Int(elapsed))ms for \(textStorage.length) chars")
-        }
+        DiagnosticLog.log("highlightAll: \(textStorage.length) chars in \(Int(elapsed))ms")
     }
 }


### PR DESCRIPTION
## Summary

- Wrap `highlightAll()` in `beginEditing()/endEditing()` to batch 50-100+ individual attribute mutations into a single layout pass instead of triggering separate `processEditing()` → layout invalidation cycles for each one
- Move `NSTextViewDelegate` assignment after text setup in `makeNSView` to prevent `textDidChange` from firing during init and cascading unnecessary SwiftUI re-evaluation
- Move `typingAttributes` update into the appearance-change conditional so `updateNSView` doesn't recreate paragraph styles on every call
- Add diagnostic logging for `updateNSView` call frequency, `textDidChange`, and `highlightAll` duration to catch any remaining hang patterns

Fixes #41

## Test plan

- [ ] Open a `.md` file — verify syntax highlighting works
- [ ] Open a second `.md` file — verify no hang
- [ ] Toggle light/dark mode — verify highlighting refreshes
- [ ] Type in editor — verify live highlighting works
- [ ] Export diagnostic log — verify `updateNSView` count is single digits per doc open