### PR TITLE
Add GitHub issue templates and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Something isn't working right
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected to happen instead.
+      placeholder: "When I do X, Y happens. I expected Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we see this bug?
+      placeholder: |
+        1. Open a markdown file with...
+        2. Switch to preview mode
+        3. See...
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: "Found in Clearly → Settings → About"
+      placeholder: "e.g. 1.7.4"
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      description: "Found in  → About This Mac"
+      placeholder: "e.g. 15.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, drag and drop screenshots here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: file
+    attributes:
+      label: Problematic file
+      description: If a specific markdown file triggers the bug, paste its contents or attach it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions or feedback
+    url: https://x.com/Shpigford
+    about: Reach out on X for questions, feedback, or general discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest something new
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: Describe the feature or change you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: What problem does this solve or what's your use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or examples
+      description: Mockups, screenshots from other apps, or anything that helps illustrate the idea.
+    validations:
+      required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+If you discover a security vulnerability in Clearly, please report it through
+GitHub's [private vulnerability reporting](https://github.com/Shpigford/clearly/security/advisories/new)
+rather than opening a public issue.


### PR DESCRIPTION
## Summary
- Adds YAML-based issue form templates for bug reports (requires app version, macOS version, description, repro steps; prompts for screenshots and problematic files) and feature requests (requires what and why; prompts for screenshots/examples)
- Disables blank issues and adds an X contact link for general questions
- Adds a security policy pointing to GitHub's private vulnerability reporting