### PR TITLE
Add show/hide hidden files toggle in sidebar

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -342,7 +342,8 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 
     func shouldToggleHiddenFiles(for event: NSEvent) -> Bool {
         guard event.type == .keyDown else { return false }
-        guard event.charactersIgnoringModifiers == "." else { return false }
+        // keyCode 47 = period key; charactersIgnoringModifiers gives ">" when Shift is held
+        guard event.keyCode == 47 else { return false }
 
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         guard modifiers == [.command, .shift] else { return false }

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -136,6 +136,7 @@ struct MainWindowMarker: NSViewRepresentable {
 final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     private var observers: [Any] = []
     private var commandQMonitor: Any?
+    private var showHiddenFilesMonitor: Any?
     private var isProgrammaticallyClosingWindows = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -173,6 +174,13 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return event }
             guard self.shouldCloseToMenuBar(for: event) else { return event }
             self.closeDocumentWindowsToMenuBar()
+            return nil
+        }
+
+        showHiddenFilesMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            guard self.shouldToggleHiddenFiles(for: event) else { return event }
+            WorkspaceManager.shared.toggleShowHiddenFiles()
             return nil
         }
 
@@ -226,6 +234,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         if let commandQMonitor {
             NSEvent.removeMonitor(commandQMonitor)
             self.commandQMonitor = nil
+        }
+        if let showHiddenFilesMonitor {
+            NSEvent.removeMonitor(showHiddenFilesMonitor)
+            self.showHiddenFilesMonitor = nil
         }
     }
 
@@ -326,6 +338,19 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         return modifiers == [.command]
+    }
+
+    func shouldToggleHiddenFiles(for event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+        guard event.charactersIgnoringModifiers == "." else { return false }
+
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers == [.command, .shift] else { return false }
+
+        guard let window = event.window else { return false }
+        guard WindowRouter.isMainDocumentWindow(window) else { return false }
+
+        return true
     }
 }
 
@@ -489,6 +514,12 @@ struct ClearlyApp: App {
                 Divider()
 
                 OutlineToggleCommand()
+
+                Divider()
+
+                Button(workspace.showHiddenFiles ? "Hide Hidden Files" : "Show Hidden Files") {
+                    workspace.toggleShowHiddenFiles()
+                }
             }
 
             CommandGroup(after: .textEditing) {

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -495,6 +495,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             cell.viewWithTag(addButtonTag)?.removeFromSuperview()
             cell.textField?.font = .systemFont(ofSize: 12)
             cell.textField?.textColor = .labelColor
+            cell.alphaValue = 1.0
 
             switch outlineItem.kind {
             case .section(let section):
@@ -546,6 +547,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     cell.imageView?.contentTintColor = .tertiaryLabelColor
                 }
                 cell.imageView?.isHidden = false
+                if node.isHidden { cell.alphaValue = 0.5 }
 
             case .recentFile(let url):
                 let filename = url.lastPathComponent

--- a/Clearly/FileNode.swift
+++ b/Clearly/FileNode.swift
@@ -5,6 +5,7 @@ struct FileNode: Identifiable, Hashable {
     var id: URL { url }
     let name: String
     let url: URL
+    let isHidden: Bool
     var children: [FileNode]?
 
     var isDirectory: Bool { children != nil }
@@ -14,12 +15,13 @@ struct FileNode: Identifiable, Hashable {
     ]
 
     /// Build a file tree from a directory URL, filtering to markdown files.
-    static func buildTree(at url: URL) -> [FileNode] {
+    static func buildTree(at url: URL, showHiddenFiles: Bool = false) -> [FileNode] {
         let fm = FileManager.default
+        let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
         guard let contents = try? fm.contentsOfDirectory(
             at: url,
             includingPropertiesForKeys: [.isDirectoryKey, .nameKey],
-            options: [.skipsHiddenFiles]
+            options: options
         ) else { return [] }
 
         var folders: [FileNode] = []
@@ -28,15 +30,16 @@ struct FileNode: Identifiable, Hashable {
         for itemURL in contents {
             let isDir = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
             let name = itemURL.lastPathComponent
+            let hidden = name.hasPrefix(".")
 
             if isDir {
-                let children = buildTree(at: itemURL)
+                let children = buildTree(at: itemURL, showHiddenFiles: showHiddenFiles)
                 // Only include folders that contain markdown files (directly or nested)
                 if !children.isEmpty {
-                    folders.append(FileNode(name: name, url: itemURL, children: children))
+                    folders.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: children))
                 }
             } else if markdownExtensions.contains(itemURL.pathExtension.lowercased()) {
-                files.append(FileNode(name: name, url: itemURL, children: nil))
+                files.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: nil))
             }
         }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -32,6 +32,7 @@ final class WorkspaceManager {
     // MARK: - Sidebar
 
     var isSidebarVisible: Bool = false
+    var showHiddenFiles: Bool = false
 
     // MARK: - Private
 
@@ -48,6 +49,7 @@ final class WorkspaceManager {
     private static let sidebarVisibleKey = "sidebarVisible"
     private static let launchBehaviorKey = "launchBehavior"
     private static let folderIconsKey = "folderIcons"
+    private static let showHiddenFilesKey = "showHiddenFiles"
 
     /// Custom folder icons keyed by folder path (URL.path → SF Symbol name).
     var folderIcons: [String: String] = [:]
@@ -62,6 +64,7 @@ final class WorkspaceManager {
 
     init() {
         isSidebarVisible = UserDefaults.standard.bool(forKey: Self.sidebarVisibleKey)
+        showHiddenFiles = UserDefaults.standard.bool(forKey: Self.showHiddenFilesKey)
         folderIcons = UserDefaults.standard.dictionary(forKey: Self.folderIconsKey) as? [String: String] ?? [:]
         restoreLocations()
         restoreRecents()
@@ -87,6 +90,14 @@ final class WorkspaceManager {
     func toggleSidebar() {
         isSidebarVisible.toggle()
         UserDefaults.standard.set(isSidebarVisible, forKey: Self.sidebarVisibleKey)
+    }
+
+    func toggleShowHiddenFiles() {
+        showHiddenFiles.toggle()
+        UserDefaults.standard.set(showHiddenFiles, forKey: Self.showHiddenFilesKey)
+        for index in locations.indices {
+            locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
+        }
     }
 
     // MARK: - Open Documents
@@ -375,7 +386,7 @@ final class WorkspaceManager {
         }
         accessedURLs.insert(url)
 
-        let tree = FileNode.buildTree(at: url)
+        let tree = FileNode.buildTree(at: url, showHiddenFiles: showHiddenFiles)
         let location = BookmarkedLocation(
             url: url,
             bookmarkData: bookmarkData,
@@ -401,7 +412,7 @@ final class WorkspaceManager {
 
     func refreshTree(for locationID: UUID) {
         guard let index = locations.firstIndex(where: { $0.id == locationID }) else { return }
-        locations[index].fileTree = FileNode.buildTree(at: locations[index].url)
+        locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
     }
 
     // MARK: - Recents
@@ -563,7 +574,7 @@ final class WorkspaceManager {
             guard url.startAccessingSecurityScopedResource() else { continue }
             accessedURLs.insert(url)
 
-            let tree = FileNode.buildTree(at: url)
+            let tree = FileNode.buildTree(at: url, showHiddenFiles: showHiddenFiles)
             let location = BookmarkedLocation(
                 id: bookmark.id,
                 url: url,


### PR DESCRIPTION
## Summary
- Adds a **View > Show Hidden Files** menu toggle that reveals dotfiles/dotfolders (e.g. `.docs`, `.ai`) in the sidebar file tree
- Keyboard shortcut **⌘⇧.** (matches Finder convention) via NSEvent monitor, scoped to the main document window
- Hidden items render at 50% opacity to visually distinguish them from regular files
- Setting persists across launches via UserDefaults (hidden by default)

Fixes #103