### PR TITLE
Add Cmd+S save-to-file for scratchpad windows

### DIFF
--- a/Clearly/ScratchpadContentView.swift
+++ b/Clearly/ScratchpadContentView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 struct ScratchpadContentView: View {
     @Binding var text: String
     @AppStorage("editorFontSize") private var fontSize: Double = 16
+    var onSave: (() -> Void)?
 
     var body: some View {
-        ScratchpadEditorView(text: $text, fontSize: CGFloat(fontSize))
+        ScratchpadEditorView(text: $text, fontSize: CGFloat(fontSize), onSave: onSave)
     }
 }

--- a/Clearly/ScratchpadEditorView.swift
+++ b/Clearly/ScratchpadEditorView.swift
@@ -1,9 +1,25 @@
 import SwiftUI
 import AppKit
 
+final class ScratchpadTextView: PersistentTextCheckingTextView {
+    var onSave: (() -> Void)?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard event.modifierFlags.contains(.command) else {
+            return super.performKeyEquivalent(with: event)
+        }
+        if event.charactersIgnoringModifiers == "s" {
+            onSave?()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}
+
 struct ScratchpadEditorView: NSViewRepresentable {
     @Binding var text: String
     var fontSize: CGFloat = 16
+    var onSave: (() -> Void)?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -17,7 +33,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.autohidesScrollers = true
 
-        let textView = PersistentTextCheckingTextView()
+        let textView = ScratchpadTextView()
         textView.isRichText = false
         textView.allowsUndo = true
         textView.usesFindPanel = true
@@ -58,8 +74,14 @@ struct ScratchpadEditorView: NSViewRepresentable {
         textView.string = text
         textView.delegate = context.coordinator
 
+        let coordinator = context.coordinator
+        textView.onSave = { [weak coordinator] in
+            coordinator?.onSave?()
+        }
+        coordinator.onSave = onSave
+
         scrollView.documentView = textView
-        context.coordinator.textView = textView
+        coordinator.textView = textView
 
         return scrollView
     }
@@ -68,6 +90,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         guard let textView = scrollView.documentView as? NSTextView else { return }
 
         context.coordinator.parent = self
+        context.coordinator.onSave = onSave
 
         textView.insertionPointColor = Theme.textColor
 
@@ -116,6 +139,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         weak var textView: NSTextView?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?
+        var onSave: (() -> Void)?
 
         init(_ parent: ScratchpadEditorView) {
             self.parent = parent

--- a/Clearly/ScratchpadManager.swift
+++ b/Clearly/ScratchpadManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import KeyboardShortcuts
 
 struct Scratchpad: Identifiable {
@@ -68,7 +69,9 @@ final class ScratchpadManager {
             }
         )
 
-        let contentView = ScratchpadContentView(text: binding)
+        let contentView = ScratchpadContentView(text: binding, onSave: { [weak self] in
+            self?.saveAsDocument(id: padID)
+        })
         window.contentView = NSHostingView(rootView: contentView)
 
         // Add hover tracking for traffic light buttons (above content so it receives events)
@@ -120,6 +123,46 @@ final class ScratchpadManager {
         guard let window = windows[id] else { return }
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func saveAsDocument(id: UUID) {
+        guard let pad = scratchpads.first(where: { $0.id == id }),
+              !pad.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let window = windows[id] else {
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.daringFireballMarkdown]
+        let name = pad.displayTitle
+        panel.nameFieldStringValue = name.hasSuffix(".md") ? name : "\(name).md"
+
+        panel.beginSheetModal(for: window) { [weak self] response in
+            guard response == .OK, let url = panel.url else { return }
+
+            do {
+                try pad.text.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                let alert = NSAlert(error: error)
+                alert.runModal()
+                return
+            }
+
+            activateDocumentApp()
+            NSDocumentController.shared.openDocument(
+                withContentsOf: url,
+                display: true
+            ) { [weak self] _, _, error in
+                if let error {
+                    let alert = NSAlert(error: error)
+                    alert.runModal()
+                    return
+                }
+                Task { @MainActor in
+                    self?.windows[id]?.close()
+                }
+            }
+        }
     }
 
     func closeAll() {


### PR DESCRIPTION
## Summary
- Pressing Cmd+S in a scratchpad shows a save dialog (NSSavePanel as a sheet) so the user can save the content as a `.md` file
- After saving, the file opens as a regular document window and the scratchpad closes automatically
- Empty scratchpads ignore Cmd+S (no dialog shown)

## Test plan
- [ ] Create a scratchpad, type content, press Cmd+S — save dialog appears
- [ ] Save to a location — document window opens, scratchpad closes
- [ ] Empty scratchpad + Cmd+S — nothing happens
- [ ] Cancel the save dialog — scratchpad stays open with content intact