### PR TITLE
Force plain-text paste to prevent markdown mangling

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -69,7 +69,11 @@ final class ClearlyTextView: NSTextView {
             return
         }
 
-        super.paste(sender)
+        if let plainText = pasteboard.string(forType: .string) {
+            insertText(plainText, replacementRange: selectedRange())
+        } else {
+            super.paste(sender)
+        }
     }
 
     // MARK: - Find


### PR DESCRIPTION
## Summary
- NSTextView's default `super.paste()` prefers HTML/RTF from the clipboard over plain text, even with `isRichText = false`
- When pasting markdown from Claude.ai (which puts both HTML and plain text on the clipboard), NSTextView reads the HTML and converts it to plain text, destroying markdown syntax
- Fix explicitly reads the `.string` (plain text) pasteboard type and inserts it directly, preserving raw markdown

Fixes #59