### PR TITLE
Update README and marketing site for file explorer and outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Clearly Markdown</h1>
 
-<p align="center">A clean, native markdown editor for macOS.</p>
+<p align="center">A native markdown editor and document workspace for macOS.</p>
 
 <p align="center">
   <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg">Download</a> &middot;
@@ -16,14 +16,16 @@
   <img src="website/screenshot.jpg" width="720" alt="Clearly screenshot" />
 </p>
 
-Write with syntax highlighting, preview instantly, and get back to what matters. No Electron, no subscriptions, no bloat.
+Open folders, browse your files, write with syntax highlighting, and preview instantly. No Electron, no subscriptions, no bloat.
 
 ## Features
 
+- **File explorer** — open folders, browse markdown files in a sidebar with bookmarked locations and recents
+- **Document outline** — navigable header outline panel for jumping between sections (⇧⌘O)
 - **Syntax highlighting** — headings, bold, italic, links, code blocks, and more
 - **Instant preview** — rendered GitHub Flavored Markdown, including Mermaid diagrams and KaTeX math
 - **Frontmatter support** — YAML frontmatter is formatted cleanly in both editor and preview
-- **Side-by-side** — edit and preview simultaneously with synchronized scrolling
+- **Editor/Preview toggle** — switch between editor (⌘1) and preview (⌘2) with scroll position preserved
 - **PDF export** — export to PDF or print directly from the app
 - **Format shortcuts** — Cmd+B, Cmd+I, Cmd+K for bold, italic, and links
 - **Scratchpad** — menubar app with a global hotkey for capturing quick notes without opening a document

--- a/website/index.html
+++ b/website/index.html
@@ -8,10 +8,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="Clearly Markdown" />
     <link rel="manifest" href="/site.webmanifest" />
-    <title>Clearly Markdown — A clean, native markdown editor for Mac</title>
-    <meta name="description" content="A focused markdown editor built for macOS. Syntax highlighting, instant preview, and nothing else.">
+    <title>Clearly Markdown — A native markdown editor and document workspace for Mac</title>
+    <meta name="description" content="A native markdown editor and document workspace for macOS. Open folders, browse files, write with syntax highlighting, and preview instantly.">
     <meta property="og:title" content="Clearly Markdown">
-    <meta property="og:description" content="A clean, native markdown editor for Mac.">
+    <meta property="og:description" content="A native markdown editor and document workspace for Mac.">
     <meta property="og:image" content="https://clearly.md/icon.png">
     <meta property="og:url" content="https://clearly.md">
     <style>
@@ -171,7 +171,7 @@
     <div class="container">
         <img src="icon.png" alt="Clearly Markdown" class="icon">
         <h1>Clearly Markdown</h1>
-        <p class="subtitle">A clean, native markdown editor for Mac. Write with syntax highlighting, preview instantly, and get back to what matters.</p>
+        <p class="subtitle">A native markdown editor and document workspace for Mac. Open folders, browse your files, write with syntax highlighting, and preview instantly.</p>
         <div class="buttons">
             <a href="https://apps.apple.com/app/clearly-markdown/id6760669470" class="btn primary"><svg width="16" height="16" viewBox="0 0 814 1000" fill="currentColor"><path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57.8-155.5-127.4c-58.5-81.7-105.3-209-105.3-329.1 0-193.1 125.6-295.7 249.2-295.7 65.7 0 120.5 43.2 161.7 43.2 39.2 0 100.4-45.8 174.5-45.8 28.2 0 129.3 2.6 196.3 99.8zm-135.5-183.1c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.2 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg> Mac App Store</a>
             <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg" class="btn secondary">Direct Download</a>
@@ -185,6 +185,14 @@
             <h2>Features</h2>
             <div class="feature-grid">
                 <div class="feature">
+                    <h3>File Explorer</h3>
+                    <p>Open folders and browse your markdown files in a sidebar. Bookmark locations, see recents, create and rename files without leaving the app.</p>
+                </div>
+                <div class="feature">
+                    <h3>Document Outline</h3>
+                    <p>A navigable outline of every heading in your document. Click to jump. Toggle with ⇧⌘O.</p>
+                </div>
+                <div class="feature">
                     <h3>Native macOS</h3>
                     <p>Built with SwiftUI and AppKit. Fast launch, low memory, feels right at home on your Mac.</p>
                 </div>
@@ -197,8 +205,8 @@
                     <p>Full GitHub Flavored Markdown support, including Mermaid diagrams and KaTeX math.</p>
                 </div>
                 <div class="feature">
-                    <h3>Side-by-Side</h3>
-                    <p>Edit and preview at the same time. Scrolling stays in sync so you always see what you're working on.</p>
+                    <h3>Editor &amp; Preview Toggle</h3>
+                    <p>Switch between writing and reading with ⌘1 and ⌘2. Scroll position stays in sync across both.</p>
                 </div>
                 <div class="feature">
                     <h3>PDF Export</h3>
@@ -209,20 +217,16 @@
                     <p>Cmd+B for bold, Cmd+I for italic, Cmd+K for links. The keyboard shortcuts you expect.</p>
                 </div>
                 <div class="feature">
+                    <h3>Scratchpad</h3>
+                    <p>A menubar app with a global hotkey for jotting things down. Capture a thought without opening a full document.</p>
+                </div>
+                <div class="feature">
                     <h3>QuickLook</h3>
                     <p>Preview markdown files right in Finder. Press Space on any .md file.</p>
                 </div>
                 <div class="feature">
                     <h3>Light &amp; Dark</h3>
                     <p>Follows your system appearance or set it manually. Looks great either way.</p>
-                </div>
-                <div class="feature">
-                    <h3>Math &amp; Frontmatter</h3>
-                    <p>KaTeX math expressions render beautifully. YAML frontmatter is formatted cleanly in both editor and preview.</p>
-                </div>
-                <div class="feature">
-                    <h3>Scratchpad</h3>
-                    <p>A menubar app with a global hotkey for jotting things down. Capture a thought without opening a full document.</p>
                 </div>
                 <div class="feature">
                     <h3>Open Source</h3>


### PR DESCRIPTION
## Summary
- Repositions Clearly as a "document workspace" across README tagline, marketing site title, subtitle, meta description, and OG tags
- Adds **File Explorer** and **Document Outline** as the top two feature cards on the marketing site and top two bullet points in the README
- Replaces the removed Side-by-Side feature with **Editor & Preview Toggle** to match the current codebase
- Drops the redundant Math & Frontmatter card (already covered by Instant Preview)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Open `website/index.html` locally and confirm feature grid layout (12 cards, 2-column, even fill)
- [ ] Check meta tags render correctly in social sharing previews