### PR TITLE
Feature: Adjustable Preview Content Width

### DIFF
--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -73,7 +73,7 @@ enum PreviewCSS {
         font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
         font-size: \(Int(fontSize))px;
         line-height: 1.6;
-        max-width: 42em;
+        max-width: 61em;
         margin: 0 auto;
         padding: 10px 60px 40px;
         color: #222222;


### PR DESCRIPTION
If found the current hardcoded max-width a bit narrow and you can see it especially when using markdown tables. I also think having the option to pick between pre-defined layout widths would be nice. 

This PR:
- Changes the default to make it a little bit wider (42em -> 48em)
- Adds a "Preview Layout" picker to Settings (Default: 48em, Wide: 57em)                                                                                                                                                             
- Makes the preview max-width dynamic instead of hardcoded                                                                                                                                                                             
- Persists the choice via @AppStorage   

If you don't want to change the default, i can either revert it or have 3 sizes (Narrow 42, Default 48 and Wide 57). 

I named the default enum value `defaultWidth` rather than just default, because `default` is a reserved name and would need ugly backticks to make it work. 

Has made it a lot easier for me to read my docs. Let me know what you think 

**Settings**
<img width="512" height="480" alt="Screenshot 2026-03-28 at 18 05 55" src="https://github.com/user-attachments/assets/2f0810bb-b2fa-499a-a4da-ff9e90388adf" />

**New Default (48em)**
<img width="1437" height="1186" alt="Screenshot 2026-03-28 at 18 03 25" src="https://github.com/user-attachments/assets/ced9dfd9-f360-446e-826a-3b1dbd8a0515" />

**Wide (57em)**
<img width="1437" height="1186" alt="Screenshot 2026-03-28 at 18 03 40" src="https://github.com/user-attachments/assets/93301bf7-7b6c-4fa9-aa84-69e789673bda" />
