### PR TITLE
Fix multi-document open hang by deferring scroll layout queries

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -271,19 +271,27 @@ struct EditorView: NSViewRepresentable {
         private var scrollSuppressCount = 0
 
         @objc func scrollViewDidScroll(_ notification: Notification) {
-            // Suppress during highlighting — the layout manager may be mid-update
-            // and querying it here would deadlock the main thread
+            // Suppress during highlighting to avoid scheduling unnecessary async blocks
             guard !isHighlightingInProgress else {
                 scrollSuppressCount += 1
-                // Log first occurrence and every 100th to avoid flooding
                 if scrollSuppressCount == 1 || scrollSuppressCount % 100 == 0 {
                     DiagnosticLog.log("scrollViewDidScroll suppressed ×\(scrollSuppressCount)")
                 }
                 return
             }
 
-            guard let clipView = notification.object as? NSClipView,
-                  let scrollView = clipView.enclosingScrollView,
+            guard let clipView = notification.object as? NSClipView else { return }
+
+            // Defer layout manager queries to the next run loop iteration.
+            // boundsDidChangeNotification fires synchronously during layout passes;
+            // querying the layout manager in that same call stack deadlocks the main thread.
+            DispatchQueue.main.async { [weak self] in
+                self?.computeScrollPosition(clipView)
+            }
+        }
+
+        private func computeScrollPosition(_ clipView: NSClipView) {
+            guard let scrollView = clipView.enclosingScrollView,
                   let textView = scrollView.documentView as? NSTextView,
                   let layoutManager = textView.layoutManager,
                   let textContainer = textView.textContainer else { return }


### PR DESCRIPTION
## Summary

- Defer layout manager queries in `scrollViewDidScroll` to the next run loop iteration via `DispatchQueue.main.async`, breaking the synchronous reentrancy that deadlocks the main thread
- `boundsDidChangeNotification` fires synchronously during NSLayoutManager layout passes — the scroll handler was querying `glyphIndex`/`lineFragmentRect` in that same call stack, causing `ensureLayout` to reenter mid-layout
- Content with font attribute changes (headings, bold, italic) triggered this because they invalidate glyph metrics and change document height during the deferred layout pass after `textStorage.endEditing()`
- Previous fix attempts (PRs #45, #46, #49, #51) addressed reentrancy during the synchronous `highlightAll()` call, but the deadlock occurs in the *deferred* layout pass afterward when `isHighlightingInProgress` is already false

## Test plan
- [ ] Open a .md file with headings/bold/italic, then open a second — must not hang
- [ ] Close first with Cmd+W, open another — must not hang
- [ ] Scroll in editor with side-by-side mode — scroll sync still works
- [ ] Type in editor — highlighting updates without flash
- [ ] Toggle light/dark mode — both windows re-highlight correctly

Fixes #41