### PR TITLE
Fix multi-document open hang by blocking scroll handler during highlighting

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -63,13 +63,14 @@ struct EditorView: NSViewRepresentable {
         textView.insertionPointColor = Theme.textColor
         textView.documentURL = fileURL
 
-        // Set initial text BEFORE attaching any delegates.
-        // This avoids triggering highlightAll or textDidChange during makeNSView —
+        // Set initial text BEFORE attaching the text view delegate.
+        // This avoids triggering textDidChange during makeNSView —
         // the first updateNSView call handles initial highlighting via the color-scheme check.
+        // Note: we do NOT set textStorage.delegate — highlighting is driven explicitly
+        // from textDidChange and updateNSView to avoid re-entrant layout manager access.
         let highlighter = MarkdownSyntaxHighlighter()
         context.coordinator.highlighter = highlighter
         textView.string = text
-        textView.textStorage?.delegate = highlighter
         textView.delegate = context.coordinator
 
         scrollView.documentView = textView
@@ -98,6 +99,9 @@ struct EditorView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? ClearlyTextView else { return }
 
+        // Keep coordinator's parent fresh so the binding never goes stale
+        context.coordinator.parent = self
+
         context.coordinator.updateCount += 1
         let count = context.coordinator.updateCount
         if count <= 5 || count % 100 == 0 {
@@ -112,7 +116,11 @@ struct EditorView: NSViewRepresentable {
         // Re-highlight and update typing attributes when appearance or font size changes
         let currentScheme = colorScheme
         let currentFontSize = fontSize
-        if context.coordinator.lastColorScheme != currentScheme || context.coordinator.lastFontSize != currentFontSize {
+        let appearanceChanged = context.coordinator.lastColorScheme != currentScheme || context.coordinator.lastFontSize != currentFontSize
+        if appearanceChanged {
+            if count <= 5 {
+                DiagnosticLog.log("updateNSView #\(count): appearance changed (scheme=\(currentScheme), fontSize=\(currentFontSize))")
+            }
             context.coordinator.lastColorScheme = currentScheme
             context.coordinator.lastFontSize = currentFontSize
             textView.font = Theme.editorFont
@@ -127,24 +135,39 @@ struct EditorView: NSViewRepresentable {
                 .baselineOffset: Theme.editorBaselineOffset
             ]
 
-            context.coordinator.highlighter?.highlightAll(textView.textStorage!)
+            // Suppress scroll handler during highlighting to prevent layout manager deadlock
+            context.coordinator.isHighlightingInProgress = true
+            context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "appearance")
+            context.coordinator.isHighlightingInProgress = false
         }
 
         // Only update text if it changed externally (not from user typing).
-        // highlightAll fires automatically via NSTextStorageDelegate.
-        if !context.coordinator.isUpdating && textView.string != text {
-            DiagnosticLog.log("updateNSView: external text change (\(text.count) chars)")
+        let textMismatch = textView.string != text
+        if !context.coordinator.isUpdating && textMismatch {
+            DiagnosticLog.log("updateNSView #\(count): external text change (\(text.count) chars)")
+            context.coordinator.isUpdating = true
             let selectedRanges = textView.selectedRanges
             textView.string = text
             textView.selectedRanges = selectedRanges
+            context.coordinator.isHighlightingInProgress = true
+            context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "externalText")
+            context.coordinator.isHighlightingInProgress = false
+            context.coordinator.isUpdating = false
+        } else if context.coordinator.isUpdating && count <= 5 {
+            DiagnosticLog.log("updateNSView #\(count): skipped text check (isUpdating)")
+        }
+
+        if count <= 5 || count % 100 == 0 {
+            DiagnosticLog.log("updateNSView #\(count) done")
         }
     }
 
     // MARK: - Coordinator
 
     final class Coordinator: NSObject, NSTextViewDelegate {
-        let parent: EditorView
+        var parent: EditorView
         var isUpdating = false
+        var isHighlightingInProgress = false
         var highlighter: MarkdownSyntaxHighlighter?
         weak var textView: NSTextView?
         var scrollSync: ScrollSync?
@@ -159,13 +182,48 @@ struct EditorView: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+
+            // Skip if we're the ones setting text programmatically (from updateNSView)
+            if isUpdating {
+                DiagnosticLog.log("textDidChange skipped (isUpdating)")
+                return
+            }
+
             DiagnosticLog.log("textDidChange (\(textView.string.count) chars)")
-            isUpdating = true
-            parent.text = textView.string
-            isUpdating = false
+
+            // Highlight synchronously so colors appear on the same frame as the keystroke
+            isHighlightingInProgress = true
+            highlighter?.highlightAll(textView.textStorage!, caller: "textDidChange")
+            isHighlightingInProgress = false
+
+            // Update SwiftUI binding asynchronously to prevent re-entrant updateNSView
+            let newText = textView.string
+            DispatchQueue.main.async { [weak self] in
+                guard let self else {
+                    DiagnosticLog.log("textDidChange async: coordinator deallocated")
+                    return
+                }
+                DiagnosticLog.log("textDidChange async: updating binding (\(newText.count) chars)")
+                self.isUpdating = true
+                self.parent.text = newText
+                self.isUpdating = false
+            }
         }
 
+        private var scrollSuppressCount = 0
+
         @objc func scrollViewDidScroll(_ notification: Notification) {
+            // Suppress during highlighting — the layout manager may be mid-update
+            // and querying it here would deadlock the main thread
+            guard !isHighlightingInProgress else {
+                scrollSuppressCount += 1
+                // Log first occurrence and every 100th to avoid flooding
+                if scrollSuppressCount == 1 || scrollSuppressCount % 100 == 0 {
+                    DiagnosticLog.log("scrollViewDidScroll suppressed ×\(scrollSuppressCount)")
+                }
+                return
+            }
+
             guard let clipView = notification.object as? NSClipView,
                   let scrollView = clipView.enclosingScrollView,
                   let textView = scrollView.documentView as? NSTextView,

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -1,7 +1,7 @@
 import AppKit
 import os
 
-final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
+final class MarkdownSyntaxHighlighter: NSObject {
 
     private var isHighlighting = false
 
@@ -87,21 +87,9 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
         case frontmatter
     }
 
-    // MARK: - NSTextStorageDelegate
-
-    func textStorage(
-        _ textStorage: NSTextStorage,
-        didProcessEditing editedMask: NSTextStorageEditActions,
-        range editedRange: NSRange,
-        changeInLength delta: Int
-    ) {
-        guard editedMask.contains(.editedCharacters) else { return }
-        highlightAll(textStorage)
-    }
-
     // MARK: - Highlighting
 
-    func highlightAll(_ textStorage: NSTextStorage) {
+    func highlightAll(_ textStorage: NSTextStorage, caller: String = "") {
         guard !isHighlighting else { return }
         isHighlighting = true
         defer { isHighlighting = false }
@@ -305,6 +293,7 @@ final class MarkdownSyntaxHighlighter: NSObject, NSTextStorageDelegate {
         textStorage.endEditing()
 
         let elapsed = (CACurrentMediaTime() - startTime) * 1000
-        DiagnosticLog.log("highlightAll: \(textStorage.length) chars in \(Int(elapsed))ms")
+        let tag = caller.isEmpty ? "" : "(\(caller))"
+        DiagnosticLog.log("highlightAll\(tag): \(textStorage.length) chars in \(Int(elapsed))ms")
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `highlightAll` changes font/paragraph attributes → layout manager recalculates → clip view bounds change → `boundsDidChangeNotification` fires synchronously → `scrollViewDidScroll` queries the layout manager mid-update → main thread deadlock
- Removes `NSTextStorageDelegate` from the highlighter; highlighting is now driven explicitly from `textDidChange` and `updateNSView` call sites (eliminates nested editing sessions)
- Suppresses `scrollViewDidScroll` during highlighting via `isHighlightingInProgress` flag (blocks the deadlock path)
- Updates SwiftUI binding asynchronously from `textDidChange` to prevent re-entrant `updateNSView`
- Refreshes coordinator's parent reference every `updateNSView` to prevent stale binding writes
- Adds granular diagnostic logging (tagged highlightAll callers, updateNSView start/done pairs, scroll suppression counts, async binding lifecycle) so if this doesn't fix it, the next diagnostic export will pinpoint exactly where the hang occurs

## Test plan

- [ ] Open Clearly, open a .md file, then open a second .md file — must not hang
- [ ] Switch between both windows — syntax highlighting correct in both
- [ ] Type in either window — highlighting updates immediately, no flash
- [ ] Toggle light/dark mode — both windows re-highlight
- [ ] Export diagnostic log — verify `updateNSView #N done` entries for both docs, check for `scrollViewDidScroll suppressed` entries

Fixes #41