### PR TITLE
Fix document windows opening behind other apps

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -3,6 +3,14 @@ import SwiftUI
 import Sparkle
 #endif
 
+func activateDocumentApp() {
+    if NSApp.activationPolicy() != .regular {
+        NSApp.setActivationPolicy(.regular)
+    }
+    // Document opens from the menu bar must steal focus from the current app.
+    NSApp.activate(ignoringOtherApps: true)
+}
+
 // MARK: - App Delegate (dock icon management)
 
 final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
@@ -30,6 +38,14 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         })
         observers.append(nc.addObserver(forName: NSWindow.didResignMainNotification, object: nil, queue: .main) { [weak self] _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { self?.updateActivationPolicy() }
+        })
+        observers.append(nc.addObserver(forName: NSWindow.didBecomeMainNotification, object: nil, queue: .main) { notification in
+            guard let window = notification.object as? NSWindow else { return }
+            // Only for document windows, not panels/sheets/scratchpads
+            guard !(window is NSPanel), !window.isSheet, window.level != .floating else { return }
+            guard window.frame.width >= 50 && window.frame.height >= 50 else { return }
+            activateDocumentApp()
+            window.orderFrontRegardless()
         })
 
         commandQMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -90,6 +90,9 @@ struct WindowFrameSaver: NSViewRepresentable {
                     coordinator: context.coordinator,
                     persistCurrentFrame: false
                 )
+                // Ensure the document window comes to front after opening.
+                activateDocumentApp()
+                window.makeKeyAndOrderFront(nil)
             }
         }
         return view

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -27,19 +27,25 @@ struct ScratchpadMenuBar: View {
         }
 
         Button("New Document") {
-            NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                NSApp.activate(ignoringOtherApps: true)
+                activateDocumentApp()
                 NSDocumentController.shared.newDocument(nil)
             }
         }
         .keyboardShortcut("n", modifiers: [.command])
 
         Button("Open Document") {
-            NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                NSApp.activate(ignoringOtherApps: true)
-                NSDocumentController.shared.openDocument(nil)
+                activateDocumentApp()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    NSDocumentController.shared.openDocument(nil)
+                    // Ensure the open panel is frontmost
+                    DispatchQueue.main.async {
+                        for window in NSApp.windows where window is NSOpenPanel {
+                            window.orderFrontRegardless()
+                        }
+                    }
+                }
             }
         }
         .keyboardShortcut("o", modifiers: [.command])


### PR DESCRIPTION
## Summary
- Document windows opened from the launch dialog or menu bar would appear behind other applications because the app's activation policy toggling between `.regular` and `.accessory` left the app non-active when new windows were created.
- Consolidates activation logic into a shared `activateDocumentApp()` helper that ensures `.regular` policy and force-activates the app.
- Calls it from three places: `didBecomeMainNotification` observer, `WindowFrameSaver.makeNSView` (when a document view is created), and the menu bar Open/New Document buttons.
- Also fixes the Open Document menu bar button where the `NSOpenPanel` itself appeared behind other windows by delaying `openDocument` until after activation and bringing the panel to front.

## Test plan
- [ ] Launch with another app in foreground, pick a file from the open dialog — window should appear in front
- [ ] Use menu bar "Open Document" — file picker and resulting window should appear in front
- [ ] Use menu bar "New Document" — new document window should appear in front
- [ ] Close all documents (app collapses to menu bar), then reopen — window should come to front