### PR TITLE
Add document outline panel for header navigation

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -159,6 +159,7 @@ struct ClearlyApp: App {
             }
             CommandGroup(after: .textEditing) {
                 FindCommand()
+                OutlineToggleCommand()
                 ViewModeCommands()
             }
             CommandGroup(after: .textFormatting) {
@@ -295,6 +296,17 @@ struct FindCommand: View {
             findState?.present()
         }
         .keyboardShortcut("f", modifiers: .command)
+    }
+}
+
+struct OutlineToggleCommand: View {
+    @FocusedValue(\.outlineState) var outlineState
+
+    var body: some View {
+        Button("Toggle Outline") {
+            outlineState?.toggle()
+        }
+        .keyboardShortcut("o", modifiers: [.command, .shift])
     }
 }
 

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -22,6 +22,10 @@ struct FindStateKey: FocusedValueKey {
     typealias Value = FindState
 }
 
+struct OutlineStateKey: FocusedValueKey {
+    typealias Value = OutlineState
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -38,6 +42,10 @@ extension FocusedValues {
     var findState: FindState? {
         get { self[FindStateKey.self] }
         set { self[FindStateKey.self] = newValue }
+    }
+    var outlineState: OutlineState? {
+        get { self[OutlineStateKey.self] }
+        set { self[OutlineStateKey.self] = newValue }
     }
 }
 
@@ -116,6 +124,7 @@ struct ContentView: View {
     @StateObject private var scrollSync = ScrollSync()
     @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
+    @StateObject private var outlineState = OutlineState()
 
     init(document: Binding<MarkdownDocument>, fileURL: URL? = nil) {
         self._document = document
@@ -150,14 +159,14 @@ struct ContentView: View {
             Group {
                 switch mode {
                 case .edit:
-                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState)
+                    EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState, outlineState: outlineState)
                 case .sideBySide:
                     HSplitView {
-                        EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, scrollSync: scrollSync, findState: findState)
-                        PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync, fileURL: fileURL)
+                        EditorView(text: $document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, scrollSync: scrollSync, findState: findState, outlineState: outlineState)
+                        PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), scrollSync: scrollSync, fileURL: fileURL, outlineState: outlineState)
                     }
                 case .preview:
-                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState)
+                    PreviewView(markdown: document.text, fontSize: CGFloat(fontSize), fileURL: fileURL, findState: findState, outlineState: outlineState)
                 }
             }
         }
@@ -192,6 +201,11 @@ struct ContentView: View {
                 animateWindowFrame(window, to: newFrame)
             }
         }
+        .safeAreaInset(edge: .trailing, spacing: 0) {
+            if outlineState.isVisible {
+                OutlineView(outlineState: outlineState)
+            }
+        }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if mode != .preview {
                 HStack(spacing: 12) {
@@ -220,6 +234,16 @@ struct ContentView: View {
             }
             ToolbarItem(placement: .automatic) {
                 Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        outlineState.toggle()
+                    }
+                } label: {
+                    Image(systemName: "list.bullet.indent")
+                }
+                .help("Document Outline (Shift+Cmd+O)")
+            }
+            ToolbarItem(placement: .automatic) {
+                Button {
                     findState.present()
                 } label: {
                     Image(systemName: "magnifyingglass")
@@ -234,17 +258,20 @@ struct ContentView: View {
         .focusedSceneValue(\.documentText, document.text)
         .focusedSceneValue(\.documentFileURL, fileURL)
         .focusedSceneValue(\.findState, findState)
+        .focusedSceneValue(\.outlineState, outlineState)
         .onAppear {
             fileWatcher.onChange = { [self] newText in
                 document.text = newText
             }
             fileWatcher.watch(fileURL, currentText: document.text)
+            outlineState.parseHeadings(from: document.text)
         }
         .onChange(of: fileURL) { _, newURL in
             fileWatcher.watch(newURL, currentText: document.text)
         }
         .onChange(of: document.text) { _, newText in
             fileWatcher.updateCurrentText(newText)
+            outlineState.parseHeadings(from: newText)
         }
     }
 }

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -9,6 +9,7 @@ struct EditorView: NSViewRepresentable {
     var fileURL: URL?
     var scrollSync: ScrollSync?
     var findState: FindState?
+    var outlineState: OutlineState?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -79,6 +80,7 @@ struct EditorView: NSViewRepresentable {
         context.coordinator.textView = textView
         context.coordinator.scrollSync = scrollSync
         context.coordinator.findState = findState
+        context.coordinator.outlineState = outlineState
         if let findState {
             context.coordinator.observeFindState(findState)
         }
@@ -99,6 +101,11 @@ struct EditorView: NSViewRepresentable {
         }
         findState?.navigateToPrevious = { [weak coordinator] in
             coordinator?.navigateToPreviousMatch()
+        }
+
+        // Wire up outline scroll-to
+        outlineState?.scrollToRange = { [weak coordinator] range in
+            coordinator?.scrollToHeading(range)
         }
 
         // Observe scroll position for sync
@@ -197,6 +204,7 @@ struct EditorView: NSViewRepresentable {
         weak var textView: NSTextView?
         var scrollSync: ScrollSync?
         var findState: FindState?
+        var outlineState: OutlineState?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?
         var updateCount = 0
@@ -209,6 +217,12 @@ struct EditorView: NSViewRepresentable {
 
         init(_ parent: EditorView) {
             self.parent = parent
+        }
+
+        func scrollToHeading(_ range: NSRange) {
+            guard let textView else { return }
+            textView.scrollRangeToVisible(range)
+            textView.showFindIndicator(for: range)
         }
 
         func observeFindState(_ state: FindState) {

--- a/Clearly/OutlineState.swift
+++ b/Clearly/OutlineState.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+struct HeadingItem: Identifiable, Hashable {
+    let id = UUID()
+    let level: Int       // 1-6
+    let title: String    // Inline markdown stripped
+    let range: NSRange   // Location in document text
+    let previewAnchor: PreviewSourceAnchor
+}
+
+final class OutlineState: ObservableObject {
+    @Published var isVisible: Bool {
+        didSet { UserDefaults.standard.set(isVisible, forKey: "outlineVisible") }
+    }
+    @Published var headings: [HeadingItem] = []
+
+    /// Set by EditorView coordinator, called when user clicks a heading (editor scroll)
+    var scrollToRange: ((NSRange) -> Void)?
+    /// Set by PreviewView coordinator, called when user clicks a heading (preview scroll)
+    var scrollToPreviewAnchor: ((PreviewSourceAnchor) -> Void)?
+
+    private static let atxHeadingRegex = try! NSRegularExpression(
+        pattern: "^(#{1,6})\\s+(.+)$",
+        options: .anchorsMatchLines
+    )
+    private static let setextHeadingRegex = try! NSRegularExpression(
+        pattern: "^(.+)\\n([=-]+)[ \\t]*$",
+        options: .anchorsMatchLines
+    )
+    private static let codeBlockRegex = try! NSRegularExpression(
+        pattern: "^(`{3,})(.*?)\\n([\\s\\S]*?)^\\1\\s*$",
+        options: [.anchorsMatchLines]
+    )
+    private static let frontmatterRegex = try! NSRegularExpression(
+        pattern: "\\A---[ \\t]*\\n([\\s\\S]*?)\\n---[ \\t]*(?:\\n|\\z)",
+        options: []
+    )
+
+    init() {
+        self.isVisible = UserDefaults.standard.bool(forKey: "outlineVisible")
+    }
+
+    func toggle() {
+        isVisible.toggle()
+    }
+
+    func parseHeadings(from text: String) {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+
+        // Find ranges to skip (code blocks, frontmatter)
+        var skipRanges: [NSRange] = []
+
+        Self.frontmatterRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            if let range = match?.range { skipRanges.append(range) }
+        }
+        Self.codeBlockRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            if let range = match?.range { skipRanges.append(range) }
+        }
+
+        // Find headings, skipping those inside code blocks/frontmatter
+        var items: [HeadingItem] = []
+        Self.atxHeadingRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let matchRange = match.range
+
+            // Skip if inside a code block or frontmatter
+            for skip in skipRanges {
+                if skip.location <= matchRange.location &&
+                    NSMaxRange(skip) >= NSMaxRange(matchRange) {
+                    return
+                }
+            }
+
+            let hashRange = match.range(at: 1)
+            let titleRange = match.range(at: 2)
+            let level = hashRange.length
+            let rawTitle = nsText.substring(with: titleRange)
+            let title = Self.stripInlineMarkdown(rawTitle)
+            let previewAnchor = Self.previewAnchor(for: matchRange, in: nsText)
+
+            items.append(HeadingItem(level: level, title: title, range: matchRange, previewAnchor: previewAnchor))
+        }
+
+        Self.setextHeadingRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let matchRange = match.range
+
+            for skip in skipRanges {
+                if skip.location <= matchRange.location &&
+                    NSMaxRange(skip) >= NSMaxRange(matchRange) {
+                    return
+                }
+            }
+
+            let titleRange = match.range(at: 1)
+            let markerRange = match.range(at: 2)
+            let rawTitle = nsText.substring(with: titleRange)
+            let title = Self.stripInlineMarkdown(rawTitle)
+            let marker = nsText.substring(with: markerRange)
+            let level = marker.first == "=" ? 1 : 2
+            let previewAnchor = Self.previewAnchor(for: matchRange, in: nsText)
+
+            items.append(HeadingItem(level: level, title: title, range: matchRange, previewAnchor: previewAnchor))
+        }
+
+        items.sort { lhs, rhs in
+            lhs.range.location < rhs.range.location
+        }
+
+        DispatchQueue.main.async {
+            self.headings = items
+        }
+    }
+
+    /// Strip bold, italic, code, strikethrough, and link markdown from heading text
+    private static func stripInlineMarkdown(_ text: String) -> String {
+        var result = text
+        // Links [text](url) → text
+        result = result.replacingOccurrences(
+            of: "\\[([^\\]]+)\\]\\([^)]+\\)",
+            with: "$1",
+            options: .regularExpression
+        )
+        // Images ![alt](url) → alt
+        result = result.replacingOccurrences(
+            of: "!\\[([^\\]]*)\\]\\([^)]+\\)",
+            with: "$1",
+            options: .regularExpression
+        )
+        // Bold **text** or __text__
+        result = result.replacingOccurrences(
+            of: "(\\*\\*|__)(.+?)\\1",
+            with: "$2",
+            options: .regularExpression
+        )
+        // Italic *text* or _text_ (simplified)
+        result = result.replacingOccurrences(
+            of: "(?<![\\w*])[*_](.+?)[*_](?![\\w*])",
+            with: "$1",
+            options: .regularExpression
+        )
+        // Strikethrough ~~text~~
+        result = result.replacingOccurrences(
+            of: "~~(.+?)~~",
+            with: "$1",
+            options: .regularExpression
+        )
+        // Inline code `text`
+        result = result.replacingOccurrences(
+            of: "`([^`]+)`",
+            with: "$1",
+            options: .regularExpression
+        )
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func previewAnchor(for range: NSRange, in text: NSString) -> PreviewSourceAnchor {
+        let start = lineAndColumn(for: range.location, in: text)
+        let endOffset = max(range.location, NSMaxRange(range) - 1)
+        let end = lineAndColumn(for: endOffset, in: text)
+        return PreviewSourceAnchor(
+            startLine: start.line,
+            startColumn: start.column,
+            endLine: end.line,
+            endColumn: end.column,
+            progress: 0
+        )
+    }
+
+    private static func lineAndColumn(for offset: Int, in text: NSString) -> (line: Int, column: Int) {
+        let clampedOffset = min(max(0, offset), text.length)
+        var line = 1
+        var lineStart = 0
+
+        while lineStart < clampedOffset {
+            let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            let nextLineStart = NSMaxRange(lineRange)
+            if nextLineStart > clampedOffset {
+                break
+            }
+            line += 1
+            lineStart = nextLineStart
+        }
+
+        return (line, max(1, clampedOffset - lineStart + 1))
+    }
+}

--- a/Clearly/OutlineView.swift
+++ b/Clearly/OutlineView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct OutlineView: View {
+    @ObservedObject var outlineState: OutlineState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("OUTLINE")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+                .tracking(1)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 6)
+
+            if outlineState.headings.isEmpty {
+                Spacer()
+                Text("No headings")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(outlineState.headings) { heading in
+                            HeadingRow(heading: heading) {
+                                outlineState.scrollToRange?(heading.range)
+                                outlineState.scrollToPreviewAnchor?(heading.previewAnchor)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+        }
+        .frame(width: 200)
+    }
+}
+
+private struct HeadingRow: View {
+    let heading: HeadingItem
+    let onTap: () -> Void
+    @State private var isHovered = false
+
+    private var font: Font {
+        switch heading.level {
+        case 1: return .system(size: 13, weight: .semibold)
+        case 2: return .system(size: 12, weight: .medium)
+        default: return .system(size: 11, weight: .regular)
+        }
+    }
+
+    private var indent: CGFloat {
+        CGFloat(heading.level - 1) * 12
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(heading.title)
+                .font(font)
+                .foregroundStyle(heading.level <= 2 ? .primary : .secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 12 + indent)
+                .padding(.trailing, 8)
+                .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isHovered ? Color.primary.opacity(0.06) : Color.clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+}

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -8,6 +8,7 @@ struct PreviewView: NSViewRepresentable {
     var scrollSync: ScrollSync?
     var fileURL: URL?
     var findState: FindState?
+    var outlineState: OutlineState?
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
@@ -32,10 +33,15 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.scrollSync = scrollSync
         context.coordinator.fileURL = fileURL
         context.coordinator.findState = findState
+        context.coordinator.outlineState = outlineState
         scrollSync?.previewWebView = webView
         if let findState {
             context.coordinator.observeFindState(findState, webView: webView)
         }
+        outlineState?.scrollToPreviewAnchor = { [weak coordinator = context.coordinator] anchor in
+            coordinator?.scrollToHeading(anchor: anchor)
+        }
+
         loadHTML(in: webView, context: context)
         return webView
     }
@@ -227,6 +233,7 @@ struct PreviewView: NSViewRepresentable {
         var didInitialLoad = false
         var fileURL: URL?
         var findState: FindState?
+        var outlineState: OutlineState?
         weak var webView: WKWebView?
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
@@ -265,6 +272,28 @@ struct PreviewView: NSViewRepresentable {
             findState?.navigateToPrevious = { [weak self] in
                 self?.navigateToPreviousMatch()
             }
+        }
+
+        func scrollToHeading(anchor: PreviewSourceAnchor) {
+            let js = """
+            (function() {
+                var headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6');
+                for (var i = 0; i < headings.length; i++) {
+                    var sp = headings[i].getAttribute('data-sourcepos');
+                    if (!sp) continue;
+                    var match = /^(\\d+):(\\d+)-(\\d+):(\\d+)$/.exec(sp);
+                    if (!match) continue;
+                    if (
+                        parseInt(match[1], 10) === \(anchor.startLine) &&
+                        parseInt(match[2], 10) === \(anchor.startColumn)
+                    ) {
+                        headings[i].scrollIntoView({behavior:'smooth', block:'start'});
+                        return;
+                    }
+                }
+            })();
+            """
+            webView?.evaluateJavaScript(js)
         }
 
         private func performFind(query: String) {

--- a/Clearly/ScrollSync.swift
+++ b/Clearly/ScrollSync.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WebKit
 
-struct PreviewSourceAnchor {
+struct PreviewSourceAnchor: Hashable {
     let startLine: Int
     let startColumn: Int
     let endLine: Int


### PR DESCRIPTION
## Summary
- Adds a toggleable outline sidebar that parses H1-H6 headers (ATX and setext) from the markdown text and displays them with proper hierarchy/indentation
- Clicking a heading scrolls to it in the editor (with find indicator flash) or preview (via `data-sourcepos` matching)
- Works in all three view modes (editor, split, preview); toggle via toolbar button or Shift+Cmd+O
- Skips headings inside fenced code blocks and frontmatter

Fixes #65

## Test plan
- [ ] Open a markdown file with multiple heading levels (H1-H6)
- [ ] Toggle outline via toolbar button and Shift+Cmd+O
- [ ] Click headings to verify scroll-to in editor, split, and preview modes
- [ ] Verify headings inside code blocks are excluded
- [ ] Test with setext-style headings (underlined with `===` or `---`)
- [ ] Verify outline updates as you type new headings
- [ ] Test light and dark mode appearance