### PR TITLE
Persist window size and position per document

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -40,18 +40,53 @@ extension FocusedValues {
 struct WindowFrameSaver: NSViewRepresentable {
     let fileURL: URL?
 
+    final class Coordinator {
+        var autosaveName: String?
+    }
+
+    private var autosaveName: String {
+        fileURL?.absoluteString ?? "ClearlyUntitledWindow"
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    private func applyAutosaveName(
+        to window: NSWindow,
+        coordinator: Coordinator,
+        persistCurrentFrame: Bool
+    ) {
+        guard coordinator.autosaveName != autosaveName else { return }
+        coordinator.autosaveName = autosaveName
+        window.setFrameAutosaveName(autosaveName)
+        if persistCurrentFrame {
+            window.saveFrame(usingName: autosaveName)
+        }
+    }
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async {
             if let window = view.window {
-                let name = fileURL?.absoluteString ?? "ClearlyUntitledWindow"
-                window.setFrameAutosaveName(name)
+                applyAutosaveName(
+                    to: window,
+                    coordinator: context.coordinator,
+                    persistCurrentFrame: false
+                )
             }
         }
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let window = nsView.window else { return }
+        applyAutosaveName(
+            to: window,
+            coordinator: context.coordinator,
+            persistCurrentFrame: context.coordinator.autosaveName != nil
+        )
+    }
 }
 
 struct HiddenToolbarBackground: ViewModifier {


### PR DESCRIPTION
Opening any file currently will not remember the size and location of the window if you change it, which is a bit annoying. This PR will remember the size and location of the window per file.