### PR TITLE
Prevent Cmd+Q from quitting when only scratchpads are open

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -119,14 +119,12 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
-        guard !documentWindows.isEmpty else {
-            updateActivationPolicy()
-            return
-        }
-
         for window in documentWindows {
             window.performClose(nil)
         }
+
+        Task { @MainActor in ScratchpadManager.shared.closeAll() }
+        updateActivationPolicy()
     }
 
     private func updateActivationPolicy() {
@@ -155,7 +153,6 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func shouldCloseToMenuBar(for event: NSEvent) -> Bool {
-        guard hasDocumentWindows() else { return false }
         guard event.type == .keyDown else { return false }
         guard event.charactersIgnoringModifiers?.lowercased() == "q" else { return false }
 

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -60,6 +60,5 @@ struct ScratchpadMenuBar: View {
         Button("Quit Clearly") {
             NSApp.terminate(nil)
         }
-        .keyboardShortcut("q", modifiers: [.command])
     }
 }


### PR DESCRIPTION
## Summary
- Cmd+Q previously quit the app when only scratchpad windows were open (no document windows), because the event monitor's `hasDocumentWindows()` guard let the quit event pass through
- Removed the guard so Cmd+Q is always intercepted regardless of window types
- Added `ScratchpadManager.shared.closeAll()` so scratchpads close alongside document windows on Cmd+Q
- Removed the `⌘Q` keyboard shortcut from the menu bar Quit button to prevent it from bypassing the event monitor

The only way to fully quit is now clicking "Quit Clearly" in the menu bar extra or the app menu.

## Test plan
- [ ] Open a document → Cmd+Q → window closes, app collapses to menu bar
- [ ] Open only scratchpads → Cmd+Q → scratchpads close, app collapses to menu bar
- [ ] Open both → Cmd+Q → all close, app collapses to menu bar
- [ ] Click "Quit Clearly" in menu bar extra → app actually quits