### PR TITLE
Add Copy menu to toolbar and sidebar context menu

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -147,6 +147,24 @@ struct ContentView: View {
                 .frame(width: 100)
                 .help("Toggle Editor/Preview (Cmd+1/Cmd+2)")
             }
+            if workspace.activeDocumentID != nil {
+                ToolbarItem(placement: .automatic) {
+                    Menu {
+                        if let url = workspace.currentFileURL {
+                            Button("Copy File Path") { CopyActions.copyFilePath(url) }
+                            Button("Copy File Name") { CopyActions.copyFileName(url) }
+                            Divider()
+                        }
+                        Button("Copy Markdown") { CopyActions.copyMarkdown(workspace.currentFileText) }
+                        Button("Copy HTML") { CopyActions.copyHTML(workspace.currentFileText) }
+                        Button("Copy Rich Text") { CopyActions.copyRichText(workspace.currentFileText) }
+                        Button("Copy Plain Text") { CopyActions.copyPlainText(workspace.currentFileText) }
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .help("Copy document content")
+                }
+            }
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {

--- a/Clearly/CopyActions.swift
+++ b/Clearly/CopyActions.swift
@@ -1,0 +1,116 @@
+import AppKit
+
+enum CopyActions {
+    static func copyFilePath(_ url: URL) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(url.path, forType: .string)
+    }
+
+    static func copyFileName(_ url: URL) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(url.lastPathComponent, forType: .string)
+    }
+
+    static func copyMarkdown(_ text: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+    }
+
+    static func copyHTML(_ text: String) {
+        let html = MarkdownRenderer.renderHTML(text)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(html, forType: .html)
+        pb.setString(html, forType: .string)
+    }
+
+    static func copyRichText(_ text: String) {
+        let html = MarkdownRenderer.renderHTML(text)
+        guard let data = html.data(using: .utf8),
+              let attributed = NSAttributedString(html: data, documentAttributes: nil) else {
+            // Fall back to plain HTML if conversion fails
+            copyHTML(text)
+            return
+        }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        if let rtfData = attributed.rtf(from: NSRange(location: 0, length: attributed.length), documentAttributes: [:]) {
+            pb.setData(rtfData, forType: .rtf)
+        }
+        pb.setString(attributed.string, forType: .string)
+    }
+
+    static func copyPlainText(_ text: String) {
+        let html = MarkdownRenderer.renderHTML(text)
+        let plain: String
+        if let data = html.data(using: .utf8),
+           let attributed = NSAttributedString(html: data, documentAttributes: nil) {
+            plain = attributed.string
+        } else {
+            // Fall back: strip HTML tags with regex
+            plain = html.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(plain, forType: .string)
+    }
+
+    /// Reads markdown content from a file URL, using security-scoped access if needed.
+    static func readMarkdown(from url: URL) -> String? {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Builds an NSMenu with all copy items for a given file URL.
+    static func copySubmenu(for url: URL, target: AnyObject) -> NSMenu {
+        let sub = NSMenu(title: "Copy")
+
+        let pathItem = NSMenuItem(title: "Copy File Path", action: #selector(CopyMenuActions.copyFilePathAction(_:)), keyEquivalent: "")
+        pathItem.representedObject = url
+        pathItem.target = target
+        sub.addItem(pathItem)
+
+        let nameItem = NSMenuItem(title: "Copy File Name", action: #selector(CopyMenuActions.copyFileNameAction(_:)), keyEquivalent: "")
+        nameItem.representedObject = url
+        nameItem.target = target
+        sub.addItem(nameItem)
+
+        sub.addItem(.separator())
+
+        let mdItem = NSMenuItem(title: "Copy Markdown", action: #selector(CopyMenuActions.copyMarkdownAction(_:)), keyEquivalent: "")
+        mdItem.representedObject = url
+        mdItem.target = target
+        sub.addItem(mdItem)
+
+        let htmlItem = NSMenuItem(title: "Copy HTML", action: #selector(CopyMenuActions.copyHTMLAction(_:)), keyEquivalent: "")
+        htmlItem.representedObject = url
+        htmlItem.target = target
+        sub.addItem(htmlItem)
+
+        let richItem = NSMenuItem(title: "Copy Rich Text", action: #selector(CopyMenuActions.copyRichTextAction(_:)), keyEquivalent: "")
+        richItem.representedObject = url
+        richItem.target = target
+        sub.addItem(richItem)
+
+        let plainItem = NSMenuItem(title: "Copy Plain Text", action: #selector(CopyMenuActions.copyPlainTextAction(_:)), keyEquivalent: "")
+        plainItem.representedObject = url
+        plainItem.target = target
+        sub.addItem(plainItem)
+
+        return sub
+    }
+}
+
+/// Objective-C selectors for NSMenu actions.
+@objc protocol CopyMenuActions {
+    func copyFilePathAction(_ sender: NSMenuItem)
+    func copyFileNameAction(_ sender: NSMenuItem)
+    func copyMarkdownAction(_ sender: NSMenuItem)
+    func copyHTMLAction(_ sender: NSMenuItem)
+    func copyRichTextAction(_ sender: NSMenuItem)
+    func copyPlainTextAction(_ sender: NSMenuItem)
+}

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -704,6 +704,12 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 revealItem.target = self
                 menu.addItem(revealItem)
 
+                if !node.isDirectory {
+                    let copyItem = NSMenuItem(title: "Copy", action: nil, keyEquivalent: "")
+                    copyItem.submenu = CopyActions.copySubmenu(for: node.url, target: self)
+                    menu.addItem(copyItem)
+                }
+
                 menu.addItem(.separator())
 
                 let deleteItem = NSMenuItem(title: "Move to Trash", action: #selector(moveToTrashAction(_:)), keyEquivalent: "")
@@ -717,6 +723,10 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 revealItem.target = self
                 menu.addItem(revealItem)
 
+                let copyItem = NSMenuItem(title: "Copy", action: nil, keyEquivalent: "")
+                copyItem.submenu = CopyActions.copySubmenu(for: url, target: self)
+                menu.addItem(copyItem)
+
             case .openDocument(let doc):
                 if doc.isUntitled {
                     let saveItem = NSMenuItem(title: "Save As…", action: #selector(saveOpenDocAction(_:)), keyEquivalent: "")
@@ -729,6 +739,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     revealItem.representedObject = url
                     revealItem.target = self
                     menu.addItem(revealItem)
+
+                    let copyItem = NSMenuItem(title: "Copy", action: nil, keyEquivalent: "")
+                    copyItem.submenu = CopyActions.copySubmenu(for: url, target: self)
+                    menu.addItem(copyItem)
+
                     menu.addItem(.separator())
                 }
 
@@ -844,6 +859,42 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             // Switch to the document first, then save (triggers NSSavePanel for untitled)
             guard workspace.switchToDocument(docID) else { return }
             workspace.saveCurrentFile()
+        }
+
+        // MARK: - Copy Actions
+
+        @objc func copyFilePathAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            CopyActions.copyFilePath(url)
+        }
+
+        @objc func copyFileNameAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            CopyActions.copyFileName(url)
+        }
+
+        @objc func copyMarkdownAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            guard let text = workspace.textForCopy(at: url) else { return }
+            CopyActions.copyMarkdown(text)
+        }
+
+        @objc func copyHTMLAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            guard let text = workspace.textForCopy(at: url) else { return }
+            CopyActions.copyHTML(text)
+        }
+
+        @objc func copyRichTextAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            guard let text = workspace.textForCopy(at: url) else { return }
+            CopyActions.copyRichText(text)
+        }
+
+        @objc func copyPlainTextAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            guard let text = workspace.textForCopy(at: url) else { return }
+            CopyActions.copyPlainText(text)
         }
 
         // MARK: - Folder Icon Actions

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -487,6 +487,18 @@ final class WorkspaceManager {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    /// Returns the freshest available markdown for copy/export actions.
+    /// Prefer the in-memory buffer for open docs; fall back to disk for closed files.
+    func textForCopy(at url: URL) -> String? {
+        if currentFileURL == url {
+            return currentFileText
+        }
+        if let doc = openDocuments.first(where: { $0.fileURL == url }) {
+            return doc.text
+        }
+        return CopyActions.readMarkdown(from: url)
+    }
+
     // MARK: - Open Panel (supports both files and folders)
 
     func showNewFilePanel(defaultFileName: String = "Untitled.md") {


### PR DESCRIPTION
## Summary
- Adds a new toolbar dropdown button (doc.on.doc icon) with options to copy file path, file name, markdown, HTML, rich text, and plain text to the clipboard
- Adds a "Copy" submenu to the sidebar right-click context menu for files, recent files, and open documents
- New `CopyActions.swift` centralizes all copy logic including rich text conversion (HTML → NSAttributedString → RTF) and plain text extraction
- Toolbar copy button is hidden when no document is open; file path/name options only appear for saved files

## Test plan
- [ ] Open a markdown file, click the copy toolbar icon, verify all 6 options work
- [ ] Paste rich text into TextEdit/Notes and confirm formatting is preserved
- [ ] Paste plain text and confirm no markdown syntax present
- [ ] Right-click a file in the sidebar, verify "Copy" submenu appears with all options
- [ ] Close all documents, verify the toolbar copy button disappears

Fixes #107