### PR TITLE
Add enhanced markdown table support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen
 2. **ClearlyQuickLook** (app extension) — QLPreviewProvider for Finder previews
 
 **Shared code** lives in `Shared/` and is compiled into both targets:
-- `MarkdownRenderer.swift` — wraps `cmark_gfm_markdown_to_html()` for GFM rendering (tables, strikethrough, task lists, autolinks)
+- `MarkdownRenderer.swift` — wraps `cmark_gfm_markdown_to_html()` for GFM rendering (tables, strikethrough, task lists, autolinks). Also does HTML post-processing for math (`$...$` → KaTeX spans) and table captions (`Table: text` → `<caption>`)
 - `PreviewCSS.swift` — CSS string used by both the in-app preview and the QuickLook extension
+- `MathSupport.swift` / `MermaidSupport.swift` / `TableSupport.swift` — conditional JS injection for preview features. Each follows the same pattern: check if the HTML contains relevant content, return script HTML or empty string
 
 **App code** in `Clearly/`:
 - `ClearlyApp.swift` — App entry point. `DocumentGroup` with `MarkdownDocument`, menu commands for switching view modes (⌘1 Editor, ⌘2 Preview)
@@ -73,4 +74,13 @@ When adding new Sparkle-dependent code, always wrap it in `#if canImport(Sparkle
 
 - All colors go through `Theme` with dynamic light/dark resolution — don't hardcode colors
 - Preview CSS in `PreviewCSS.swift` must stay in sync with `Theme` colors for visual consistency between editor and preview modes
+- CSS changes in `PreviewCSS.swift` must cover four contexts: base (light), `@media (prefers-color-scheme: dark)`, `@media print`, and the `forExport` override string. Interactive elements (copy buttons, sort indicators) should be hidden in print/export
 - Changes to `project.yml` require running `xcodegen generate` to update the Xcode project
+
+### Adding preview features
+
+Follow the `MathSupport`/`MermaidSupport`/`TableSupport` pattern: create a `*Support.swift` enum in `Shared/` with a static method that returns a `<script>` block (or empty string if the feature isn't needed for the current content). Integrate it into `PreviewView.swift`, `PreviewProvider.swift`, and `PDFExporter.swift` HTML templates. This ensures the feature works in preview, QuickLook, and PDF export.
+
+### Demo document
+
+`Shared/Resources/demo.md` is bundled with the app and accessible via **Help → Sample Document**. Keep it updated when adding new markdown features so it serves as both a user showcase and a test fixture.

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -534,6 +534,13 @@ struct ClearlyApp: App {
                     NSWorkspace.shared.open(URL(string: "https://github.com/Shpigford/clearly/issues")!)
                 }
                 Divider()
+                Button("Sample Document") {
+                    if let url = Bundle.main.url(forResource: "demo", withExtension: "md"),
+                       let content = try? String(contentsOf: url, encoding: .utf8) {
+                        workspace.createDocumentWithContent(content)
+                    }
+                }
+                Divider()
                 Button("Export Diagnostic Log…") {
                     do {
                         let logText = try DiagnosticLog.exportRecentLogs()

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -64,6 +64,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         </head>
         <body>\(htmlBody)</body>
         \(MathSupport.scriptHTML(for: htmlBody))
+        \(TableSupport.scriptHTML(for: htmlBody))
         </html>
         """
         wv.loadHTMLString(html, baseURL: documentURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -27,6 +27,7 @@ struct PreviewView: NSViewRepresentable {
         config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         config.userContentController.add(context.coordinator, name: "linkClicked")
         config.userContentController.add(context.coordinator, name: "scrollSync")
+        config.userContentController.add(context.coordinator, name: "copyToClipboard")
         config.userContentController.add(context.coordinator, contentWorld: Self.copyButtonContentWorld, name: "copyToClipboard")
         config.userContentController.addUserScript(Self.copyButtonUserScript())
         let webView = WKWebView(frame: .zero, configuration: config)
@@ -81,6 +82,7 @@ struct PreviewView: NSViewRepresentable {
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard", contentWorld: Self.copyButtonContentWorld)
     }
 
@@ -149,6 +151,7 @@ struct PreviewView: NSViewRepresentable {
         \(scrollJS)
         </script>
         \(MathSupport.scriptHTML(for: htmlBody))
+        \(TableSupport.scriptHTML(for: htmlBody))
         \(MermaidSupport.scriptHTML)
         </html>
         """

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -122,6 +122,25 @@ final class WorkspaceManager {
     }
 
     @discardableResult
+    func createDocumentWithContent(_ content: String) -> Bool {
+        guard saveFileBacked() else { return false }
+        snapshotActiveDocument()
+        let doc = OpenDocument(
+            id: UUID(),
+            fileURL: nil,
+            text: content,
+            lastSavedText: "",
+            untitledNumber: nextUntitledNumber
+        )
+        nextUntitledNumber += 1
+        openDocuments.append(doc)
+        activateDocument(doc)
+        DiagnosticLog.log("Created document with content: \(doc.displayName)")
+        presentMainWindow()
+        return true
+    }
+
+    @discardableResult
     func switchToDocument(_ id: UUID) -> Bool {
         guard id != activeDocumentID else { return true }
         guard openDocuments.contains(where: { $0.id == id }) else { return false }

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -30,6 +30,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             </head>
             <body>\(htmlBody)</body>
             \(MathSupport.scriptHTML(for: htmlBody))
+            \(TableSupport.scriptHTML(for: htmlBody))
             \(MermaidSupport.scriptHTML)
             </html>
             """

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -9,7 +9,7 @@ enum MarkdownRenderer {
 
         let body = frontmatter?.body ?? markdown
         let len = body.utf8.count
-        let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS)
+        let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)
         var html: String
         // Try GFM renderer first (tables, strikethrough, task lists, autolinks)
         if let buf = cmark_gfm_markdown_to_html(body, len, options) {
@@ -23,6 +23,7 @@ enum MarkdownRenderer {
             return ""
         }
         html = processMath(html)
+        html = processCaptions(html)
 
         // Fix sourcepos line numbers after stripping frontmatter
         if let frontmatter, frontmatter.lineCount > 0 {
@@ -162,6 +163,21 @@ enum MarkdownRenderer {
             )
         }
         return restored
+    }
+
+    /// Convert "Table: caption text" paragraphs immediately before a <table> into <caption> elements.
+    private static func processCaptions(_ html: String) -> String {
+        guard html.contains("<table") else { return html }
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<p[^>]*>Table:\s*(.*?)</p>\s*(<table[^>]*>)"#,
+            options: [.dotMatchesLineSeparators]
+        ) else { return html }
+        let nsHTML = html as NSString
+        return regex.stringByReplacingMatches(
+            in: html,
+            range: NSRange(location: 0, length: nsHTML.length),
+            withTemplate: "$2<caption>$1</caption>"
+        )
     }
 
     private static func escapeHTML(_ text: String) -> String {

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -4,6 +4,12 @@ enum PreviewCSS {
     static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
     let exportOverrides = forExport ? """
     .code-copy-btn { display: none !important; }
+    .table-copy-btn { display: none !important; }
+    .sort-indicator { display: none !important; }
+    thead { position: static !important; }
+    thead { display: table-header-group; }
+    tr:hover td { background-color: transparent !important; }
+    th { cursor: default !important; }
     body {
         color: #222222 !important;
         background: white !important;
@@ -139,11 +145,33 @@ enum PreviewCSS {
             background-color: #2A2A2A;
             border-color: #444444;
         }
+        table th:hover {
+            background-color: #333333;
+        }
         table td {
             border-color: #333333;
         }
         table tr:nth-child(even) {
             background-color: #222222;
+        }
+        tr:hover td {
+            background-color: rgba(255, 255, 255, 0.03);
+        }
+        caption {
+            color: #999999;
+        }
+        .table-copy-btn {
+            background: rgba(255, 255, 255, 0.06);
+            color: #999999;
+        }
+        .table-copy-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+        .table-copy-btn:active {
+            background: rgba(255, 255, 255, 0.14);
+        }
+        .table-copy-btn.copied {
+            color: #3fb950;
         }
         hr {
             border-color: #333333;
@@ -345,21 +373,56 @@ enum PreviewCSS {
     }
 
     /* Tables */
+    .table-shell {
+        position: relative;
+        overflow: visible;
+        margin-bottom: 1em;
+        --table-copy-top: 6px;
+    }
+
+    .table-shell.has-copy-btn::after {
+        content: "";
+        position: absolute;
+        top: calc(var(--table-copy-top) - 6px);
+        right: -44px;
+        width: 44px;
+        height: 40px;
+        pointer-events: auto;
+    }
+
+    .table-wrapper {
+        overflow-x: auto;
+    }
+
     table {
         border-collapse: collapse;
         width: 100%;
-        margin-bottom: 1em;
+        font-variant-numeric: tabular-nums;
     }
 
     th, td {
-        text-align: left;
         padding: 0.5em 0.75em;
+        max-width: 20em;
+        overflow-wrap: break-word;
+    }
+
+    thead {
+        position: sticky;
+        top: 0;
+        z-index: 1;
     }
 
     th {
         font-weight: 600;
         background-color: #F5F5F5;
         border-bottom: 2px solid #DDDDDD;
+        cursor: pointer;
+        user-select: none;
+        white-space: nowrap;
+    }
+
+    th:hover {
+        background-color: #EEEEEE;
     }
 
     td {
@@ -368,6 +431,76 @@ enum PreviewCSS {
 
     tr:nth-child(even) {
         background-color: #FAFAFA;
+    }
+
+    tr:hover td {
+        background-color: rgba(0, 0, 0, 0.03);
+    }
+
+    .sort-indicator {
+        font-size: 0.7em;
+        margin-left: 0.3em;
+        opacity: 0.3;
+    }
+
+    th.sort-asc .sort-indicator,
+    th.sort-desc .sort-indicator {
+        opacity: 1;
+    }
+
+    caption {
+        caption-side: top;
+        text-align: left;
+        font-size: 0.9em;
+        font-weight: 500;
+        color: #666666;
+        padding-bottom: 0.5em;
+    }
+
+    .table-copy-btn {
+        position: absolute;
+        right: -36px;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        margin: 0;
+        border: none;
+        border-radius: 4px;
+        background: rgba(0, 0, 0, 0.04);
+        color: #666666;
+        cursor: pointer;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateX(-4px);
+        transition: opacity 0.15s ease, transform 0.15s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 2;
+    }
+
+    .table-copy-btn svg {
+        display: block;
+    }
+
+    .table-copy-btn.copied {
+        color: #2ea043;
+    }
+
+    .table-shell:hover .table-copy-btn,
+    .table-copy-btn:hover,
+    .table-copy-btn:focus-visible {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateX(0);
+    }
+
+    .table-copy-btn:hover {
+        background: rgba(0, 0, 0, 0.08);
+    }
+
+    .table-copy-btn:active {
+        background: rgba(0, 0, 0, 0.12);
     }
 
     /* Strikethrough */
@@ -464,6 +597,12 @@ enum PreviewCSS {
 
     @media print {
         .code-copy-btn { display: none !important; }
+        .table-copy-btn { display: none !important; }
+        .sort-indicator { display: none !important; }
+        thead { position: static !important; }
+        thead { display: table-header-group; }
+        tr:hover td { background-color: transparent !important; }
+        th { cursor: default !important; }
         body {
             color: #222222 !important;
             background-color: #FFFFFF !important;

--- a/Shared/Resources/demo.md
+++ b/Shared/Resources/demo.md
@@ -1,0 +1,240 @@
+---
+title: Clearly — A Native Markdown Editor for macOS
+author: Josh Pigford
+date: 2026-04-11
+tags: markdown, macos, swiftui, demo
+---
+
+# Clearly
+
+A **native macOS markdown editor** built with SwiftUI — fast, focused, and beautifully rendered. This document shows off everything Clearly can do.
+
+> "The best tool is the one that gets out of your way." — *somebody, probably*
+
+---
+
+## Headings
+
+# H1 — The biggest statement
+## H2 — Section header
+### H3 — Subsection
+#### H4 — Smaller grouping
+##### H5 — Smaller still
+###### H6 — The smallest
+
+---
+
+## Text Formatting
+
+You can write in **bold**, *italic*, ***bold italic***, or ~~strikethrough~~. Combine them inline: this sentence has **bold with *nested italic* inside** for emphasis.
+
+Use `inline code` for short snippets, variable names like `NSTextStorage`, or file paths like `~/Desktop/demo.md`.
+
+Links look like this: [Clearly on GitHub](https://github.com/joshpigford/clearly), and autolinked URLs work too: https://apple.com.
+
+---
+
+## Lists
+
+### Unordered
+
+- First item
+- Second item
+  - Nested item
+  - Another nested item
+    - Even deeper
+- Third item
+
+### Ordered
+
+1. Draft the idea
+2. Write it down
+3. Ship it
+   1. Build
+   2. Test
+   3. Release
+
+### Task List
+
+- [x] Open a markdown file
+- [x] See beautiful syntax highlighting
+- [x] Render a live preview
+- [ ] Tell all your friends
+- [ ] World domination
+
+---
+
+## Blockquotes
+
+> Simplicity is the ultimate sophistication.
+>
+> > Nested blockquotes work too — useful for threaded replies or layered citations.
+>
+> — Leonardo da Vinci
+
+---
+
+## Code
+
+Inline: use `cmd + 1` for editor mode and `cmd + 2` for preview mode.
+
+Fenced code block with a language hint:
+
+```swift
+import SwiftUI
+
+@main
+struct ClearlyApp: App {
+    var body: some Scene {
+        DocumentGroup(newDocument: MarkdownDocument()) { file in
+            ContentView(document: file.$document)
+        }
+    }
+}
+```
+
+```python
+def fibonacci(n: int) -> list[int]:
+    seq = [0, 1]
+    for _ in range(n - 2):
+        seq.append(seq[-1] + seq[-2])
+    return seq
+
+print(fibonacci(10))
+```
+
+```bash
+# Build Clearly from the command line
+xcodegen generate
+xcodebuild -scheme Clearly -configuration Debug build
+```
+
+---
+
+## Tables
+
+### Feature Matrix (centered alignment)
+
+| Feature              | Editor | Preview | QuickLook |
+| :------------------- | :----: | :-----: | :-------: |
+| Syntax highlighting  |   ✓    |    —    |     —     |
+| Live GFM rendering   |   —    |    ✓    |     ✓     |
+| Tables               |   ✓    |    ✓    |     ✓     |
+| Math (KaTeX)         |   ✓    |    ✓    |     ✓     |
+| Mermaid diagrams     |   ✓    |    ✓    |     ✓     |
+| Task lists           |   ✓    |    ✓    |     ✓     |
+
+### Right-aligned numbers
+
+Numbers align cleanly in right-aligned columns — try clicking column headers to sort.
+
+| Item       | Qty | Price   |
+| ---------- | --: | ------: |
+| Coffee     |   2 |  $8.50  |
+| Croissant  |   1 |  $4.25  |
+| Donut      |   3 |  $9.00  |
+| Juice      |   1 |  $5.50  |
+| **Total**  |   7 | **$27.25** |
+
+### Table Captions
+
+A paragraph starting with "Table:" immediately before a table becomes a caption.
+
+Table: Quarterly revenue by region (in thousands)
+
+| Region        | Q1    | Q2    | Q3    | Q4    |
+| ------------- | ----: | ----: | ----: | ----: |
+| North America | $142  | $158  | $171  | $195  |
+| Europe        | $98   | $105  | $112  | $128  |
+| Asia Pacific  | $67   | $82   | $91   | $103  |
+
+### Wide Table (horizontal scroll)
+
+Tables wider than the viewport scroll horizontally inside their container.
+
+| Metric | January | February | March | April | May | June | July | August | September | October | November | December |
+| ------ | ------: | -------: | ----: | ----: | --: | ---: | ---: | -----: | --------: | ------: | -------: | -------: |
+| Users  | 1,200   | 1,450    | 1,800 | 2,100 | 2,400 | 2,750 | 3,100 | 3,500 | 3,900 | 4,200 | 4,600 | 5,100 |
+| Revenue | $12k   | $14.5k   | $18k  | $21k  | $24k | $27.5k | $31k | $35k  | $39k  | $42k  | $46k  | $51k  |
+
+---
+
+## Math (KaTeX)
+
+Inline math flows with your prose: the quadratic formula is $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$, and Euler's identity $e^{i\pi} + 1 = 0$ still feels like magic.
+
+Display math sits on its own line:
+
+$$
+\int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi}
+$$
+
+---
+
+## Mermaid Diagrams
+
+```mermaid
+flowchart LR
+    A[Write Markdown] --> B{Mode?}
+    B -->|⌘1| C[Editor]
+    B -->|⌘2| D[Preview]
+    C --> E[Syntax Highlighting]
+    D --> F[Live HTML]
+    E --> G[Save .md]
+    F --> G
+```
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant E as Editor
+    participant R as Renderer
+    U->>E: Types markdown
+    E->>E: Highlight syntax
+    U->>R: ⌘2 (Preview)
+    R->>R: cmark-gfm → HTML
+    R-->>U: Rendered preview
+```
+
+---
+
+## Horizontal Rules
+
+Three dashes, asterisks, or underscores all work:
+
+---
+
+***
+
+___
+
+---
+
+## Images
+
+![Clearly Screenshot](https://raw.githubusercontent.com/Shpigford/clearly/main/website/screenshot.jpg)
+
+---
+
+## Footnotes
+
+Clearly renders GitHub-style footnotes[^1], including multiple references[^note] in the same paragraph[^1].
+
+[^1]: This is the first footnote. It can contain **formatting** and `code`.
+[^note]: Named footnotes work too — use any label you like.
+
+---
+
+## Escapes & Edge Cases
+
+Use backslashes to escape markdown: \*not italic\*, \`not code\`, \# not a heading.
+
+HTML passes through for when you need it:
+
+<kbd>⌘</kbd> + <kbd>S</kbd> to save, <kbd>⌘</kbd> + <kbd>F</kbd> to find.
+
+---
+
+## The End
+
+That's Clearly — **every markdown feature you actually use**, rendered beautifully, highlighted live, and ready to ship. 🚀

--- a/Shared/TableSupport.swift
+++ b/Shared/TableSupport.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+enum TableSupport {
+    static func scriptHTML(for htmlBody: String) -> String {
+        guard htmlBody.contains("<table") else { return "" }
+
+        let copyIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"18\" height=\"18\" viewBox=\"0 0 18 18\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"M12.25 5.75H13.75C14.8546 5.75 15.75 6.6454 15.75 7.75V13.75C15.75 14.8546 14.8546 15.75 13.75 15.75H7.75C6.6454 15.75 5.75 14.8546 5.75 13.75V12.25\"></path><path d=\"M10.25 2.25H4.25C3.14543 2.25 2.25 3.14543 2.25 4.25V10.25C2.25 11.3546 3.14543 12.25 4.25 12.25H10.25C11.3546 12.25 12.25 11.3546 12.25 10.25V4.25C12.25 3.14543 11.3546 2.25 10.25 2.25Z\"></path></g></svg>"#
+        let checkIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"12\" height=\"12\" viewBox=\"0 0 12 12\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"m1.76,7.004l2.25,3L10.24,1.746\"></path></g></svg>"#
+
+        return """
+        <script>
+        (function() {
+            var copyIcon = '\(copyIcon)';
+            var checkIcon = '\(checkIcon)';
+
+            function positionCopyButton(table, button) {
+                if (!button) return;
+                var caption = table.querySelector('caption');
+                var top = (caption ? caption.getBoundingClientRect().height : 0) + 6;
+                button.style.top = top + 'px';
+                button.parentElement.style.setProperty('--table-copy-top', top + 'px');
+            }
+
+            // Wrap each table in a shell + scrollable container
+            document.querySelectorAll('table').forEach(function(table) {
+                var shell = document.createElement('div');
+                shell.className = 'table-shell';
+                var wrapper = document.createElement('div');
+                wrapper.className = 'table-wrapper';
+                table.parentNode.insertBefore(shell, table);
+                shell.appendChild(wrapper);
+                wrapper.appendChild(table);
+            });
+
+            // Add copy-as-TSV button (only when copyToClipboard handler is available)
+            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.copyToClipboard) {
+                document.querySelectorAll('.table-shell').forEach(function(shell) {
+                    var table = shell.querySelector('table');
+                    var btn = document.createElement('button');
+                    btn.className = 'table-copy-btn';
+                    btn.type = 'button';
+                    btn.setAttribute('aria-label', 'Copy table as TSV');
+                    btn.innerHTML = copyIcon;
+                    btn.addEventListener('click', function(e) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        var tsv = [];
+                        table.querySelectorAll('tr').forEach(function(row) {
+                            var cells = [];
+                            row.querySelectorAll('th, td').forEach(function(cell) {
+                                cells.push(cell.textContent.trim());
+                            });
+                            tsv.push(cells.join('\\t'));
+                        });
+                        window.webkit.messageHandlers.copyToClipboard.postMessage(tsv.join('\\n'));
+                        btn.classList.add('copied');
+                        btn.innerHTML = checkIcon;
+                        setTimeout(function() {
+                            btn.classList.remove('copied');
+                            btn.innerHTML = copyIcon;
+                        }, 1500);
+                    });
+                    shell.classList.add('has-copy-btn');
+                    shell.appendChild(btn);
+                    positionCopyButton(table, btn);
+                    window.addEventListener('resize', function() {
+                        positionCopyButton(table, btn);
+                    });
+                });
+            }
+
+            // Sortable columns — iterate per-table so colIndex is correct
+            document.querySelectorAll('table').forEach(function(table) {
+                var thead = table.querySelector('thead');
+                if (!thead) return;
+                var originalRows = null;
+
+                thead.querySelectorAll('th').forEach(function(th, colIndex) {
+                    var span = document.createElement('span');
+                    span.className = 'sort-indicator';
+                    th.appendChild(span);
+                    th.dataset.sortState = '0'; // 0=none, 1=asc, 2=desc
+
+                    th.addEventListener('click', function() {
+                        var tbody = table.querySelector('tbody') || table;
+                        var rows = Array.from(tbody.querySelectorAll('tr'));
+                        var sortState = parseInt(th.dataset.sortState || '0', 10);
+
+                        // Store original order on first sort
+                        if (!originalRows) {
+                            originalRows = rows.slice();
+                        }
+
+                        // Clear other column states in this table
+                        thead.querySelectorAll('th').forEach(function(otherTh, i) {
+                            if (i !== colIndex) {
+                                otherTh.classList.remove('sort-asc', 'sort-desc');
+                                otherTh.dataset.sortState = '0';
+                                var ind = otherTh.querySelector('.sort-indicator');
+                                if (ind) ind.textContent = '';
+                            }
+                        });
+
+                        sortState = (sortState + 1) % 3;
+                        th.dataset.sortState = String(sortState);
+
+                        if (sortState === 0) {
+                            th.classList.remove('sort-asc', 'sort-desc');
+                            span.textContent = '';
+                            if (originalRows) originalRows.forEach(function(row) { tbody.appendChild(row); });
+                        } else {
+                            var asc = sortState === 1;
+                            th.classList.toggle('sort-asc', asc);
+                            th.classList.toggle('sort-desc', !asc);
+                            span.textContent = asc ? ' \\u25B2' : ' \\u25BC';
+
+                            rows.sort(function(a, b) {
+                                var aText = (a.children[colIndex] || {}).textContent || '';
+                                var bText = (b.children[colIndex] || {}).textContent || '';
+                                var result = aText.localeCompare(bText, undefined, { numeric: true, sensitivity: 'base' });
+                                return asc ? result : -result;
+                            });
+                            rows.forEach(function(row) { tbody.appendChild(row); });
+                        }
+                    });
+                });
+            });
+        })();
+        </script>
+        """
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -36,6 +36,8 @@ targets:
       - path: Shared/Resources/fonts
         buildPhase: resources
         type: folder
+      - path: Shared/Resources/demo.md
+        buildPhase: resources
     dependencies:
       - package: cmark-gfm
         product: cmark


### PR DESCRIPTION
## Summary
- Fixes table cell alignment (center/right via `:---:` and `---:` syntax) by enabling `CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES` so cmark-gfm emits inline styles
- Adds table captions (`Table: caption text` paragraph before a table becomes a `<caption>` element)
- Adds scrollable wrapper for wide tables, sortable columns (click header to cycle asc/desc/reset), and copy-as-TSV button
- CSS polish: sticky headers, row hover highlighting, tabular numerals, `nowrap` on headers, dark mode and print variants
- Bundles a `demo.md` showcasing all supported features, accessible via **Help → Sample Document**

## Test plan
- [ ] Open Help → Sample Document and verify the demo loads as an untitled document
- [ ] Verify center/right-aligned columns render correctly in preview (Feature Matrix and price tables)
- [ ] Click column headers to sort — confirm all tables sort correctly, not just the first
- [ ] Scroll the wide monthly metrics table horizontally
- [ ] Hover over a table to see the copy button; click it and paste into a spreadsheet
- [ ] Verify `Table: Quarterly revenue...` renders as a caption above its table
- [ ] Test in dark mode, QuickLook preview, and PDF export