### PR TITLE
Add native spell checking support

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -38,6 +38,53 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             self.closeDocumentWindowsToMenuBar()
             return nil
         }
+
+    }
+
+    // MARK: - Spelling and Grammar menu injection
+
+    /// SwiftUI owns the Edit menu and regenerates its items on every update cycle.
+    /// `applicationWillUpdate` fires on every run-loop iteration just before the
+    /// UI refreshes, so we can re-inject our submenu after SwiftUI wipes it.
+    /// The guard on `contains(where:)` makes this a no-op in the common case.
+    func applicationWillUpdate(_ notification: Notification) {
+        injectSpellingMenuIfNeeded()
+    }
+
+    private func injectSpellingMenuIfNeeded() {
+        guard let editMenu = NSApp.mainMenu?.item(withTitle: "Edit")?.submenu else { return }
+        guard !editMenu.items.contains(where: { $0.title == "Spelling and Grammar" }) else { return }
+
+        let spellingItem = NSMenuItem(title: "Spelling and Grammar", action: nil, keyEquivalent: "")
+        let spellingMenu = NSMenu(title: "Spelling and Grammar")
+
+        let showItem = NSMenuItem(title: "Show Spelling and Grammar", action: #selector(NSText.showGuessPanel(_:)), keyEquivalent: ":")
+        showItem.keyEquivalentModifierMask = [.command]
+        spellingMenu.addItem(showItem)
+
+        let checkItem = NSMenuItem(title: "Check Document Now", action: #selector(NSText.checkSpelling(_:)), keyEquivalent: ";")
+        checkItem.keyEquivalentModifierMask = [.command]
+        spellingMenu.addItem(checkItem)
+
+        spellingMenu.addItem(.separator())
+        spellingMenu.addItem(NSMenuItem(title: "Check Spelling While Typing", action: #selector(NSTextView.toggleContinuousSpellChecking(_:)), keyEquivalent: ""))
+        spellingMenu.addItem(NSMenuItem(title: "Check Grammar With Spelling", action: #selector(NSTextView.toggleGrammarChecking(_:)), keyEquivalent: ""))
+        spellingMenu.addItem(NSMenuItem(title: "Correct Spelling Automatically", action: #selector(NSTextView.toggleAutomaticSpellingCorrection(_:)), keyEquivalent: ""))
+
+        spellingItem.submenu = spellingMenu
+
+        // Place before Writing Tools (and its preceding separator) if present.
+        if let writingToolsIndex = editMenu.items.firstIndex(where: { $0.title == "Writing Tools" }) {
+            // Insert before the separator that precedes Writing Tools
+            let insertIndex = (writingToolsIndex > 0 && editMenu.items[writingToolsIndex - 1].isSeparatorItem)
+                ? writingToolsIndex - 1
+                : writingToolsIndex
+            editMenu.insertItem(spellingItem, at: insertIndex)
+            editMenu.insertItem(.separator(), at: insertIndex)
+        } else {
+            editMenu.addItem(.separator())
+            editMenu.addItem(spellingItem)
+        }
     }
 
     func applicationWillBecomeActive(_ notification: Notification) {

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -1,6 +1,41 @@
 import AppKit
 
-final class ClearlyTextView: NSTextView {
+enum TextCheckingPreferences {
+    private static let continuousSpellCheckingKey = "continuousSpellCheckingEnabled"
+    private static let grammarCheckingKey = "grammarCheckingEnabled"
+    private static let automaticSpellingCorrectionKey = "automaticSpellingCorrectionEnabled"
+
+    static func apply(to textView: NSTextView) {
+        textView.isContinuousSpellCheckingEnabled = UserDefaults.standard.object(forKey: continuousSpellCheckingKey) as? Bool ?? true
+        textView.isGrammarCheckingEnabled = UserDefaults.standard.object(forKey: grammarCheckingKey) as? Bool ?? true
+        textView.isAutomaticSpellingCorrectionEnabled = UserDefaults.standard.object(forKey: automaticSpellingCorrectionKey) as? Bool ?? false
+    }
+
+    static func persist(from textView: NSTextView) {
+        UserDefaults.standard.set(textView.isContinuousSpellCheckingEnabled, forKey: continuousSpellCheckingKey)
+        UserDefaults.standard.set(textView.isGrammarCheckingEnabled, forKey: grammarCheckingKey)
+        UserDefaults.standard.set(textView.isAutomaticSpellingCorrectionEnabled, forKey: automaticSpellingCorrectionKey)
+    }
+}
+
+class PersistentTextCheckingTextView: NSTextView {
+    @objc override func toggleContinuousSpellChecking(_ sender: Any?) {
+        super.toggleContinuousSpellChecking(sender)
+        TextCheckingPreferences.persist(from: self)
+    }
+
+    @objc override func toggleGrammarChecking(_ sender: Any?) {
+        super.toggleGrammarChecking(sender)
+        TextCheckingPreferences.persist(from: self)
+    }
+
+    @objc override func toggleAutomaticSpellingCorrection(_ sender: Any?) {
+        super.toggleAutomaticSpellingCorrection(sender)
+        TextCheckingPreferences.persist(from: self)
+    }
+}
+
+final class ClearlyTextView: PersistentTextCheckingTextView {
     var documentURL: URL?
     var onShowFind: (() -> Void)?
 

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -31,7 +31,7 @@ struct EditorView: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
+        TextCheckingPreferences.apply(to: textView)
 
         // Font
         textView.font = Theme.editorFont

--- a/Clearly/OutlineState.swift
+++ b/Clearly/OutlineState.swift
@@ -28,7 +28,7 @@ final class OutlineState: ObservableObject {
         options: .anchorsMatchLines
     )
     private static let codeBlockRegex = try! NSRegularExpression(
-        pattern: "^(`{3,})(.*?)\\n([\\s\\S]*?)^\\1\\s*$",
+        pattern: "^((?:`{3,}|~{3,}))[^\n]*\\n([\\s\\S]*?)^\\1[ \\t]*$",
         options: [.anchorsMatchLines]
     )
     private static let frontmatterRegex = try! NSRegularExpression(

--- a/Clearly/ScratchpadEditorView.swift
+++ b/Clearly/ScratchpadEditorView.swift
@@ -17,14 +17,14 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.autohidesScrollers = true
 
-        let textView = NSTextView()
+        let textView = PersistentTextCheckingTextView()
         textView.isRichText = false
         textView.allowsUndo = true
         textView.usesFindPanel = true
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
+        TextCheckingPreferences.apply(to: textView)
 
         textView.font = Theme.editorFont
         textView.textColor = Theme.textColor


### PR DESCRIPTION
## Summary
- Enable continuous spell checking and grammar checking on NSTextView in both the main editor and scratchpad
- Inject a "Spelling and Grammar" submenu into the Edit menu via `applicationWillUpdate` to work around SwiftUI regenerating menu contents on every update cycle
- Persist spell check/grammar/autocorrect toggle preferences in UserDefaults so they survive across sessions via a `PersistentTextCheckingTextView` base class
- Fix outline code block regex to handle tilde-fenced blocks (`~~~`)

## Test plan
- [ ] Open a document and type a misspelled word — confirm red underline appears
- [ ] Right-click a misspelled word — confirm suggestions and "Add to Dictionary" appear
- [ ] Edit > Spelling and Grammar submenu appears with all options (Show Spelling and Grammar, Check Document Now, Check Spelling While Typing, Check Grammar With Spelling, Correct Spelling Automatically)
- [ ] Toggle options via the menu and relaunch — confirm preferences persist
- [ ] Test scratchpad editor has the same spell checking behavior

Fixes #68