### PR TITLE
Add automatic file change detection for open documents

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -50,6 +50,7 @@ struct ContentView: View {
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @State private var widthBeforeSplit: CGFloat?
     @StateObject private var scrollSync = ScrollSync()
+    @StateObject private var fileWatcher = FileWatcher()
 
     init(document: Binding<MarkdownDocument>, fileURL: URL? = nil) {
         self._document = document
@@ -162,5 +163,17 @@ struct ContentView: View {
         .focusedSceneValue(\.viewMode, $mode)
         .focusedSceneValue(\.documentText, document.text)
         .focusedSceneValue(\.documentFileURL, fileURL)
+        .onAppear {
+            fileWatcher.onChange = { [self] newText in
+                document.text = newText
+            }
+            fileWatcher.watch(fileURL, currentText: document.text)
+        }
+        .onChange(of: fileURL) { _, newURL in
+            fileWatcher.watch(newURL, currentText: document.text)
+        }
+        .onChange(of: document.text) { _, newText in
+            fileWatcher.updateCurrentText(newText)
+        }
     }
 }

--- a/Clearly/FileWatcher.swift
+++ b/Clearly/FileWatcher.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+final class FileWatcher: ObservableObject {
+    private var source: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+    private var debounceWork: DispatchWorkItem?
+    private var monitoredURL: URL?
+    private var currentText: String?
+    private var lastKnownDiskText: String?
+    var onChange: ((String) -> Void)?
+
+    func watch(_ url: URL?, currentText: String? = nil) {
+        stopMonitoring()
+        monitoredURL = url
+        self.currentText = currentText
+        lastKnownDiskText = currentText
+        guard let url else { return }
+        startMonitoring(url)
+    }
+
+    func updateCurrentText(_ text: String) {
+        currentText = text
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    // MARK: - Private
+
+    private func startMonitoring(_ url: URL) {
+        let fd = open(url.path, O_EVTONLY)
+        guard fd != -1 else { return }
+        fileDescriptor = fd
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename, .link, .extend, .attrib],
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            let flags = source.data
+            if flags.contains(.delete) || flags.contains(.rename) {
+                // Atomic save: file was replaced. Tear down and re-establish.
+                self.stopMonitoring()
+                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                    guard let self, let url = self.monitoredURL else { return }
+                    self.startMonitoring(url)
+                    self.readAndNotify()
+                }
+                return
+            }
+            self.debouncedReadAndNotify()
+        }
+
+        source.setCancelHandler { [fd] in
+            close(fd)
+        }
+
+        source.resume()
+        self.source = source
+    }
+
+    private func stopMonitoring() {
+        debounceWork?.cancel()
+        debounceWork = nil
+        source?.cancel()
+        source = nil
+        fileDescriptor = -1
+    }
+
+    private func debouncedReadAndNotify() {
+        debounceWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.readAndNotify()
+        }
+        debounceWork = work
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+
+    private func readAndNotify() {
+        guard let url = monitoredURL else { return }
+        guard let data = try? Data(contentsOf: url),
+              let newText = String(data: data, encoding: .utf8) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard newText != self.lastKnownDiskText else { return }
+
+            let hasUnsavedChanges = self.currentText != self.lastKnownDiskText
+            self.lastKnownDiskText = newText
+
+            guard !hasUnsavedChanges else {
+                DiagnosticLog.log("External file change ignored: unsaved local edits")
+                return
+            }
+
+            self.currentText = newText
+            self.onChange?(newText)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `FileWatcher` that uses `DispatchSource` (kqueue) to monitor open files for external modifications from git, terminal tools, Claude, or other editors
- Handles atomic saves (write-temp-then-rename) by re-establishing the monitor after delete/rename events
- Debounces rapid events (300ms) and skips reload when user has unsaved local edits
- Wired into `ContentView` via `@StateObject` — no changes needed to EditorView, PreviewView, or ClearlyApp

## Test plan
- [ ] Open a `.md` file in Clearly, modify it externally (`echo "test" >> file.md`), verify editor updates automatically
- [ ] Test atomic saves (e.g., `sed -i '' 's/old/new/' file.md`) to verify monitor re-establishes correctly
- [ ] Type unsaved edits in editor, modify file externally — verify local edits are preserved
- [ ] Open a new unsaved document — verify no crashes (fileURL is nil, watcher is a no-op)

Fixes #54