### PR TITLE
Hoist frontmatter YAML key regex to static property

### DIFF
--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -7,6 +7,11 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
 
     // MARK: - Regex Patterns
 
+    private static let frontmatterKeyRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: "^([\\w][\\w\\s.-]*)(:)",
+        options: .anchorsMatchLines
+    )
+
     private static let patterns: [(NSRegularExpression, HighlightStyle)] = {
         var result: [(NSRegularExpression, HighlightStyle)] = []
 
@@ -285,7 +290,7 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
                     // Color YAML keys within the body (group 1)
                     if match.numberOfRanges >= 2 {
                         let bodyRange = match.range(at: 1)
-                        if bodyRange.location != NSNotFound, let keyRegex = try? NSRegularExpression(pattern: "^([\\w][\\w\\s.-]*)(:)", options: .anchorsMatchLines) {
+                        if bodyRange.location != NSNotFound, let keyRegex = Self.frontmatterKeyRegex {
                             keyRegex.enumerateMatches(in: text, range: bodyRange) { keyMatch, _, _ in
                                 guard let keyMatch = keyMatch, keyMatch.numberOfRanges >= 3 else { return }
                                 textStorage.addAttribute(.foregroundColor, value: Theme.headingColor, range: keyMatch.range(at: 1))


### PR DESCRIPTION
## Summary
- Moves the YAML frontmatter key regex from being recompiled on every highlighting pass to a `private static let`, matching the pattern used by all other regexes in the highlighter.
- This is a micro-optimization that eliminates redundant `NSRegularExpression` compilation during syntax highlighting of frontmatter blocks.

## Test plan
- [ ] Open a markdown file with YAML frontmatter — verify keys are still highlighted correctly
- [ ] Open multiple documents — verify no regression in behavior