### PR TITLE
Add copy-to-clipboard button for code blocks in preview

### DIFF
--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -3,6 +3,8 @@ import WebKit
 import Combine
 
 struct PreviewView: NSViewRepresentable {
+    private static let copyButtonContentWorld = WKContentWorld.world(name: "ClearlyCopyButtons")
+
     let markdown: String
     var fontSize: CGFloat = 18
     var mode: ViewMode
@@ -25,6 +27,8 @@ struct PreviewView: NSViewRepresentable {
         config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         config.userContentController.add(context.coordinator, name: "linkClicked")
         config.userContentController.add(context.coordinator, name: "scrollSync")
+        config.userContentController.add(context.coordinator, contentWorld: Self.copyButtonContentWorld, name: "copyToClipboard")
+        config.userContentController.addUserScript(Self.copyButtonUserScript())
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.underPageBackgroundColor = Theme.backgroundColor
@@ -77,6 +81,7 @@ struct PreviewView: NSViewRepresentable {
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard", contentWorld: Self.copyButtonContentWorld)
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
@@ -370,6 +375,12 @@ struct PreviewView: NSViewRepresentable {
         }
 
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if message.name == "copyToClipboard", let text = message.body as? String {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+                return
+            }
+
             if message.name == "linkClicked", let href = message.body as? String {
                 handleLinkClick(href)
                 return
@@ -382,5 +393,44 @@ struct PreviewView: NSViewRepresentable {
             scrollFraction = fraction
             ScrollBridge.setFraction(fraction, for: self.positionSyncID)
         }
+    }
+
+    private static func copyButtonUserScript() -> WKUserScript {
+        let copyIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"18\" height=\"18\" viewBox=\"0 0 18 18\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"M12.25 5.75H13.75C14.8546 5.75 15.75 6.6454 15.75 7.75V13.75C15.75 14.8546 14.8546 15.75 13.75 15.75H7.75C6.6454 15.75 5.75 14.8546 5.75 13.75V12.25\"></path><path d=\"M10.25 2.25H4.25C3.14543 2.25 2.25 3.14543 2.25 4.25V10.25C2.25 11.3546 3.14543 12.25 4.25 12.25H10.25C11.3546 12.25 12.25 11.3546 12.25 10.25V4.25C12.25 3.14543 11.3546 2.25 10.25 2.25Z\"></path></g></svg>"#
+        let checkIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"12\" height=\"12\" viewBox=\"0 0 12 12\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"m1.76,7.004l2.25,3L10.24,1.746\"></path></g></svg>"#
+        let source = """
+        (function() {
+            var copyIcon = '\(copyIcon)';
+            var checkIcon = '\(checkIcon)';
+            document.querySelectorAll('pre').forEach(function(pre) {
+                if (pre.closest('.frontmatter') || pre.querySelector('.code-copy-btn')) return;
+                var btn = document.createElement('button');
+                btn.className = 'code-copy-btn';
+                btn.type = 'button';
+                btn.setAttribute('aria-label', 'Copy code');
+                btn.innerHTML = copyIcon;
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var code = pre.querySelector('code');
+                    var text = code ? code.textContent : pre.textContent;
+                    window.webkit.messageHandlers.copyToClipboard.postMessage(text);
+                    btn.classList.add('copied');
+                    btn.innerHTML = checkIcon;
+                    setTimeout(function() {
+                        btn.classList.remove('copied');
+                        btn.innerHTML = copyIcon;
+                    }, 1500);
+                });
+                pre.appendChild(btn);
+            });
+        })();
+        """
+        return WKUserScript(
+            source: source,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true,
+            in: copyButtonContentWorld
+        )
     }
 }

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -3,6 +3,7 @@ import Foundation
 enum PreviewCSS {
     static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
     let exportOverrides = forExport ? """
+    .code-copy-btn { display: none !important; }
     body {
         color: #222222 !important;
         background: white !important;
@@ -116,6 +117,19 @@ enum PreviewCSS {
         pre code {
             background: none !important;
             color: #E0E0E0 !important;
+        }
+        .code-copy-btn {
+            background: rgba(255, 255, 255, 0.06);
+            color: #999999;
+        }
+        .code-copy-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+        .code-copy-btn:active {
+            background: rgba(255, 255, 255, 0.14);
+        }
+        .code-copy-btn.copied {
+            color: #3fb950;
         }
         blockquote {
             border-left-color: #444444;
@@ -236,12 +250,57 @@ enum PreviewCSS {
     }
 
     pre {
+        position: relative;
         background-color: #F5F5F5;
         border: 1px solid #E0E0E0;
         border-radius: 4px;
         padding: 1em;
         margin-bottom: 1em;
         overflow-x: auto;
+    }
+
+    .code-copy-btn {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        margin: 0;
+        border: none;
+        border-radius: 4px;
+        background: rgba(0, 0, 0, 0.04);
+        color: #666666;
+        cursor: pointer;
+        opacity: 0;
+        transition: opacity 0.15s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .code-copy-btn svg {
+        display: block;
+    }
+
+    .code-copy-btn.copied {
+        color: #2ea043;
+    }
+
+    pre:hover .code-copy-btn {
+        opacity: 1;
+    }
+
+    .code-copy-btn:hover {
+        background: rgba(0, 0, 0, 0.08);
+    }
+
+    .code-copy-btn:active {
+        background: rgba(0, 0, 0, 0.12);
+    }
+
+    .frontmatter .code-copy-btn {
+        display: none;
     }
 
     pre code {
@@ -404,6 +463,7 @@ enum PreviewCSS {
     }
 
     @media print {
+        .code-copy-btn { display: none !important; }
         body {
             color: #222222 !important;
             background-color: #FFFFFF !important;


### PR DESCRIPTION
## Summary
- Adds a hover-revealed copy button (top-right) on all `<pre>` code blocks in preview mode
- Copies code to clipboard via native `NSPasteboard` bridge (WKScriptMessageHandler), since the JS Clipboard API doesn't work in WKWebView's non-secure context
- Shows a checkmark confirmation for 1.5s after copying
- Dark/light mode aware with `currentColor` SVG icons
- Hidden in print, export, and frontmatter `<pre>` blocks

Fixes #85

## Test plan
- [ ] Open a markdown file with fenced code blocks, switch to Preview (Cmd+2)
- [ ] Hover over a code block — copy button appears top-right
- [ ] Click button — checkmark shows, clipboard contains the code
- [ ] Toggle dark mode — button colors adapt
- [ ] Print preview (Cmd+P) — no copy buttons visible
- [ ] Frontmatter blocks have no copy button