### PR TITLE
Cmd+Q hides window to menubar instead of quitting

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -7,6 +7,7 @@ import Sparkle
 
 final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     private var observers: [Any] = []
+    private var commandQMonitor: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // A normal Launch Services open activates the app and opens a document window.
@@ -30,11 +31,38 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         observers.append(nc.addObserver(forName: NSWindow.didResignMainNotification, object: nil, queue: .main) { [weak self] _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { self?.updateActivationPolicy() }
         })
+
+        commandQMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            guard self.shouldCloseToMenuBar(for: event) else { return event }
+            self.closeDocumentWindowsToMenuBar()
+            return nil
+        }
     }
 
     func applicationWillBecomeActive(_ notification: Notification) {
         if hasDocumentWindows() && NSApp.activationPolicy() != .regular {
             NSApp.setActivationPolicy(.regular)
+        }
+    }
+
+    func closeDocumentWindowsToMenuBar() {
+        let documentWindows = NSApp.windows.filter { window in
+            guard window.isVisible || window.isMiniaturized else { return false }
+            if window.level == .floating { return false }
+            if window.isSheet { return false }
+            if window is NSPanel { return false }
+            if window.frame.width < 50 || window.frame.height < 50 { return false }
+            return true
+        }
+
+        guard !documentWindows.isEmpty else {
+            updateActivationPolicy()
+            return
+        }
+
+        for window in documentWindows {
+            window.performClose(nil)
         }
     }
 
@@ -60,6 +88,22 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             if window is NSPanel { return false }
             if window.frame.width < 50 || window.frame.height < 50 { return false }
             return true
+        }
+    }
+
+    func shouldCloseToMenuBar(for event: NSEvent) -> Bool {
+        guard hasDocumentWindows() else { return false }
+        guard event.type == .keyDown else { return false }
+        guard event.charactersIgnoringModifiers?.lowercased() == "q" else { return false }
+
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return modifiers == [.command]
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let commandQMonitor {
+            NSEvent.removeMonitor(commandQMonitor)
+            self.commandQMonitor = nil
         }
     }
 }


### PR DESCRIPTION
## Summary
- Intercepts Cmd+Q when document windows are open and closes them instead of terminating the app
- App hides to menubar so the scratchpad remains accessible
- Full quit is still available from the menubar dropdown
- Uses a local key event monitor that swallows the Cmd+Q event and calls `performClose` on document windows

## Test plan
- [ ] Open a document, press Cmd+Q — window closes, menubar icon stays, app disappears from Dock
- [ ] Open scratchpad from menubar after Cmd+Q — works normally
- [ ] Quit from menubar dropdown — app fully terminates
- [ ] With no document windows open, Cmd+Q behaves normally (passes through)