### PR TITLE
Add installation source field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,6 +32,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: Installation source
+      description: How did you install Clearly?
+      options:
+        - Direct download (from website or GitHub)
+        - Mac App Store
+        - Not sure
+    validations:
+      required: true
+
   - type: input
     id: macos-version
     attributes:


### PR DESCRIPTION
Adds a required "Installation source" dropdown to the GitHub bug report issue template so users can indicate whether they installed Clearly from the Mac App Store or via direct download. Options: Direct download, Mac App Store, or Not sure.