### PR TITLE
Add inline Find bar replacing broken system Find panel

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -51,6 +51,7 @@ struct ClearlyApp: App {
                 PrintCommand()
             }
             CommandGroup(after: .textEditing) {
+                FindCommand()
                 ViewModeCommands()
             }
             CommandGroup(after: .textFormatting) {
@@ -172,6 +173,17 @@ struct ClearlyApp: App {
                 .preferredColorScheme(resolvedColorScheme)
             #endif
         }
+    }
+}
+
+struct FindCommand: View {
+    @FocusedValue(\.findState) var findState
+
+    var body: some View {
+        Button("Find…") {
+            findState?.present()
+        }
+        .keyboardShortcut("f", modifiers: .command)
     }
 }
 

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -2,6 +2,7 @@ import AppKit
 
 final class ClearlyTextView: NSTextView {
     var documentURL: URL?
+    var onShowFind: (() -> Void)?
 
     // MARK: - Cursor
 
@@ -74,9 +75,7 @@ final class ClearlyTextView: NSTextView {
     // MARK: - Find
 
     @objc func showFindPanel(_ sender: Any?) {
-        let item = NSMenuItem()
-        item.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
-        performFindPanelAction(item)
+        onShowFind?()
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -84,7 +83,7 @@ final class ClearlyTextView: NSTextView {
             return super.performKeyEquivalent(with: event)
         }
         if event.charactersIgnoringModifiers == "f" {
-            showFindPanel(nil)
+            onShowFind?()
             return true
         }
         return super.performKeyEquivalent(with: event)

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -18,6 +18,10 @@ struct DocumentFileURLKey: FocusedValueKey {
     typealias Value = URL
 }
 
+struct FindStateKey: FocusedValueKey {
+    typealias Value = FindState
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -30,6 +34,10 @@ extension FocusedValues {
     var documentFileURL: URL? {
         get { self[DocumentFileURLKey.self] }
         set { self[DocumentFileURLKey.self] = newValue }
+    }
+    var findState: FindState? {
+        get { self[FindStateKey.self] }
+        set { self[FindStateKey.self] = newValue }
     }
 }
 
@@ -106,6 +114,7 @@ struct ContentView: View {
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @State private var widthBeforeSplit: CGFloat?
     @StateObject private var scrollSync = ScrollSync()
+    @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
 
     init(document: Binding<MarkdownDocument>, fileURL: URL? = nil) {
@@ -133,17 +142,23 @@ struct ContentView: View {
     }
 
     var body: some View {
-        Group {
-            switch mode {
-            case .edit:
-                EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL)
-            case .sideBySide:
-                HSplitView {
-                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, scrollSync: scrollSync)
-                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync, fileURL: fileURL)
+        VStack(spacing: 0) {
+            if findState.isVisible {
+                FindBarView(findState: findState)
+                Divider()
+            }
+            Group {
+                switch mode {
+                case .edit:
+                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState)
+                case .sideBySide:
+                    HSplitView {
+                        EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, scrollSync: scrollSync, findState: findState)
+                        PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync, fileURL: fileURL)
+                    }
+                case .preview:
+                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState)
                 }
-            case .preview:
-                PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), fileURL: fileURL)
             }
         }
         .frame(minWidth: mode == .sideBySide ? 1000 : 500, minHeight: 400)
@@ -204,14 +219,12 @@ struct ContentView: View {
                 .frame(width: 150)
             }
             ToolbarItem(placement: .automatic) {
-                if mode != .preview {
-                    Button {
-                        NSApp.sendAction(#selector(ClearlyTextView.showFindPanel(_:)), to: nil, from: nil)
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                    }
-                    .help("Find (Cmd+F)")
+                Button {
+                    findState.present()
+                } label: {
+                    Image(systemName: "magnifyingglass")
                 }
+                .help("Find (Cmd+F)")
             }
         }
         .modifier(HiddenToolbarBackground())
@@ -220,6 +233,7 @@ struct ContentView: View {
         .focusedSceneValue(\.viewMode, $mode)
         .focusedSceneValue(\.documentText, document.text)
         .focusedSceneValue(\.documentFileURL, fileURL)
+        .focusedSceneValue(\.findState, findState)
         .onAppear {
             fileWatcher.onChange = { [self] newText in
                 document.text = newText

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import Combine
 import os
 
 struct EditorView: NSViewRepresentable {
@@ -7,6 +8,7 @@ struct EditorView: NSViewRepresentable {
     var fontSize: CGFloat = 16
     var fileURL: URL?
     var scrollSync: ScrollSync?
+    var findState: FindState?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -24,7 +26,7 @@ struct EditorView: NSViewRepresentable {
         let textView = ClearlyTextView()
         textView.isRichText = false
         textView.allowsUndo = true
-        textView.usesFindPanel = true
+        textView.usesFindPanel = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
@@ -76,7 +78,28 @@ struct EditorView: NSViewRepresentable {
         scrollView.documentView = textView
         context.coordinator.textView = textView
         context.coordinator.scrollSync = scrollSync
+        context.coordinator.findState = findState
+        if let findState {
+            context.coordinator.observeFindState(findState)
+        }
         scrollSync?.editorScrollView = scrollView
+
+        // Wire up find bar presentation
+        textView.onShowFind = { [weak findState] in
+            guard let findState else { return }
+            DispatchQueue.main.async {
+                findState.present()
+            }
+        }
+
+        // Wire up find navigation
+        let coordinator = context.coordinator
+        findState?.navigateToNext = { [weak coordinator] in
+            coordinator?.navigateToNextMatch()
+        }
+        findState?.navigateToPrevious = { [weak coordinator] in
+            coordinator?.navigateToPreviousMatch()
+        }
 
         // Observe scroll position for sync
         scrollView.contentView.postsBoundsChangedNotifications = true
@@ -139,6 +162,7 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.isHighlightingInProgress = true
             context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "appearance")
             context.coordinator.isHighlightingInProgress = false
+            context.coordinator.restoreFindHighlightsIfNeeded()
         }
 
         // Only update text if it changed externally (not from user typing).
@@ -152,6 +176,7 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.isHighlightingInProgress = true
             context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "externalText")
             context.coordinator.isHighlightingInProgress = false
+            context.coordinator.restoreFindHighlightsIfNeeded()
             context.coordinator.isUpdating = false
         } else if context.coordinator.isUpdating && count <= 5 {
             DiagnosticLog.log("updateNSView #\(count): skipped text check (isUpdating)")
@@ -171,13 +196,43 @@ struct EditorView: NSViewRepresentable {
         var highlighter: MarkdownSyntaxHighlighter?
         weak var textView: NSTextView?
         var scrollSync: ScrollSync?
+        var findState: FindState?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?
         var updateCount = 0
         private var lastScrollTime: TimeInterval = 0
 
+        // Find state tracking
+        var matchRanges: [NSRange] = []
+        private var currentMatchIdx = 0 // 0-based internal index
+        private var findCancellables = Set<AnyCancellable>()
+
         init(_ parent: EditorView) {
             self.parent = parent
+        }
+
+        func observeFindState(_ state: FindState) {
+            findCancellables.removeAll()
+
+            state.$query
+                .removeDuplicates()
+                .sink { [weak self] _ in
+                    guard let self, self.findState?.isVisible == true else { return }
+                    self.performFind()
+                }
+                .store(in: &findCancellables)
+
+            state.$isVisible
+                .removeDuplicates()
+                .sink { [weak self] visible in
+                    guard let self else { return }
+                    if visible {
+                        self.performFind()
+                    } else {
+                        self.clearFindHighlights()
+                    }
+                }
+                .store(in: &findCancellables)
         }
 
         func textDidChange(_ notification: Notification) {
@@ -195,6 +250,9 @@ struct EditorView: NSViewRepresentable {
             isHighlightingInProgress = true
             highlighter?.highlightAll(textView.textStorage!, caller: "textDidChange")
             isHighlightingInProgress = false
+
+            // Re-apply find highlights after syntax highlighting (text may have changed match positions)
+            restoreFindHighlightsIfNeeded()
 
             // Update SwiftUI binding asynchronously to prevent re-entrant updateNSView
             let newText = textView.string
@@ -260,6 +318,106 @@ struct EditorView: NSViewRepresentable {
             let frac = lineHeight > 0 ? min(1, max(0, (centerY - lineTop) / lineHeight)) : 0
 
             scrollSync?.editorDidScroll(line: Double(line) + frac)
+        }
+
+        // MARK: - Find
+
+        func restoreFindHighlightsIfNeeded() {
+            guard findState?.isVisible == true, !(findState?.query.isEmpty ?? true) else { return }
+            performFind()
+        }
+
+        func performFind() {
+            guard let textView, let findState else { return }
+            let query = findState.query
+            clearFindHighlights()
+
+            guard !query.isEmpty else {
+                matchRanges = []
+                currentMatchIdx = 0
+                DispatchQueue.main.async {
+                    findState.matchCount = 0
+                    findState.currentIndex = 0
+                }
+                return
+            }
+
+            // Find all matches (case-insensitive)
+            let nsText = textView.string as NSString
+            var ranges: [NSRange] = []
+            var searchRange = NSRange(location: 0, length: nsText.length)
+            while searchRange.location < nsText.length {
+                let found = nsText.range(of: query, options: .caseInsensitive, range: searchRange)
+                if found.location == NSNotFound { break }
+                ranges.append(found)
+                searchRange.location = found.upperBound
+                searchRange.length = nsText.length - searchRange.location
+            }
+
+            matchRanges = ranges
+            currentMatchIdx = ranges.isEmpty ? 0 : 0
+
+            applyFindHighlights()
+
+            DispatchQueue.main.async {
+                findState.matchCount = ranges.count
+                findState.currentIndex = ranges.isEmpty ? 0 : 1
+            }
+
+            if !ranges.isEmpty {
+                textView.scrollRangeToVisible(ranges[0])
+            }
+        }
+
+        func navigateToNextMatch() {
+            guard !matchRanges.isEmpty else { return }
+            currentMatchIdx = (currentMatchIdx + 1) % matchRanges.count
+            applyFindHighlights()
+            textView?.scrollRangeToVisible(matchRanges[currentMatchIdx])
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.findState?.currentIndex = self.currentMatchIdx + 1
+            }
+        }
+
+        func navigateToPreviousMatch() {
+            guard !matchRanges.isEmpty else { return }
+            currentMatchIdx = (currentMatchIdx - 1 + matchRanges.count) % matchRanges.count
+            applyFindHighlights()
+            textView?.scrollRangeToVisible(matchRanges[currentMatchIdx])
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.findState?.currentIndex = self.currentMatchIdx + 1
+            }
+        }
+
+        private func applyFindHighlights() {
+            guard let textView else { return }
+            let storage = textView.textStorage!
+
+            // Clear existing find highlights first
+            let fullRange = NSRange(location: 0, length: storage.length)
+            storage.beginEditing()
+            storage.removeAttribute(.backgroundColor, range: fullRange)
+
+            // Apply highlight to all matches
+            for (i, range) in matchRanges.enumerated() {
+                guard range.upperBound <= storage.length else { continue }
+                let color = (i == currentMatchIdx) ? Theme.findCurrentHighlightColor : Theme.findHighlightColor
+                storage.addAttribute(.backgroundColor, value: color, range: range)
+            }
+            storage.endEditing()
+        }
+
+        func clearFindHighlights() {
+            guard let textView else { return }
+            let storage = textView.textStorage!
+            let fullRange = NSRange(location: 0, length: storage.length)
+            storage.beginEditing()
+            storage.removeAttribute(.backgroundColor, range: fullRange)
+            storage.endEditing()
+            matchRanges = []
+            currentMatchIdx = 0
         }
     }
 }

--- a/Clearly/FindBarView.swift
+++ b/Clearly/FindBarView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct FindBarView: View {
+    @ObservedObject var findState: FindState
+    @FocusState private var isFieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 12))
+
+                TextField("Find", text: $findState.query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .focused($isFieldFocused)
+                    .onSubmit {
+                        if NSApp.currentEvent?.modifierFlags.contains(.shift) == true {
+                            findState.navigateToPrevious?()
+                        } else {
+                            findState.navigateToNext?()
+                        }
+                    }
+                    .onExitCommand {
+                        findState.isVisible = false
+                    }
+
+                if !findState.query.isEmpty {
+                    if findState.matchCount > 0 {
+                        Text("\(findState.currentIndex) of \(findState.matchCount)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    } else {
+                        Text("No results")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(.quaternary)
+            )
+
+            HStack(spacing: 2) {
+                Button {
+                    findState.navigateToPrevious?()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.borderless)
+                .disabled(findState.matchCount == 0)
+
+                Button {
+                    findState.navigateToNext?()
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.borderless)
+                .disabled(findState.matchCount == 0)
+            }
+
+            Button("Done") {
+                findState.isVisible = false
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 13))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Theme.backgroundColorSwiftUI)
+        .onAppear {
+            isFieldFocused = true
+        }
+        .onChange(of: findState.focusRequest) { _, _ in
+            isFieldFocused = true
+        }
+    }
+}

--- a/Clearly/FindState.swift
+++ b/Clearly/FindState.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+final class FindState: ObservableObject {
+    @Published var isVisible = false
+    @Published var query = ""
+    @Published var matchCount = 0
+    @Published var currentIndex = 0 // 1-based, 0 = no matches
+    @Published var focusRequest = UUID()
+
+    // Set by EditorView coordinator, called by FindBarView
+    var navigateToNext: (() -> Void)?
+    var navigateToPrevious: (() -> Void)?
+
+    func present() {
+        isVisible = true
+        focusRequest = UUID()
+    }
+}

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import WebKit
+import Combine
 
 struct PreviewView: NSViewRepresentable {
     let markdown: String
     var fontSize: CGFloat = 18
     var scrollSync: ScrollSync?
     var fileURL: URL?
+    var findState: FindState?
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
@@ -29,7 +31,11 @@ struct PreviewView: NSViewRepresentable {
         webView.alphaValue = 0 // hidden until content loads
         context.coordinator.scrollSync = scrollSync
         context.coordinator.fileURL = fileURL
+        context.coordinator.findState = findState
         scrollSync?.previewWebView = webView
+        if let findState {
+            context.coordinator.observeFindState(findState, webView: webView)
+        }
         loadHTML(in: webView, context: context)
         return webView
     }
@@ -168,7 +174,14 @@ struct PreviewView: NSViewRepresentable {
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css(fontSize: fontSize))</style>
+        <style>\(PreviewCSS.css(fontSize: fontSize))
+        mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
+        mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
+        @media (prefers-color-scheme: dark) {
+            mark.clearly-find { background-color: rgba(180, 150, 0, 0.4); }
+            mark.clearly-find.current { background-color: rgba(200, 150, 0, 0.6); }
+        }
+        </style>
         </head>
         <body>\(htmlBody)</body>
         <script>
@@ -213,6 +226,159 @@ struct PreviewView: NSViewRepresentable {
         var lastContentKey: String?
         var didInitialLoad = false
         var fileURL: URL?
+        var findState: FindState?
+        weak var webView: WKWebView?
+        private var findCancellables = Set<AnyCancellable>()
+        private var matchCount = 0
+        private var currentMatchIdx = 0
+
+        func observeFindState(_ state: FindState, webView: WKWebView) {
+            self.webView = webView
+            findCancellables.removeAll()
+
+            state.$query
+                .removeDuplicates()
+                .sink { [weak self] query in
+                    guard let self, self.findState?.isVisible == true else { return }
+                    self.performFind(query: query)
+                }
+                .store(in: &findCancellables)
+
+            state.$isVisible
+                .removeDuplicates()
+                .sink { [weak self] visible in
+                    guard let self else { return }
+                    if visible {
+                        self.setNavigationClosures()
+                        self.performFind(query: self.findState?.query ?? "")
+                    } else {
+                        self.clearFindHighlights()
+                    }
+                }
+                .store(in: &findCancellables)
+        }
+
+        private func setNavigationClosures() {
+            findState?.navigateToNext = { [weak self] in
+                self?.navigateToNextMatch()
+            }
+            findState?.navigateToPrevious = { [weak self] in
+                self?.navigateToPreviousMatch()
+            }
+        }
+
+        private func performFind(query: String) {
+            guard let webView, didInitialLoad else { return }
+            guard !query.isEmpty else {
+                clearFindHighlights()
+                return
+            }
+
+            let escaped = query
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+
+            let js = """
+            (function() {
+                document.querySelectorAll('mark.clearly-find').forEach(function(m) {
+                    var p = m.parentNode;
+                    p.replaceChild(document.createTextNode(m.textContent), m);
+                    p.normalize();
+                });
+                var query = '\(escaped)';
+                var count = 0;
+                var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+                var nodes = [];
+                while (walker.nextNode()) {
+                    if (walker.currentNode.parentElement.closest('script,style')) continue;
+                    nodes.push(walker.currentNode);
+                }
+                nodes.forEach(function(node) {
+                    var text = node.textContent;
+                    var lower = text.toLowerCase();
+                    var lq = query.toLowerCase();
+                    if (lower.indexOf(lq) === -1) return;
+                    var frag = document.createDocumentFragment();
+                    var last = 0, idx;
+                    while ((idx = lower.indexOf(lq, last)) !== -1) {
+                        if (idx > last) frag.appendChild(document.createTextNode(text.substring(last, idx)));
+                        var mark = document.createElement('mark');
+                        mark.className = 'clearly-find';
+                        mark.dataset.idx = count;
+                        mark.textContent = text.substring(idx, idx + query.length);
+                        frag.appendChild(mark);
+                        count++;
+                        last = idx + query.length;
+                    }
+                    if (last < text.length) frag.appendChild(document.createTextNode(text.substring(last)));
+                    node.parentNode.replaceChild(frag, node);
+                });
+                var first = document.querySelector('mark.clearly-find');
+                if (first) { first.classList.add('current'); first.scrollIntoView({block:'center'}); }
+                return count;
+            })();
+            """
+
+            webView.evaluateJavaScript(js) { [weak self] result, _ in
+                guard let self else { return }
+                let count = (result as? Int) ?? 0
+                self.matchCount = count
+                self.currentMatchIdx = 0
+                DispatchQueue.main.async {
+                    self.findState?.matchCount = count
+                    self.findState?.currentIndex = count > 0 ? 1 : 0
+                }
+            }
+        }
+
+        private func navigateToNextMatch() {
+            guard matchCount > 0 else { return }
+            currentMatchIdx = (currentMatchIdx + 1) % matchCount
+            navigateToMatch(currentMatchIdx)
+        }
+
+        private func navigateToPreviousMatch() {
+            guard matchCount > 0 else { return }
+            currentMatchIdx = (currentMatchIdx - 1 + matchCount) % matchCount
+            navigateToMatch(currentMatchIdx)
+        }
+
+        private func navigateToMatch(_ index: Int) {
+            let js = """
+            (function() {
+                var marks = document.querySelectorAll('mark.clearly-find');
+                marks.forEach(function(m) { m.classList.remove('current'); });
+                if (marks[\(index)]) {
+                    marks[\(index)].classList.add('current');
+                    marks[\(index)].scrollIntoView({block:'center'});
+                }
+            })();
+            """
+            webView?.evaluateJavaScript(js)
+            DispatchQueue.main.async { [weak self] in
+                self?.findState?.currentIndex = index + 1
+            }
+        }
+
+        private func clearFindHighlights() {
+            let js = """
+            (function() {
+                document.querySelectorAll('mark.clearly-find').forEach(function(m) {
+                    var p = m.parentNode;
+                    p.replaceChild(document.createTextNode(m.textContent), m);
+                    p.normalize();
+                });
+            })();
+            """
+            webView?.evaluateJavaScript(js)
+            matchCount = 0
+            currentMatchIdx = 0
+            DispatchQueue.main.async { [weak self] in
+                self?.findState?.matchCount = 0
+                self?.findState?.currentIndex = 0
+            }
+        }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             if !didInitialLoad {
@@ -220,6 +386,10 @@ struct PreviewView: NSViewRepresentable {
                 didInitialLoad = true
             }
             scrollSync?.syncPreview()
+            // Re-apply find highlights after page reload
+            if let query = findState?.query, findState?.isVisible == true, !query.isEmpty {
+                performFind(query: query)
+            }
         }
 
         private func resolvedLinkURL(for href: String) -> URL? {

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -99,6 +99,18 @@ enum Theme {
             : NSColor(red: 0.35, green: 0.35, blue: 0.5, alpha: 1)
     }
 
+    static let findHighlightColor = NSColor(name: "themeFindHighlight") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.6, green: 0.5, blue: 0.0, alpha: 0.3)
+            : NSColor(red: 1.0, green: 0.9, blue: 0.0, alpha: 0.4)
+    }
+
+    static let findCurrentHighlightColor = NSColor(name: "themeFindCurrentHighlight") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.8, green: 0.6, blue: 0.0, alpha: 0.5)
+            : NSColor(red: 1.0, green: 0.7, blue: 0.0, alpha: 0.6)
+    }
+
     static var backgroundColorSwiftUI: Color { Color(nsColor: backgroundColor) }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the non-functional toolbar search button with a custom inline Find bar (similar to Apple Notes) that appears below the toolbar
- Works in all three view modes: editor highlights matches in `NSTextStorage`, preview highlights via JavaScript DOM manipulation
- Supports Cmd+F toggle, prev/next navigation with match count display, Enter/Shift+Enter for navigation, and Escape to dismiss
- Adds `FindState` (shared ObservableObject) and `FindBarView` (SwiftUI) as new files; wires find state through `FocusedValue` for menu command support

## Test plan
- [ ] Open a markdown file, click the magnifying glass or press Cmd+F — find bar appears below toolbar
- [ ] Type a search term — matches highlighted in editor with current match in orange
- [ ] Click prev/next arrows or use Enter/Shift+Enter to navigate between matches
- [ ] Press Done or Escape to dismiss, highlights cleared
- [ ] Switch to Preview mode (Cmd+3), search works via JS highlighting in rendered HTML
- [ ] Switch to Side-by-side (Cmd+2), search highlights in editor pane
- [ ] Verify find bar doesn't overlap content in any mode