### PR TITLE
Add extended markdown support, code highlighting, and interactive preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen
 2. **ClearlyQuickLook** (app extension) — QLPreviewProvider for Finder previews
 
 **Shared code** lives in `Shared/` and is compiled into both targets:
-- `MarkdownRenderer.swift` — wraps `cmark_gfm_markdown_to_html()` for GFM rendering (tables, strikethrough, task lists, autolinks). Also does HTML post-processing for math (`$...$` → KaTeX spans) and table captions (`Table: text` → `<caption>`)
+- `MarkdownRenderer.swift` — wraps `cmark_gfm_markdown_to_html()` for GFM rendering. Post-processing pipeline (in order): math (`$...$` → KaTeX spans), highlight marks (`==text==` → `<mark>`), superscript/subscript, emoji shortcodes, callouts/admonitions (`[!TYPE]` blockquotes), TOC generation, table captions, code filename headers. All post-processing that touches inline syntax must use `protectCodeRegions()`/`restoreProtectedSegments()` to avoid transforming content inside `<pre>`/`<code>` tags.
 - `PreviewCSS.swift` — CSS string used by both the in-app preview and the QuickLook extension
 - `MathSupport.swift` / `MermaidSupport.swift` / `TableSupport.swift` — conditional JS injection for preview features. Each follows the same pattern: check if the HTML contains relevant content, return script HTML or empty string
 
@@ -75,11 +75,14 @@ When adding new Sparkle-dependent code, always wrap it in `#if canImport(Sparkle
 - All colors go through `Theme` with dynamic light/dark resolution — don't hardcode colors
 - Preview CSS in `PreviewCSS.swift` must stay in sync with `Theme` colors for visual consistency between editor and preview modes
 - CSS changes in `PreviewCSS.swift` must cover four contexts: base (light), `@media (prefers-color-scheme: dark)`, `@media print`, and the `forExport` override string. Interactive elements (copy buttons, sort indicators) should be hidden in print/export
+- **CSS source order in `PreviewCSS.swift`**: Base (light) styles for new elements must be defined BEFORE any `@media (prefers-color-scheme: dark)` overrides for those elements. If a base style comes after a dark-mode `@media` block, the base style wins by source order and dark mode breaks. Place the dark-mode override immediately after the base definition (in its own `@media` block if needed), not in the consolidated dark-mode block near the top of the file.
 - Changes to `project.yml` require running `xcodegen generate` to update the Xcode project
 
 ### Adding preview features
 
-Follow the `MathSupport`/`MermaidSupport`/`TableSupport` pattern: create a `*Support.swift` enum in `Shared/` with a static method that returns a `<script>` block (or empty string if the feature isn't needed for the current content). Integrate it into `PreviewView.swift`, `PreviewProvider.swift`, and `PDFExporter.swift` HTML templates. This ensures the feature works in preview, QuickLook, and PDF export.
+Follow the `MathSupport`/`MermaidSupport`/`TableSupport`/`SyntaxHighlightSupport` pattern: create a `*Support.swift` enum in `Shared/` with a static method that returns a `<script>` block (or empty string if the feature isn't needed for the current content). Integrate it into `PreviewView.swift`, `PreviewProvider.swift`, and `PDFExporter.swift` HTML templates. This ensures the feature works in preview, QuickLook, and PDF export.
+
+**Preview-to-editor communication**: Interactive preview features that modify source text or switch modes use `WKScriptMessageHandler` callbacks. Register the handler in `makeNSView`, add a callback closure on `PreviewView`, and wire it in `ContentView`. When the preview modifies source text (e.g., task checkbox toggle), set `coordinator.skipNextReload = true` before updating the binding — this prevents a full `loadHTMLString` flash since the DOM is already updated.
 
 ### Demo document
 

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+extension Notification.Name {
+    static let scrollEditorToLine = Notification.Name("scrollEditorToLine")
+}
+
 enum ViewMode: String, CaseIterable {
     case edit
     case preview
@@ -98,7 +102,40 @@ struct ContentView: View {
     private var previewPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
-        return PreviewView(markdown: workspace.currentFileText, fontSize: editorFontSize, mode: mode, positionSyncID: positionSyncID, fileURL: fileURL, findState: findState, outlineState: outlineState)
+        return PreviewView(
+            markdown: workspace.currentFileText,
+            fontSize: editorFontSize,
+            mode: mode,
+            positionSyncID: positionSyncID,
+            fileURL: fileURL,
+            findState: findState,
+            outlineState: outlineState,
+            onTaskToggle: { [workspace] line, checked in
+                var lines = workspace.currentFileText.components(separatedBy: "\n")
+                let idx = line - 1
+                guard idx >= 0, idx < lines.count else { return }
+                if checked {
+                    lines[idx] = lines[idx]
+                        .replacingOccurrences(of: "- [ ]", with: "- [x]")
+                        .replacingOccurrences(of: "* [ ]", with: "* [x]")
+                        .replacingOccurrences(of: "+ [ ]", with: "+ [x]")
+                } else {
+                    lines[idx] = lines[idx]
+                        .replacingOccurrences(of: "- [x]", with: "- [ ]")
+                        .replacingOccurrences(of: "- [X]", with: "- [ ]")
+                        .replacingOccurrences(of: "* [x]", with: "* [ ]")
+                        .replacingOccurrences(of: "* [X]", with: "* [ ]")
+                        .replacingOccurrences(of: "+ [x]", with: "+ [ ]")
+                        .replacingOccurrences(of: "+ [X]", with: "+ [ ]")
+                }
+                workspace.currentFileText = lines.joined(separator: "\n")
+            },
+            onClickToSource: { line in
+                mode = .edit
+                // Post a notification that EditorView can observe to scroll to line
+                NotificationCenter.default.post(name: .scrollEditorToLine, object: nil, userInfo: ["line": line])
+            }
+        )
     }
 
     private var mainContent: some View {

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -115,6 +115,14 @@ struct EditorView: NSViewRepresentable {
             object: scrollView.contentView
         )
 
+        // Observe click-to-source from preview
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleScrollToLine(_:)),
+            name: .scrollEditorToLine,
+            object: nil
+        )
+
         DiagnosticLog.log("makeNSView: EditorView ready")
         return scrollView
     }
@@ -252,6 +260,28 @@ struct EditorView: NSViewRepresentable {
             guard let textView else { return }
             textView.scrollRangeToVisible(range)
             textView.showFindIndicator(for: range)
+        }
+
+        @objc func handleScrollToLine(_ notification: Notification) {
+            guard let line = notification.userInfo?["line"] as? Int,
+                  let textView,
+                  line > 0 else { return }
+            let text = textView.string
+            let lines = (text as NSString).components(separatedBy: "\n")
+            let targetLine = min(line, lines.count)
+            var charOffset = 0
+            for i in 0..<(targetLine - 1) {
+                charOffset += (lines[i] as NSString).length + 1 // +1 for \n
+            }
+            let nsText = text as NSString
+            let range = NSRange(location: min(charOffset, nsText.length), length: 0)
+            textView.scrollRangeToVisible(range)
+            // Briefly highlight the line
+            if targetLine - 1 < lines.count {
+                let lineLen = (lines[targetLine - 1] as NSString).length
+                let highlightRange = NSRange(location: min(charOffset, nsText.length), length: min(lineLen, nsText.length - charOffset))
+                textView.showFindIndicator(for: highlightRange)
+            }
         }
 
         func observeFindState(_ state: FindState) {

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -31,7 +31,7 @@ final class MarkdownSyntaxHighlighter: NSObject {
         add("^\\$\\$\\n([\\s\\S]*?)^\\$\\$\\s*$", .mathBlock, options: .anchorsMatchLines)
 
         // Inline math: $...$
-        add("(?<!\\$)\\$(?!\\$)(.+?)(?<!\\$)\\$(?!\\$)", .mathInline)
+        add("(?<!\\$)\\$(?!\\$)([^\n$]+?)(?<!\\$)\\$(?!\\$)", .mathInline)
 
         // Headings: # Heading
         add("^(#{1,6}\\s+)(.+)$", .heading, options: .anchorsMatchLines)
@@ -46,13 +46,19 @@ final class MarkdownSyntaxHighlighter: NSObject {
         add("(?<![\\w*])(\\*(?!\\*)|_(?!_))(?!\\s)(.+?)(?<!\\s)\\1(?![\\w*])", .italic)
 
         // Strikethrough: ~~text~~
-        add("(~~)(.+?)(~~)", .strikethrough)
+        add("(~~)([^\n]+?)(~~)", .strikethrough)
 
         // Inline code: `code`
-        add("(`+)(.+?)(\\1)", .inlineCode)
+        add("(`+)([^\n]+?)(\\1)", .inlineCode)
+
+        // Images: ![alt](src) — must come before links
+        add("(!\\[)([^\\]\n]*)(\\]\\([^\n]+?\\))", .link)
 
         // Links: [text](url)
-        add("(\\[)(.+?)(\\]\\(.+?\\))", .link)
+        add("(\\[)([^\n]+?)(\\]\\([^\n]+?\\))", .link)
+
+        // Reference links: [text][ref]
+        add("(\\[)([^\\]\n]+)(\\])(\\[)([^\\]\n]*)(\\])", .link)
 
         // Blockquotes: > text
         add("^(>+\\s?)(.*)$", .blockquote, options: .anchorsMatchLines)
@@ -68,6 +74,21 @@ final class MarkdownSyntaxHighlighter: NSObject {
 
         // Horizontal rule
         add("^([-*_]{3,})\\s*$", .syntax, options: .anchorsMatchLines)
+
+        // Highlight/Mark: ==text==
+        add("(==)([^=\n]+?)(==)", .highlight)
+
+        // Footnote markers: [^ref]
+        add("(\\[\\^)([^\\]\n]+)(\\])", .footnote)
+
+        // Table rows: lines with pipes
+        add("^(\\|.+\\|)\\s*$", .syntax, options: .anchorsMatchLines)
+
+        // Setext headings: text followed by === or --- on next line
+        add("^(.+)\\n(={3,}|-{3,})\\s*$", .heading, options: .anchorsMatchLines)
+
+        // HTML tags
+        add("(</?[a-zA-Z][a-zA-Z0-9]*(?:\\s+[^>]*)?>)", .htmlTag)
 
         return result
     }()
@@ -89,6 +110,9 @@ final class MarkdownSyntaxHighlighter: NSObject {
         case mathBlock
         case mathInline
         case frontmatter
+        case highlight
+        case footnote
+        case htmlTag
     }
 
     // MARK: - Highlighting
@@ -271,6 +295,25 @@ final class MarkdownSyntaxHighlighter: NSObject {
                         textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: closeRange)
                         textStorage.addAttribute(.foregroundColor, value: Theme.mathColor, range: contentRange)
                     }
+
+                case .highlight:
+                    if match.numberOfRanges >= 4 {
+                        let openRange = match.range(at: 1)
+                        let contentRange = match.range(at: 2)
+                        let closeRange = match.range(at: 3)
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: openRange)
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: closeRange)
+                        textStorage.addAttributes([
+                            .foregroundColor: Theme.highlightColor,
+                            .backgroundColor: Theme.highlightBackgroundColor
+                        ], range: contentRange)
+                    }
+
+                case .footnote:
+                    textStorage.addAttribute(.foregroundColor, value: Theme.footnoteColor, range: match.range)
+
+                case .htmlTag:
+                    textStorage.addAttribute(.foregroundColor, value: Theme.htmlTagColor, range: match.range)
 
                 case .frontmatter:
                     let matchedText = (text as NSString).substring(with: match.range)

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -65,6 +65,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         <body>\(htmlBody)</body>
         \(MathSupport.scriptHTML(for: htmlBody))
         \(TableSupport.scriptHTML(for: htmlBody))
+        \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
         wv.loadHTMLString(html, baseURL: documentURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -12,6 +12,8 @@ struct PreviewView: NSViewRepresentable {
     var fileURL: URL?
     var findState: FindState?
     var outlineState: OutlineState?
+    var onTaskToggle: ((Int, Bool) -> Void)?
+    var onClickToSource: ((Int) -> Void)?
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
@@ -29,6 +31,8 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "scrollSync")
         config.userContentController.add(context.coordinator, name: "copyToClipboard")
         config.userContentController.add(context.coordinator, contentWorld: Self.copyButtonContentWorld, name: "copyToClipboard")
+        config.userContentController.add(context.coordinator, name: "taskToggle")
+        config.userContentController.add(context.coordinator, name: "clickToSource")
         config.userContentController.addUserScript(Self.copyButtonUserScript())
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
@@ -38,6 +42,8 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.positionSyncID = positionSyncID
         context.coordinator.findState = findState
         context.coordinator.outlineState = outlineState
+        context.coordinator.onTaskToggle = onTaskToggle
+        context.coordinator.onClickToSource = onClickToSource
         let coordinator = context.coordinator
         findState?.previewNavigateToNext = { [weak coordinator] in
             coordinator?.navigateToNextMatch()
@@ -75,7 +81,13 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.lastMode = mode
 
         if context.coordinator.lastContentKey != contentKey {
-            loadHTML(in: webView, context: context)
+            if context.coordinator.skipNextReload {
+                // Task toggle already updated the DOM; just sync the content key
+                context.coordinator.skipNextReload = false
+                context.coordinator.lastContentKey = contentKey
+            } else {
+                loadHTML(in: webView, context: context)
+            }
         }
     }
 
@@ -84,6 +96,8 @@ struct PreviewView: NSViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard", contentWorld: Self.copyButtonContentWorld)
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "clickToSource")
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
@@ -149,10 +163,115 @@ struct PreviewView: NSViewRepresentable {
             window.webkit.messageHandlers.linkClicked.postMessage(href);
         });
         \(scrollJS)
+        // Heading anchor links
+        var usedHeadingIDs = new Set();
+        function uniqueHeadingID(base, normalize) {
+            var normalized = base || 'section';
+            if (normalize) {
+                normalized = normalized.toLowerCase().replace(/[^\\w]+/g, '-').replace(/^-|-$/g, '') || 'section';
+            }
+            var candidate = normalized;
+            var suffix = 1;
+            while (usedHeadingIDs.has(candidate)) {
+                candidate = normalized + '-' + suffix;
+                suffix += 1;
+            }
+            usedHeadingIDs.add(candidate);
+            return candidate;
+        }
+        document.querySelectorAll('h1,h2,h3,h4,h5,h6').forEach(function(h) {
+            h.id = uniqueHeadingID(h.id || h.textContent.trim(), !h.id);
+            var link = document.createElement('a');
+            link.className = 'heading-anchor';
+            link.href = '#' + h.id;
+            link.textContent = '#';
+            link.addEventListener('click', function(e) { e.stopPropagation(); });
+            h.prepend(link);
+        });
+        // Task list checkbox toggle
+        document.querySelectorAll('input[type="checkbox"]').forEach(function(cb) {
+            var li = cb.closest('li');
+            if (!li) return;
+            cb.removeAttribute('disabled');
+            cb.disabled = false;
+            cb.style.cursor = 'pointer';
+            cb.addEventListener('click', function(e) {
+                e.stopPropagation();
+                var sp = li.getAttribute('data-sourcepos');
+                if (!sp) {
+                    var parent = li.closest('[data-sourcepos]');
+                    if (parent) sp = parent.getAttribute('data-sourcepos');
+                }
+                if (sp && window.webkit && window.webkit.messageHandlers.taskToggle) {
+                    window.webkit.messageHandlers.taskToggle.postMessage({
+                        sourcepos: sp,
+                        checked: cb.checked
+                    });
+                }
+            });
+        });
+        // Click-to-source: double-click to jump to editor
+        document.addEventListener('dblclick', function(e) {
+            var el = e.target;
+            while (el && el !== document.body) {
+                var sp = el.getAttribute('data-sourcepos');
+                if (sp) {
+                    var m = /^(\\d+):/.exec(sp);
+                    if (m && window.webkit && window.webkit.messageHandlers.clickToSource) {
+                        window.webkit.messageHandlers.clickToSource.postMessage(parseInt(m[1], 10));
+                    }
+                    return;
+                }
+                el = el.parentElement;
+            }
+        });
+        // Image lightbox
+        document.querySelectorAll('img').forEach(function(img) {
+            img.style.cursor = 'zoom-in';
+            img.addEventListener('click', function(e) {
+                e.preventDefault();
+                var overlay = document.createElement('div');
+                overlay.className = 'lightbox-overlay';
+                var clone = img.cloneNode();
+                clone.className = 'lightbox-img';
+                clone.style.cursor = 'default';
+                overlay.appendChild(clone);
+                overlay.addEventListener('click', function() {
+                    overlay.style.opacity = '0';
+                    setTimeout(function() { overlay.remove(); }, 200);
+                });
+                document.body.appendChild(overlay);
+                requestAnimationFrame(function() { overlay.style.opacity = '1'; });
+            });
+        });
+        // Footnote popovers
+        document.querySelectorAll('.footnote-ref a, sup.footnote-ref a').forEach(function(a) {
+            var popover = null;
+            a.addEventListener('mouseenter', function(e) {
+                var href = a.getAttribute('href');
+                if (!href || !href.startsWith('#')) return;
+                var target = document.querySelector(href);
+                if (!target) return;
+                popover = document.createElement('div');
+                popover.className = 'footnote-popover';
+                var content = target.cloneNode(true);
+                var backref = content.querySelector('.footnote-backref');
+                if (backref) backref.remove();
+                popover.innerHTML = content.innerHTML;
+                document.body.appendChild(popover);
+                var rect = a.getBoundingClientRect();
+                popover.style.top = (rect.bottom + window.scrollY + 6) + 'px';
+                popover.style.left = Math.max(8, Math.min(rect.left, window.innerWidth - 420)) + 'px';
+            });
+            a.addEventListener('mouseleave', function() {
+                if (popover) { popover.remove(); popover = null; }
+            });
+        });
         </script>
         \(MathSupport.scriptHTML(for: htmlBody))
         \(TableSupport.scriptHTML(for: htmlBody))
         \(MermaidSupport.scriptHTML)
+        \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
         webView.loadHTMLString(html, baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
@@ -167,6 +286,9 @@ struct PreviewView: NSViewRepresentable {
         var positionSyncID = ""
         var findState: FindState?
         var outlineState: OutlineState?
+        var onTaskToggle: ((Int, Bool) -> Void)?
+        var onClickToSource: ((Int) -> Void)?
+        var skipNextReload = false
         weak var webView: WKWebView?
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
@@ -386,6 +508,29 @@ struct PreviewView: NSViewRepresentable {
 
             if message.name == "linkClicked", let href = message.body as? String {
                 handleLinkClick(href)
+                return
+            }
+
+            if message.name == "taskToggle", let body = message.body as? [String: Any],
+               let sourcepos = body["sourcepos"] as? String,
+               let checked = body["checked"] as? Bool {
+                // Parse line number from sourcepos "startLine:startCol-endLine:endCol"
+                if let dashIdx = sourcepos.firstIndex(of: ":"),
+                   let line = Int(sourcepos[sourcepos.startIndex..<dashIdx]) {
+                    // The checkbox is already toggled in the DOM — skip the next
+                    // HTML reload so the page doesn't flash.
+                    skipNextReload = true
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onTaskToggle?(line, checked)
+                    }
+                }
+                return
+            }
+
+            if message.name == "clickToSource", let line = message.body as? Int {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onClickToSource?(line)
+                }
                 return
             }
 

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -35,8 +35,8 @@ enum Theme {
 
     static let backgroundColor = NSColor(name: "themeBackground") { appearance in
         appearance.isDark
-            ? NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1)
-            : NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1)
+            ? NSColor(red: 0.11, green: 0.11, blue: 0.118, alpha: 1)
+            : NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1)
     }
 
     static let textColor = NSColor(name: "themeText") { appearance in
@@ -97,6 +97,30 @@ enum Theme {
         appearance.isDark
             ? NSColor(red: 0.55, green: 0.55, blue: 0.65, alpha: 1)
             : NSColor(red: 0.35, green: 0.35, blue: 0.5, alpha: 1)
+    }
+
+    static let highlightColor = NSColor(name: "themeHighlight") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.9, green: 0.8, blue: 0.3, alpha: 1)
+            : NSColor(red: 0.6, green: 0.5, blue: 0.0, alpha: 1)
+    }
+
+    static let highlightBackgroundColor = NSColor(name: "themeHighlightBg") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.9, green: 0.8, blue: 0.3, alpha: 0.15)
+            : NSColor(red: 1.0, green: 0.9, blue: 0.0, alpha: 0.25)
+    }
+
+    static let footnoteColor = NSColor(name: "themeFootnote") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.6, green: 0.7, blue: 0.9, alpha: 1)
+            : NSColor(red: 0.3, green: 0.4, blue: 0.7, alpha: 1)
+    }
+
+    static let htmlTagColor = NSColor(name: "themeHTMLTag") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+            : NSColor(red: 0.55, green: 0.55, blue: 0.55, alpha: 1)
     }
 
     static let findHighlightColor = NSColor(name: "themeFindHighlight") { appearance in

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -32,6 +32,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             \(MathSupport.scriptHTML(for: htmlBody))
             \(TableSupport.scriptHTML(for: htmlBody))
             \(MermaidSupport.scriptHTML)
+            \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
             </html>
             """
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ Open folders, browse your files, write with syntax highlighting, and preview ins
 
 - **File explorer** — open folders, browse markdown files in a sidebar with bookmarked locations and recents
 - **Document outline** — navigable header outline panel for jumping between sections (⇧⌘O)
-- **Syntax highlighting** — headings, bold, italic, links, code blocks, and more
+- **Syntax highlighting** — headings, bold, italic, links, code blocks, tables, footnotes, highlights, and more
 - **Instant preview** — rendered GitHub Flavored Markdown, including Mermaid diagrams and KaTeX math
+- **Code syntax highlighting** — 27+ languages via Highlight.js with line numbers and diff highlighting
+- **Callouts & admonitions** — `> [!NOTE]`, `> [!WARNING]`, and 15 callout types with foldable support
+- **Extended markdown** — ==highlights==, ^superscript^, ~subscript~, :emoji: shortcodes, and `[TOC]` generation
+- **Interactive preview** — clickable task checkboxes, heading anchor links, image lightbox, footnote popovers
+- **Click-to-source** — double-click any element in preview to jump to its source line in the editor
 - **Frontmatter support** — YAML frontmatter is formatted cleanly in both editor and preview
 - **Editor/Preview toggle** — switch between editor (⌘1) and preview (⌘2) with scroll position preserved
 - **PDF export** — export to PDF or print directly from the app
@@ -79,8 +84,11 @@ ClearlyQuickLook/
 └── Info.plist                      # Extension config (NSExtensionAttributes)
 
 Shared/
-├── MarkdownRenderer.swift          # cmark-gfm wrapper — GFM → HTML
-└── PreviewCSS.swift                # CSS shared by in-app preview and QuickLook
+├── MarkdownRenderer.swift          # cmark-gfm wrapper — GFM → HTML + post-processing pipeline
+├── PreviewCSS.swift                # CSS shared by in-app preview and QuickLook
+├── EmojiShortcodes.swift           # :shortcode: → Unicode emoji lookup table
+├── SyntaxHighlightSupport.swift    # Highlight.js injection for code block syntax coloring
+└── Resources/                      # Bundled JS/CSS (Mermaid, KaTeX, Highlight.js, demo.md)
 
 website/                 # Static marketing site (HTML/CSS), deployed to clearly.md
 scripts/                 # Release pipeline (release.sh)

--- a/Shared/EmojiShortcodes.swift
+++ b/Shared/EmojiShortcodes.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+enum EmojiShortcodes {
+    static let lookup: [String: String] = [
+        // Smileys
+        "smile": "😄", "laughing": "😆", "blush": "😊", "smiley": "😃",
+        "grinning": "😀", "wink": "😉", "heart_eyes": "😍", "kissing_heart": "😘",
+        "stuck_out_tongue_winking_eye": "😜", "sunglasses": "😎", "smirk": "😏",
+        "thinking": "🤔", "joy": "😂", "rofl": "🤣", "relieved": "😌",
+        "unamused": "😒", "sweat_smile": "😅", "sob": "😭", "cry": "😢",
+        "scream": "😱", "angry": "😠", "rage": "😡", "sleeping": "😴",
+        "mask": "😷", "skull": "💀", "alien": "👽", "robot": "🤖",
+        "clown_face": "🤡", "nerd_face": "🤓", "shushing_face": "🤫",
+        "zany_face": "🤪", "pleading_face": "🥺", "yawning_face": "🥱",
+
+        // Gestures
+        "thumbsup": "👍", "+1": "👍", "thumbsdown": "👎", "-1": "👎",
+        "wave": "👋", "clap": "👏", "ok_hand": "👌", "raised_hands": "🙌",
+        "pray": "🙏", "muscle": "💪", "point_up": "☝️", "point_down": "👇",
+        "point_left": "👈", "point_right": "👉", "crossed_fingers": "🤞",
+        "v": "✌️", "vulcan_salute": "🖖", "writing_hand": "✍️",
+
+        // People
+        "man": "👨", "woman": "👩", "boy": "👦", "girl": "👧",
+        "baby": "👶", "person_frowning": "🙍", "person_shrugging": "🤷",
+
+        // Hearts & Emotions
+        "heart": "❤️", "broken_heart": "💔", "sparkling_heart": "💖",
+        "blue_heart": "💙", "green_heart": "💚", "yellow_heart": "💛",
+        "purple_heart": "💜", "black_heart": "🖤", "white_heart": "🤍",
+        "orange_heart": "🧡", "fire": "🔥", "star": "⭐", "star2": "🌟",
+        "sparkles": "✨", "boom": "💥", "zap": "⚡", "100": "💯",
+
+        // Nature
+        "sunny": "☀️", "cloud": "☁️", "umbrella": "☂️", "snowflake": "❄️",
+        "rainbow": "🌈", "earth_americas": "🌎", "earth_africa": "🌍",
+        "earth_asia": "🌏", "crescent_moon": "🌙",
+        "sun_with_face": "🌞", "full_moon_with_face": "🌝",
+
+        // Animals
+        "dog": "🐶", "cat": "🐱", "mouse": "🐭", "bear": "🐻",
+        "panda_face": "🐼", "monkey_face": "🐵", "chicken": "🐔",
+        "penguin": "🐧", "frog": "🐸", "snail": "🐌", "bug": "🐛",
+        "bee": "🐝", "butterfly": "🦋", "unicorn": "🦄", "fox_face": "🦊",
+        "owl": "🦉", "wolf": "🐺", "octopus": "🐙", "whale": "🐳",
+        "dolphin": "🐬", "turtle": "🐢", "snake": "🐍", "bird": "🐦",
+
+        // Food
+        "apple": "🍎", "green_apple": "🍏", "pizza": "🍕", "hamburger": "🍔",
+        "fries": "🍟", "coffee": "☕", "beer": "🍺", "wine_glass": "🍷",
+        "cake": "🍰", "cookie": "🍪", "doughnut": "🍩", "ice_cream": "🍦",
+        "taco": "🌮", "burrito": "🌯", "popcorn": "🍿", "champagne": "🍾",
+        "tropical_drink": "🍹", "tea": "🍵",
+
+        // Activities & Objects
+        "soccer": "⚽", "basketball": "🏀", "football": "🏈",
+        "baseball": "⚾", "tennis": "🎾", "trophy": "🏆", "medal_sports": "🏅",
+        "guitar": "🎸", "microphone": "🎤", "headphones": "🎧",
+        "art": "🎨", "video_game": "🎮", "dart": "🎯", "dice": "🎲",
+        "bowling": "🎳", "tada": "🎉", "confetti_ball": "🎊", "balloon": "🎈",
+        "gift": "🎁", "ribbon": "🎀",
+
+        // Travel & Transport
+        "rocket": "🚀", "airplane": "✈️", "car": "🚗", "bus": "🚌",
+        "bike": "🚲", "ship": "🚢", "helicopter": "🚁",
+
+        // Tech & Office
+        "computer": "💻", "keyboard": "⌨️", "phone": "📱",
+        "email": "📧", "envelope": "✉️", "pencil": "✏️", "pencil2": "✏️",
+        "pen": "🖊️", "memo": "📝", "book": "📖", "books": "📚",
+        "bookmark": "🔖", "link": "🔗", "paperclip": "📎",
+        "scissors": "✂️", "lock": "🔒", "unlock": "🔓",
+        "key": "🔑", "bulb": "💡", "gear": "⚙️", "wrench": "🔧",
+        "hammer": "🔨", "nut_and_bolt": "🔩", "mag": "🔍", "mag_right": "🔎",
+        "microscope": "🔬", "telescope": "🔭", "satellite": "📡",
+        "battery": "🔋", "electric_plug": "🔌", "floppy_disk": "💾",
+        "cd": "💿", "dvd": "📀", "camera": "📷", "tv": "📺",
+        "desktop_computer": "🖥️", "printer": "🖨️", "bell": "🔔",
+        "loudspeaker": "📢", "mega": "📣", "hourglass": "⌛",
+        "alarm_clock": "⏰", "stopwatch": "⏱️", "timer_clock": "⏲️",
+        "calendar": "📅", "date": "📅",
+
+        // Symbols
+        "white_check_mark": "✅", "x": "❌", "heavy_check_mark": "✔️",
+        "heavy_multiplication_x": "✖️", "exclamation": "❗", "question": "❓",
+        "warning": "⚠️", "no_entry": "⛔", "recycle": "♻️",
+        "heavy_plus_sign": "➕", "heavy_minus_sign": "➖",
+        "bangbang": "‼️", "interrobang": "⁉️",
+        "arrow_up": "⬆️", "arrow_down": "⬇️", "arrow_left": "⬅️",
+        "arrow_right": "➡️", "arrow_upper_right": "↗️",
+        "arrows_counterclockwise": "🔄", "back": "🔙",
+        "checkered_flag": "🏁", "triangular_flag_on_post": "🚩",
+        "white_flag": "🏳️", "black_flag": "🏴",
+        "copyright": "©️", "registered": "®️", "tm": "™️",
+        "hash": "#️⃣", "zero": "0️⃣", "one": "1️⃣", "two": "2️⃣",
+        "three": "3️⃣", "four": "4️⃣", "five": "5️⃣",
+        "six": "6️⃣", "seven": "7️⃣", "eight": "8️⃣", "nine": "9️⃣",
+        "ten": "🔟", "abc": "🔤", "abcd": "🔡",
+        "red_circle": "🔴", "orange_circle": "🟠", "yellow_circle": "🟡",
+        "green_circle": "🟢", "blue_circle": "🔵", "purple_circle": "🟣",
+        "white_circle": "⚪", "black_circle": "⚫",
+        "red_square": "🟥", "blue_square": "🟦", "green_square": "🟩",
+
+        // Flags
+        "flag_us": "🇺🇸", "flag_gb": "🇬🇧", "flag_fr": "🇫🇷",
+        "flag_de": "🇩🇪", "flag_jp": "🇯🇵", "flag_cn": "🇨🇳",
+        "flag_kr": "🇰🇷", "flag_br": "🇧🇷", "flag_in": "🇮🇳",
+        "flag_au": "🇦🇺", "flag_ca": "🇨🇦", "flag_es": "🇪🇸",
+        "flag_it": "🇮🇹", "flag_mx": "🇲🇽",
+    ]
+}

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -7,7 +7,8 @@ enum MarkdownRenderer {
 
         let frontmatter = FrontmatterSupport.extract(from: markdown)
 
-        let body = frontmatter?.body ?? markdown
+        let rawBody = frontmatter?.body ?? markdown
+        let (body, codeFilenames) = extractCodeFilenames(rawBody)
         let len = body.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)
         var html: String
@@ -23,7 +24,13 @@ enum MarkdownRenderer {
             return ""
         }
         html = processMath(html)
+        html = processHighlightMarks(html)
+        html = processSuperSub(html)
+        html = processEmoji(html)
+        html = processCallouts(html)
+        html = processTOC(html)
         html = processCaptions(html)
+        html = injectCodeFilenames(html, filenames: codeFilenames)
 
         // Fix sourcepos line numbers after stripping frontmatter
         if let frontmatter, frontmatter.lineCount > 0 {
@@ -178,6 +185,337 @@ enum MarkdownRenderer {
             range: NSRange(location: 0, length: nsHTML.length),
             withTemplate: "$2<caption>$1</caption>"
         )
+    }
+
+    // MARK: - Code Filename Headers
+
+    /// Pre-processing: extract `title="filename"` from fenced code info strings before cmark processes them.
+    /// Returns the cleaned markdown and a mapping of source line numbers to filenames.
+    private static func extractCodeFilenames(_ markdown: String) -> (String, [Int: String]) {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"^(`{3,})(\w+)\s+title="([^"]+)"\s*$"#,
+            options: .anchorsMatchLines
+        ) else { return (markdown, [:]) }
+
+        var filenames: [Int: String] = [:]
+        let ns = markdown as NSString
+        var cleaned = ""
+        var lastEnd = 0
+        let lines = markdown.components(separatedBy: "\n")
+        var lineStart = 0
+
+        for (lineIdx, line) in lines.enumerated() {
+            let lineRange = NSRange(location: lineStart, length: (line as NSString).length)
+            if let match = regex.firstMatch(in: markdown, range: lineRange) {
+                let fence = ns.substring(with: match.range(at: 1))
+                let lang = ns.substring(with: match.range(at: 2))
+                let filename = ns.substring(with: match.range(at: 3))
+                filenames[lineIdx + 1] = filename // 1-indexed
+                // Replace with just fence + lang (strip title)
+                cleaned += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+                cleaned += "\(fence)\(lang)"
+                lastEnd = match.range.location + match.range.length
+            }
+            lineStart += (line as NSString).length + 1 // +1 for \n
+        }
+        cleaned += ns.substring(from: lastEnd)
+        return (cleaned, filenames)
+    }
+
+    /// Post-processing: inject `<div class="code-filename">` before `<pre>` blocks that had title= attributes.
+    private static func injectCodeFilenames(_ html: String, filenames: [Int: String]) -> String {
+        guard !filenames.isEmpty else { return html }
+        guard let regex = try? NSRegularExpression(pattern: #"<pre data-sourcepos="(\d+):\d+-\d+:\d+""#) else { return html }
+        let ns = html as NSString
+        var result = ""
+        var lastEnd = 0
+        for match in regex.matches(in: html, range: NSRange(location: 0, length: ns.length)) {
+            let lineStr = ns.substring(with: match.range(at: 1))
+            guard let line = Int(lineStr), let filename = filenames[line] else {
+                continue
+            }
+            let prefix = ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            result += prefix
+            result += "<div class=\"code-filename\">\(escapeHTML(filename))</div>"
+            lastEnd = match.range.location
+        }
+        result += ns.substring(from: lastEnd)
+        return result
+    }
+
+    // MARK: - Highlight/Mark ==text==
+
+    private static func processHighlightMarks(_ html: String) -> String {
+        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        guard let regex = try? NSRegularExpression(pattern: #"==([^=\n]+?)=="#) else {
+            return restoreProtectedSegments(in: protectedHTML, segments: segments)
+        }
+        let ns = protectedHTML as NSString
+        let result = regex.stringByReplacingMatches(
+            in: protectedHTML,
+            range: NSRange(location: 0, length: ns.length),
+            withTemplate: "<mark>$1</mark>"
+        )
+        return restoreProtectedSegments(in: result, segments: segments)
+    }
+
+    // MARK: - Superscript/Subscript
+
+    private static func processSuperSub(_ html: String) -> String {
+        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        var result = protectedHTML
+        // Superscript: ^text^ (not ^^)
+        if let supRegex = try? NSRegularExpression(pattern: #"(?<!\^)\^(?!\^)([^\^\s\n]+?)(?<!\^)\^(?!\^)"#) {
+            let ns = result as NSString
+            result = supRegex.stringByReplacingMatches(
+                in: result,
+                range: NSRange(location: 0, length: ns.length),
+                withTemplate: "<sup>$1</sup>"
+            )
+        }
+        // Subscript: ~text~ (not ~~)
+        if let subRegex = try? NSRegularExpression(pattern: #"(?<!~)~(?!~)([^~\s\n]+?)(?<!~)~(?!~)"#) {
+            let ns = result as NSString
+            result = subRegex.stringByReplacingMatches(
+                in: result,
+                range: NSRange(location: 0, length: ns.length),
+                withTemplate: "<sub>$1</sub>"
+            )
+        }
+        return restoreProtectedSegments(in: result, segments: segments)
+    }
+
+    // MARK: - Emoji Shortcodes
+
+    private static func processEmoji(_ html: String) -> String {
+        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        guard let tagRegex = try? NSRegularExpression(pattern: #"<[^>]+>"#),
+              let emojiRegex = try? NSRegularExpression(pattern: #":([a-z0-9_+-]+):"#) else {
+            return restoreProtectedSegments(in: protectedHTML, segments: segments)
+        }
+
+        var result = ""
+        var lastLocation = 0
+        let fullRange = NSRange(protectedHTML.startIndex..., in: protectedHTML)
+
+        for match in tagRegex.matches(in: protectedHTML, range: fullRange) {
+            let textRange = NSRange(location: lastLocation, length: match.range.location - lastLocation)
+            if let range = Range(textRange, in: protectedHTML) {
+                result += replacingEmojiShortcodes(in: String(protectedHTML[range]), regex: emojiRegex)
+            }
+            if let range = Range(match.range, in: protectedHTML) {
+                result += protectedHTML[range]
+            }
+            lastLocation = match.range.location + match.range.length
+        }
+
+        if lastLocation < fullRange.length {
+            let tailRange = NSRange(location: lastLocation, length: fullRange.length - lastLocation)
+            if let range = Range(tailRange, in: protectedHTML) {
+                result += replacingEmojiShortcodes(in: String(protectedHTML[range]), regex: emojiRegex)
+            }
+        }
+
+        return restoreProtectedSegments(in: result, segments: segments)
+    }
+
+    private static func replacingEmojiShortcodes(in text: String, regex: NSRegularExpression) -> String {
+        let ns = text as NSString
+        var result = ""
+        var lastEnd = 0
+
+        for match in regex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            let shortcode = ns.substring(with: match.range(at: 1))
+            result += EmojiShortcodes.lookup[shortcode] ?? ns.substring(with: match.range)
+            lastEnd = match.range.location + match.range.length
+        }
+
+        result += ns.substring(from: lastEnd)
+        return result
+    }
+
+    // MARK: - Callouts/Admonitions
+
+    private static let calloutTypes: [String: (icon: String, label: String)] = [
+        "note": ("\u{2139}\u{FE0F}", "Note"),
+        "tip": ("\u{2600}\u{FE0F}", "Tip"),
+        "important": ("\u{2757}", "Important"),
+        "warning": ("\u{26A0}\u{FE0F}", "Warning"),
+        "caution": ("\u{26D4}", "Caution"),
+        "abstract": ("\u{1F4CB}", "Abstract"),
+        "todo": ("\u{2611}\u{FE0F}", "Todo"),
+        "example": ("\u{1F4DD}", "Example"),
+        "quote": ("\u{275D}", "Quote"),
+        "bug": ("\u{1F41B}", "Bug"),
+        "danger": ("\u{26A1}", "Danger"),
+        "failure": ("\u{2717}", "Failure"),
+        "success": ("\u{2713}", "Success"),
+        "question": ("\u{003F}", "Question"),
+        "info": ("\u{2139}\u{FE0F}", "Info"),
+    ]
+
+    private static func processCallouts(_ html: String) -> String {
+        guard html.contains("[!") else { return html }
+        // Match blockquote containing [!TYPE] at the start.
+        // Group 5 captures title on the same line as [!TYPE].
+        // Group 6 captures remaining content inside the first <p> (may span newlines).
+        // Group 7 captures content after the first </p>.
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<blockquote([^>]*)>\s*<p([^>]*)>\[!([\w]+)\](-?)[ \t]*([^\n]*)\n?([\s\S]*?)</p>([\s\S]*?)</blockquote>"#,
+            options: []
+        ) else { return html }
+        let ns = html as NSString
+        var result = ""
+        var lastEnd = 0
+        for match in regex.matches(in: html, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            let bqAttrs = ns.substring(with: match.range(at: 1))
+            let typeStr = ns.substring(with: match.range(at: 3)).lowercased()
+            let foldable = ns.substring(with: match.range(at: 4)) == "-"
+            let titleText = ns.substring(with: match.range(at: 5)).trimmingCharacters(in: .whitespaces)
+            let firstParaContent = ns.substring(with: match.range(at: 6)).trimmingCharacters(in: .whitespacesAndNewlines)
+            let restContent = ns.substring(with: match.range(at: 7))
+
+            let info = calloutTypes[typeStr] ?? ("\u{2139}\u{FE0F}", typeStr.capitalized)
+            let displayTitle = titleText.isEmpty ? info.label : titleText
+
+            // Build content from remaining first-paragraph text + rest of blockquote
+            var contentHTML = ""
+            if !firstParaContent.isEmpty {
+                contentHTML += "<p>\(firstParaContent)</p>"
+            }
+            contentHTML += restContent
+
+            if foldable {
+                result += """
+                <details class="callout callout-\(typeStr)"\(bqAttrs)>\
+                <summary class="callout-title"><span class="callout-icon">\(info.icon)</span> \
+                <span class="callout-title-text">\(displayTitle)</span></summary>\
+                <div class="callout-content">\(contentHTML)</div></details>
+                """
+            } else {
+                result += """
+                <div class="callout callout-\(typeStr)"\(bqAttrs)>\
+                <div class="callout-title"><span class="callout-icon">\(info.icon)</span> \
+                <span class="callout-title-text">\(displayTitle)</span></div>\
+                <div class="callout-content">\(contentHTML)</div></div>
+                """
+            }
+            lastEnd = match.range.location + match.range.length
+        }
+        result += ns.substring(from: lastEnd)
+        return result
+    }
+
+    // MARK: - Table of Contents
+
+    private static func processTOC(_ html: String) -> String {
+        guard html.contains("[TOC]") else { return html }
+        // Parse headings from the HTML
+        guard let headingRegex = try? NSRegularExpression(pattern: #"<(h[1-6])([^>]*)>(.*?)</\1>"#, options: .dotMatchesLineSeparators) else { return html }
+        let ns = html as NSString
+        var headings: [(level: Int, text: String, id: String)] = []
+        var usedIDs: [String: Int] = [:]
+        for match in headingRegex.matches(in: html, range: NSRange(location: 0, length: ns.length)) {
+            let tag = ns.substring(with: match.range(at: 1))
+            let level = Int(String(tag.last!)) ?? 1
+            let attrs = ns.substring(with: match.range(at: 2))
+            let rawText = ns.substring(with: match.range(at: 3))
+            // Strip HTML tags from heading text
+            let text = rawText.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            let baseID = headingID(from: text, existingAttributes: attrs)
+            let id = uniqueHeadingID(baseID, usedIDs: &usedIDs)
+            headings.append((level: level, text: text, id: id))
+        }
+        guard !headings.isEmpty else { return html }
+
+        // Add or update id attributes on headings in the HTML so TOC links always resolve.
+        var withIDs = html
+        var offset = 0
+        for (index, match) in headingRegex.matches(in: html, range: NSRange(location: 0, length: ns.length)).enumerated() {
+            guard index < headings.count else { break }
+            let tag = ns.substring(with: match.range(at: 1))
+            let attrs = ns.substring(with: match.range(at: 2))
+            let replacement = "<\(tag)\(updatingHeadingAttributes(attrs, id: headings[index].id))>"
+            let matchText = ns.substring(with: match.range)
+            guard let openTagEnd = matchText.firstIndex(of: ">") else { continue }
+            let openTagLength = matchText.distance(from: matchText.startIndex, to: matchText.index(after: openTagEnd))
+            let replacementRange = NSRange(location: match.range.location + offset, length: openTagLength)
+            withIDs = (withIDs as NSString).replacingCharacters(in: replacementRange, with: replacement)
+            offset += (replacement as NSString).length - openTagLength
+        }
+
+        // Build TOC HTML
+        let minLevel = headings.map(\.level).min() ?? 1
+        var tocHTML = "<nav class=\"toc\"><ul>"
+        var prevLevel = minLevel
+        for heading in headings {
+            let level = heading.level
+            if level > prevLevel {
+                for _ in 0..<(level - prevLevel) { tocHTML += "<ul>" }
+            } else if level < prevLevel {
+                for _ in 0..<(prevLevel - level) { tocHTML += "</ul></li>" }
+            } else if heading.id != headings.first?.id {
+                tocHTML += "</li>"
+            }
+            tocHTML += "<li><a href=\"#\(heading.id)\">\(heading.text)</a>"
+            prevLevel = level
+        }
+        for _ in 0..<(prevLevel - minLevel) { tocHTML += "</li></ul>" }
+        tocHTML += "</li></ul></nav>"
+
+        // Replace [TOC] paragraph
+        if let tocRegex = try? NSRegularExpression(pattern: #"<p[^>]*>\[TOC\]</p>"#, options: .caseInsensitive) {
+            let nsResult = withIDs as NSString
+            withIDs = tocRegex.stringByReplacingMatches(
+                in: withIDs,
+                range: NSRange(location: 0, length: nsResult.length),
+                withTemplate: tocHTML
+            )
+        }
+        return withIDs
+    }
+
+    private static func headingID(from text: String, existingAttributes attrs: String) -> String {
+        if let existingID = existingHeadingID(in: attrs), !existingID.isEmpty {
+            return existingID
+        }
+
+        let slug = text.lowercased()
+            .replacingOccurrences(of: "[^\\w\\s-]", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        return slug.isEmpty ? "section" : slug
+    }
+
+    private static func uniqueHeadingID(_ baseID: String, usedIDs: inout [String: Int]) -> String {
+        let count = usedIDs[baseID, default: 0]
+        usedIDs[baseID] = count + 1
+        return count == 0 ? baseID : "\(baseID)-\(count)"
+    }
+
+    private static func existingHeadingID(in attrs: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: #"id=(["'])(.*?)\1"#) else { return nil }
+        let ns = attrs as NSString
+        guard let match = regex.firstMatch(in: attrs, range: NSRange(location: 0, length: ns.length)),
+              match.numberOfRanges >= 3 else { return nil }
+        return ns.substring(with: match.range(at: 2))
+    }
+
+    private static func updatingHeadingAttributes(_ attrs: String, id: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: #"(\s*)id=(["']).*?\2"#) else {
+            return attrs + " id=\"\(id)\""
+        }
+
+        let ns = attrs as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        guard regex.firstMatch(in: attrs, range: range) != nil else {
+            return attrs + " id=\"\(id)\""
+        }
+
+        return regex.stringByReplacingMatches(in: attrs, range: range, withTemplate: " id=\"\(id)\"")
     }
 
     private static func escapeHTML(_ text: String) -> String {

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -11,57 +11,68 @@ enum PreviewCSS {
     tr:hover td { background-color: transparent !important; }
     th { cursor: default !important; }
     body {
-        color: #222222 !important;
+        color: #1D1D1F !important;
         background: white !important;
         max-width: none !important;
         margin: 0 !important;
         padding: 0 !important;
     }
-    a { color: #3366AA !important; }
+    a { color: #0071E3 !important; }
     code {
-        background-color: #F0F0F0 !important;
-        color: #CC3333 !important;
+        background-color: #F5F5F7 !important;
+        color: #1D1D1F !important;
     }
     pre {
-        background-color: #F5F5F5 !important;
-        border-color: #E0E0E0 !important;
-        color: #222222 !important;
+        background-color: #F5F5F7 !important;
+        color: #1D1D1F !important;
     }
     pre code {
         background: none !important;
-        color: #222222 !important;
+        color: #1D1D1F !important;
     }
     blockquote {
-        border-left-color: #CCCCCC !important;
-        color: #666666 !important;
+        border: none !important;
+        color: #48484A !important;
     }
     table th {
-        background-color: #F5F5F5 !important;
-        border-color: #DDDDDD !important;
+        background-color: transparent !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
     }
     table td {
-        border-color: #EEEEEE !important;
+        border-color: rgba(0, 0, 0, 0.06) !important;
     }
     table tr:nth-child(even) {
-        background-color: #FAFAFA !important;
+        background-color: transparent !important;
     }
     hr {
-        border-color: #DDDDDD !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
     }
     .img-placeholder {
-        background-color: #F0F0F0 !important;
-        border-color: #CCCCCC !important;
-        color: #999999 !important;
+        background-color: #F5F5F7 !important;
+        border-color: rgba(0, 0, 0, 0.12) !important;
+        color: #AEAEB2 !important;
     }
     .frontmatter {
-        background-color: #F0F0F0 !important;
+        background-color: #F5F5F7 !important;
     }
     .frontmatter dt {
-        color: #555555 !important;
+        color: #86868B !important;
     }
     .frontmatter dd {
-        color: #333333 !important;
+        color: #1D1D1F !important;
     }
+    mark {
+        background-color: rgba(255, 212, 0, 0.4) !important;
+    }
+    .callout {
+        border: none !important;
+        background-color: rgba(0, 0, 0, 0.03) !important;
+    }
+    details.callout > summary::before { content: "" !important; }
+    .toc { background-color: #F5F5F7 !important; }
+    .heading-anchor { display: none !important; }
+    .lightbox-overlay { display: none !important; }
+    .footnote-popover { display: none !important; }
     .page-break {
         height: 0 !important;
         border: none !important;
@@ -94,106 +105,24 @@ enum PreviewCSS {
     }
 
     body {
-        font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", sans-serif;
         font-size: \(Int(fontSize))px;
-        line-height: 1.6;
+        line-height: 1.75;
         max-width: 61em;
         margin: 0 auto;
-        padding: 10px 60px 40px;
-        color: #222222;
-        background-color: #FAFAFA;
+        padding: 16px 64px 48px;
+        color: #1D1D1F;
+        background-color: #FFFFFF;
         -webkit-font-smoothing: antialiased;
-    }
-
-    @media (prefers-color-scheme: dark) {
-        body {
-            color: #E0E0E0;
-            background-color: #1A1A1A;
-        }
-        a { color: #6699CC; }
-        code {
-            background-color: #2A2A2A !important;
-            color: #E07070 !important;
-        }
-        pre {
-            background-color: #2A2A2A !important;
-            border-color: #333333 !important;
-            color: #E0E0E0 !important;
-        }
-        pre code {
-            background: none !important;
-            color: #E0E0E0 !important;
-        }
-        .code-copy-btn {
-            background: rgba(255, 255, 255, 0.06);
-            color: #999999;
-        }
-        .code-copy-btn:hover {
-            background: rgba(255, 255, 255, 0.1);
-        }
-        .code-copy-btn:active {
-            background: rgba(255, 255, 255, 0.14);
-        }
-        .code-copy-btn.copied {
-            color: #3fb950;
-        }
-        blockquote {
-            border-left-color: #444444;
-            color: #999999;
-        }
-        table th {
-            background-color: #2A2A2A;
-            border-color: #444444;
-        }
-        table th:hover {
-            background-color: #333333;
-        }
-        table td {
-            border-color: #333333;
-        }
-        table tr:nth-child(even) {
-            background-color: #222222;
-        }
-        tr:hover td {
-            background-color: rgba(255, 255, 255, 0.03);
-        }
-        caption {
-            color: #999999;
-        }
-        .table-copy-btn {
-            background: rgba(255, 255, 255, 0.06);
-            color: #999999;
-        }
-        .table-copy-btn:hover {
-            background: rgba(255, 255, 255, 0.1);
-        }
-        .table-copy-btn:active {
-            background: rgba(255, 255, 255, 0.14);
-        }
-        .table-copy-btn.copied {
-            color: #3fb950;
-        }
-        hr {
-            border-color: #333333;
-        }
-        .frontmatter {
-            background-color: #222222 !important;
-            border: 1px solid #333333 !important;
-        }
-        .frontmatter dt {
-            color: #777777 !important;
-        }
-        .frontmatter dd {
-            color: #999999 !important;
-        }
+        -webkit-text-size-adjust: 100%;
     }
 
     h1, h2, h3, h4, h5, h6 {
-        font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-        font-weight: 700;
-        line-height: 1.3;
-        margin-top: 1.5em;
-        margin-bottom: 0.5em;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+        line-height: 1.25;
+        margin-top: 2em;
+        margin-bottom: 0.75em;
+        letter-spacing: -0.015em;
     }
 
     body > *:first-child {
@@ -203,9 +132,9 @@ enum PreviewCSS {
     /* Frontmatter metadata */
     .frontmatter {
         margin-bottom: 1.5em;
-        padding: 0.75em 1em;
-        background-color: #F0F0F0;
-        border-radius: 6px;
+        padding: 1em 1.25em;
+        background-color: rgba(0, 0, 0, 0.03);
+        border-radius: 10px;
         font-size: 0.85em;
     }
 
@@ -227,7 +156,7 @@ enum PreviewCSS {
 
     .frontmatter dt {
         font-weight: 600;
-        color: #555555;
+        color: #86868B;
         min-width: 6em;
     }
 
@@ -237,7 +166,7 @@ enum PreviewCSS {
 
     .frontmatter dd {
         margin: 0;
-        color: #333333;
+        color: #1D1D1F;
         white-space: pre-wrap;
     }
 
@@ -251,17 +180,19 @@ enum PreviewCSS {
         font-size: 0.95em;
     }
 
-    h1 { font-size: 2em; }
-    h2 { font-size: 1.5em; }
-    h3 { font-size: 1.25em; }
-    h4 { font-size: 1.1em; }
+    h1 { font-size: 2.25em; font-weight: 700; letter-spacing: -0.025em; }
+    h2 { font-size: 1.625em; font-weight: 650; }
+    h3 { font-size: 1.3125em; font-weight: 600; }
+    h4 { font-size: 1.125em; font-weight: 600; }
+    h5 { font-size: 1em; font-weight: 600; }
+    h6 { font-size: 0.9375em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: rgba(29, 29, 31, 0.55); }
 
     p {
-        margin-bottom: 1em;
+        margin-bottom: 1.125em;
     }
 
     a {
-        color: #3366AA;
+        color: #0071E3;
         text-decoration: none;
     }
     a:hover {
@@ -270,20 +201,20 @@ enum PreviewCSS {
 
     code {
         font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
-        font-size: 0.85em;
-        background-color: #F0F0F0;
-        color: #CC3333;
-        padding: 0.15em 0.35em;
-        border-radius: 3px;
+        font-size: 0.875em;
+        background-color: rgba(0, 0, 0, 0.04);
+        color: #1D1D1F;
+        padding: 0.125em 0.375em;
+        border-radius: 5px;
     }
 
     pre {
         position: relative;
-        background-color: #F5F5F5;
-        border: 1px solid #E0E0E0;
-        border-radius: 4px;
-        padding: 1em;
-        margin-bottom: 1em;
+        background-color: #F5F5F7;
+        border: none;
+        border-radius: 10px;
+        padding: 1.125em 1.25em;
+        margin-bottom: 1.25em;
         overflow-x: auto;
     }
 
@@ -296,9 +227,9 @@ enum PreviewCSS {
         padding: 0;
         margin: 0;
         border: none;
-        border-radius: 4px;
-        background: rgba(0, 0, 0, 0.04);
-        color: #666666;
+        border-radius: 6px;
+        background: rgba(0, 0, 0, 0.05);
+        color: #86868B;
         cursor: pointer;
         opacity: 0;
         transition: opacity 0.15s ease;
@@ -312,7 +243,7 @@ enum PreviewCSS {
     }
 
     .code-copy-btn.copied {
-        color: #2ea043;
+        color: #34C759;
     }
 
     pre:hover .code-copy-btn {
@@ -335,25 +266,29 @@ enum PreviewCSS {
         background: none;
         color: inherit;
         padding: 0;
-        font-size: 0.85em;
+        font-size: 0.875em;
     }
 
     blockquote {
-        border-left: 3px solid #CCCCCC;
-        padding-left: 1em;
+        border: none;
+        background-color: rgba(0, 0, 0, 0.03);
+        border-radius: 8px;
+        padding: 0.75em 1.25em;
         margin-left: 0;
-        margin-bottom: 1em;
-        color: #666666;
-        font-style: italic;
+        margin-bottom: 1.25em;
+        color: #48484A;
+    }
+    blockquote > *:last-child {
+        margin-bottom: 0;
     }
 
     ul, ol {
         margin-bottom: 1em;
-        padding-left: 1.5em;
+        padding-left: 1.625em;
     }
 
     li {
-        margin-bottom: 0.25em;
+        margin-bottom: 0.3em;
     }
 
     /* Task lists */
@@ -401,7 +336,7 @@ enum PreviewCSS {
     }
 
     th, td {
-        padding: 0.5em 0.75em;
+        padding: 0.625em 0.875em;
         max-width: 20em;
         overflow-wrap: break-word;
     }
@@ -414,27 +349,27 @@ enum PreviewCSS {
 
     th {
         font-weight: 600;
-        background-color: #F5F5F5;
-        border-bottom: 2px solid #DDDDDD;
+        background-color: transparent;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
         cursor: pointer;
         user-select: none;
         white-space: nowrap;
     }
 
     th:hover {
-        background-color: #EEEEEE;
+        background-color: rgba(0, 0, 0, 0.03);
     }
 
     td {
-        border-bottom: 1px solid #EEEEEE;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
     }
 
     tr:nth-child(even) {
-        background-color: #FAFAFA;
+        background-color: transparent;
     }
 
     tr:hover td {
-        background-color: rgba(0, 0, 0, 0.03);
+        background-color: rgba(0, 0, 0, 0.02);
     }
 
     .sort-indicator {
@@ -453,7 +388,7 @@ enum PreviewCSS {
         text-align: left;
         font-size: 0.9em;
         font-weight: 500;
-        color: #666666;
+        color: #86868B;
         padding-bottom: 0.5em;
     }
 
@@ -465,9 +400,9 @@ enum PreviewCSS {
         padding: 0;
         margin: 0;
         border: none;
-        border-radius: 4px;
-        background: rgba(0, 0, 0, 0.04);
-        color: #666666;
+        border-radius: 6px;
+        background: rgba(0, 0, 0, 0.05);
+        color: #86868B;
         cursor: pointer;
         opacity: 0;
         pointer-events: none;
@@ -484,7 +419,7 @@ enum PreviewCSS {
     }
 
     .table-copy-btn.copied {
-        color: #2ea043;
+        color: #34C759;
     }
 
     .table-shell:hover .table-copy-btn,
@@ -511,22 +446,155 @@ enum PreviewCSS {
 
     hr {
         border: none;
-        border-top: 1px solid #DDDDDD;
-        margin: 2em 0;
+        border-top: 0.5px solid rgba(0, 0, 0, 0.1);
+        margin: 2.5em 0;
     }
 
     .page-break {
         display: block;
         height: 0;
-        border-top: 2px dashed #CCCCCC;
+        border-top: 1px dashed rgba(0, 0, 0, 0.12);
         margin: 2em 0;
     }
 
-    @media (prefers-color-scheme: dark) {
-        .page-break {
-            border-top-color: #444444;
-        }
+    /* Highlight/Mark */
+    mark {
+        background-color: rgba(255, 212, 0, 0.3);
+        color: inherit !important;
+        padding: 0.1em 0.2em;
+        border-radius: 3px;
     }
+    /* Superscript/Subscript */
+    sup, sub {
+        font-size: 0.75em;
+        line-height: 0;
+    }
+
+    /* Callouts/Admonitions */
+    .callout {
+        border: none;
+        border-radius: 10px;
+        padding: 1em 1.25em;
+        margin-bottom: 1.25em;
+        background-color: rgba(0, 122, 255, 0.1);
+    }
+    .callout-title {
+        font-weight: 600;
+        margin-bottom: 0.375em;
+        display: flex;
+        align-items: center;
+        gap: 0.4em;
+    }
+    .callout-icon { flex-shrink: 0; }
+    .callout-content > *:last-child { margin-bottom: 0; }
+    .callout-content blockquote { border-left: none; padding-left: 0; color: inherit; }
+
+    details.callout > summary { cursor: pointer; list-style: none; }
+    details.callout > summary::-webkit-details-marker { display: none; }
+    details.callout > summary::before { content: "▶"; font-size: 0.7em; margin-right: 0.3em; transition: transform 0.2s; display: inline-block; }
+    details.callout[open] > summary::before { transform: rotate(90deg); }
+
+    .callout-note, .callout-info { background-color: rgba(0, 122, 255, 0.1); }
+    .callout-tip { background-color: rgba(52, 199, 89, 0.1); }
+    .callout-important { background-color: rgba(175, 82, 222, 0.1); }
+    .callout-warning { background-color: rgba(255, 149, 0, 0.1); }
+    .callout-caution, .callout-danger { background-color: rgba(255, 59, 48, 0.1); }
+    .callout-abstract { background-color: rgba(90, 200, 250, 0.1); }
+    .callout-todo { background-color: rgba(0, 122, 255, 0.1); }
+    .callout-example { background-color: rgba(88, 86, 214, 0.1); }
+    .callout-quote { background-color: rgba(142, 142, 147, 0.1); }
+    .callout-bug, .callout-failure { background-color: rgba(255, 59, 48, 0.1); }
+    .callout-success { background-color: rgba(52, 199, 89, 0.1); }
+    .callout-question { background-color: rgba(255, 204, 0, 0.1); }
+
+    /* Table of Contents */
+    .toc {
+        background-color: rgba(0, 0, 0, 0.025);
+        border: none;
+        border-radius: 10px;
+        padding: 1.25em 1.5em;
+        margin-bottom: 1.5em;
+    }
+    .toc::before {
+        content: "Table of Contents";
+        display: block;
+        font-weight: 600;
+        font-size: 0.9em;
+        margin-bottom: 0.5em;
+        color: #86868B;
+    }
+    .toc ul {
+        margin-bottom: 0;
+        padding-left: 1.2em;
+        list-style: none;
+    }
+    .toc > ul { padding-left: 0; }
+    .toc li { margin-bottom: 0.15em; }
+    .toc a { font-size: 0.9em; }
+
+    /* Heading anchor links */
+    .heading-anchor {
+        opacity: 0;
+        margin-left: -1.2em;
+        padding-right: 0.3em;
+        text-decoration: none;
+        color: #AEAEB2;
+        font-weight: 400;
+        transition: opacity 0.15s ease;
+    }
+    h1:hover .heading-anchor, h2:hover .heading-anchor, h3:hover .heading-anchor,
+    h4:hover .heading-anchor, h5:hover .heading-anchor, h6:hover .heading-anchor {
+        opacity: 0.4;
+    }
+    .heading-anchor:hover { opacity: 1 !important; }
+
+    /* Collapsible details animation */
+    details::details-content {
+        transition: block-size 0.3s ease, opacity 0.3s ease, content-visibility 0.3s ease allow-discrete;
+        block-size: 0;
+        opacity: 0;
+        overflow: clip;
+    }
+    details[open]::details-content {
+        block-size: auto;
+        opacity: 1;
+    }
+
+    /* Image lightbox */
+    .lightbox-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.75);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+        cursor: zoom-out;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+    }
+    .lightbox-img {
+        max-width: 90vw;
+        max-height: 90vh;
+        object-fit: contain;
+        border-radius: 8px;
+    }
+
+    /* Footnote popovers */
+    .footnote-popover {
+        position: absolute;
+        max-width: 400px;
+        padding: 14px 18px;
+        background: #FFFFFF;
+        border: none;
+        border-radius: 10px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 0 0 0.5px rgba(0, 0, 0, 0.06);
+        font-size: 0.9em;
+        z-index: 100;
+        line-height: 1.5;
+    }
+    .footnote-popover p { margin-bottom: 0.5em; }
+    .footnote-popover p:last-child { margin-bottom: 0; }
 
     .math-block {
         text-align: center;
@@ -549,10 +617,10 @@ enum PreviewCSS {
         justify-content: center;
         gap: 8px;
         padding: 24px 16px;
-        border-radius: 6px;
-        background-color: #F0F0F0;
-        border: 1px dashed #CCCCCC;
-        color: #999999;
+        border-radius: 10px;
+        background-color: rgba(0, 0, 0, 0.03);
+        border: 1px dashed rgba(0, 0, 0, 0.12);
+        color: #AEAEB2;
         font-size: 0.85em;
         margin-bottom: 1em;
         overflow: hidden;
@@ -581,17 +649,127 @@ enum PreviewCSS {
         height: auto;
     }
 
+    /* ========== Dark Mode ========== */
     @media (prefers-color-scheme: dark) {
-        .mermaid {
-            color: #E0E0E0;
+        body {
+            color: #F5F5F7;
+            background-color: #1C1C1E;
         }
-    }
-
-    @media (prefers-color-scheme: dark) {
+        a { color: #0A84FF; }
+        h6 { color: rgba(245, 245, 247, 0.55); }
+        code {
+            background-color: rgba(255, 255, 255, 0.06);
+            color: #F5F5F7;
+        }
+        pre {
+            background-color: rgba(255, 255, 255, 0.05);
+            color: #F5F5F7;
+        }
+        pre code {
+            background: none;
+            color: #F5F5F7;
+        }
+        .code-copy-btn {
+            background: rgba(255, 255, 255, 0.07);
+            color: #AEAEB2;
+        }
+        .code-copy-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+        .code-copy-btn:active {
+            background: rgba(255, 255, 255, 0.14);
+        }
+        .code-copy-btn.copied {
+            color: #30D158;
+        }
+        blockquote {
+            color: #E5E5EA;
+            background-color: rgba(255, 255, 255, 0.04);
+        }
+        table th {
+            background-color: transparent;
+            border-color: rgba(255, 255, 255, 0.15);
+        }
+        table th:hover {
+            background-color: rgba(255, 255, 255, 0.05);
+        }
+        table td {
+            border-color: rgba(255, 255, 255, 0.08);
+        }
+        table tr:nth-child(even) {
+            background-color: transparent;
+        }
+        tr:hover td {
+            background-color: rgba(255, 255, 255, 0.03);
+        }
+        caption {
+            color: #AEAEB2;
+        }
+        .table-copy-btn {
+            background: rgba(255, 255, 255, 0.07);
+            color: #AEAEB2;
+        }
+        .table-copy-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+        .table-copy-btn:active {
+            background: rgba(255, 255, 255, 0.14);
+        }
+        .table-copy-btn.copied {
+            color: #30D158;
+        }
+        hr {
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+        .page-break {
+            border-top-color: rgba(255, 255, 255, 0.12);
+        }
+        mark {
+            background-color: rgba(255, 214, 0, 0.25);
+        }
+        .callout {
+            background-color: rgba(10, 132, 255, 0.14);
+        }
+        .callout-tip { background-color: rgba(48, 209, 88, 0.14); }
+        .callout-important { background-color: rgba(191, 90, 242, 0.14); }
+        .callout-warning { background-color: rgba(255, 159, 10, 0.14); }
+        .callout-caution, .callout-danger { background-color: rgba(255, 69, 58, 0.14); }
+        .callout-abstract { background-color: rgba(100, 210, 255, 0.14); }
+        .callout-example { background-color: rgba(94, 92, 230, 0.14); }
+        .callout-quote { background-color: rgba(152, 152, 157, 0.14); }
+        .callout-bug, .callout-failure { background-color: rgba(255, 69, 58, 0.14); }
+        .callout-success { background-color: rgba(48, 209, 88, 0.14); }
+        .callout-question { background-color: rgba(255, 214, 10, 0.14); }
+        .toc {
+            background-color: rgba(255, 255, 255, 0.035);
+        }
+        .toc::before { color: #AEAEB2; }
+        .heading-anchor { color: rgba(255, 255, 255, 0.2); }
+        .frontmatter {
+            background-color: rgba(255, 255, 255, 0.04);
+        }
+        .frontmatter dt {
+            color: #AEAEB2;
+        }
+        .frontmatter dd {
+            color: #F5F5F7;
+        }
+        .footnote-popover {
+            background: #2C2C2E;
+            color: #F5F5F7;
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35), 0 0 0 0.5px rgba(255, 255, 255, 0.08);
+        }
+        .footnote-popover code {
+            background-color: rgba(255, 255, 255, 0.08);
+            color: #F5F5F7;
+        }
+        .mermaid {
+            color: #F5F5F7;
+        }
         .img-placeholder {
-            background-color: #2A2A2A;
-            border-color: #444444;
-            color: #777777;
+            background-color: rgba(255, 255, 255, 0.04);
+            border-color: rgba(255, 255, 255, 0.12);
+            color: #8E8E93;
         }
     }
 
@@ -604,57 +782,71 @@ enum PreviewCSS {
         tr:hover td { background-color: transparent !important; }
         th { cursor: default !important; }
         body {
-            color: #222222 !important;
+            color: #1D1D1F !important;
             background-color: #FFFFFF !important;
             max-width: none;
             padding: 0;
             margin: 0;
         }
-        a { color: #3366AA !important; }
+        a { color: #0071E3 !important; }
         code {
-            background-color: #F0F0F0 !important;
-            color: #CC3333 !important;
+            background-color: #F5F5F7 !important;
+            color: #1D1D1F !important;
         }
         pre {
-            background-color: #F5F5F5 !important;
-            border-color: #E0E0E0 !important;
-            color: #222222 !important;
+            background-color: #F5F5F7 !important;
+            color: #1D1D1F !important;
         }
         pre code {
             background: none !important;
-            color: #222222 !important;
+            color: #1D1D1F !important;
         }
         blockquote {
-            border-left-color: #CCCCCC !important;
-            color: #666666 !important;
+            border-left-color: rgba(0, 0, 0, 0.15) !important;
+            color: #48484A !important;
         }
         th {
-            background-color: #F5F5F5 !important;
-            border-color: #DDDDDD !important;
+            background-color: transparent !important;
+            border-color: rgba(0, 0, 0, 0.12) !important;
         }
         td {
-            border-color: #EEEEEE !important;
+            border-color: rgba(0, 0, 0, 0.06) !important;
         }
         tr:nth-child(even) {
-            background-color: #FAFAFA !important;
+            background-color: transparent !important;
         }
         hr {
-            border-color: #DDDDDD !important;
+            border-color: rgba(0, 0, 0, 0.12) !important;
         }
         .img-placeholder {
-            background-color: #F0F0F0 !important;
-            border-color: #CCCCCC !important;
-            color: #999999 !important;
+            background-color: #F5F5F7 !important;
+            border-color: rgba(0, 0, 0, 0.12) !important;
+            color: #AEAEB2 !important;
         }
         .frontmatter {
-            background-color: #F0F0F0 !important;
+            background-color: #F5F5F7 !important;
         }
         .frontmatter dt {
-            color: #555555 !important;
+            color: #86868B !important;
         }
         .frontmatter dd {
-            color: #333333 !important;
+            color: #1D1D1F !important;
         }
+        mark {
+            background-color: rgba(255, 212, 0, 0.4) !important;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+        .callout {
+            border: none !important;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+        details.callout > summary::before { content: "" !important; }
+        .toc { background-color: #F5F5F7 !important; }
+        .heading-anchor { display: none !important; }
+        .lightbox-overlay { display: none !important; }
+        .footnote-popover { display: none !important; }
         .page-break {
             page-break-after: always;
             break-after: page;

--- a/Shared/Resources/demo.md
+++ b/Shared/Resources/demo.md
@@ -11,6 +11,8 @@ A **native macOS markdown editor** built with SwiftUI — fast, focused, and bea
 
 > "The best tool is the one that gets out of your way." — *somebody, probably*
 
+[TOC]
+
 ---
 
 ## Headings
@@ -31,6 +33,22 @@ You can write in **bold**, *italic*, ***bold italic***, or ~~strikethrough~~. Co
 Use `inline code` for short snippets, variable names like `NSTextStorage`, or file paths like `~/Desktop/demo.md`.
 
 Links look like this: [Clearly on GitHub](https://github.com/joshpigford/clearly), and autolinked URLs work too: https://apple.com.
+
+### Highlight
+
+Use ==double equals== to ==highlight important text==. Great for drawing attention to key points.
+
+### Superscript & Subscript
+
+Water is H~2~O. Einstein's famous equation: E = mc^2^.
+
+The formula for the area of a circle is A = πr^2^, and CO~2~ levels are rising.
+
+### Emoji Shortcodes
+
+Clearly supports GitHub-style emoji shortcodes: :rocket: :fire: :sparkles: :tada: :heart: :100:
+
+Ship features :ship:, fix bugs :bug:, and celebrate :champagne:!
 
 ---
 
@@ -62,6 +80,8 @@ Links look like this: [Clearly on GitHub](https://github.com/joshpigford/clearly
 - [ ] Tell all your friends
 - [ ] World domination
 
+*Tip: In preview mode, you can click the checkboxes to toggle them!*
+
 ---
 
 ## Blockquotes
@@ -74,13 +94,55 @@ Links look like this: [Clearly on GitHub](https://github.com/joshpigford/clearly
 
 ---
 
+## Callouts & Admonitions
+
+Clearly supports GitHub/Obsidian-style callouts with `> [!TYPE]` syntax:
+
+> [!NOTE]
+> This is a note callout. Use it for supplementary information.
+
+> [!TIP]
+> Pro tip: double-click any element in the preview to jump to its source line in the editor.
+
+> [!IMPORTANT]
+> Critical information that users need to know.
+
+> [!WARNING]
+> Potential issues that need attention.
+
+> [!CAUTION]
+> Negative consequences that could occur.
+
+### More callout types
+
+> [!EXAMPLE]
+> Here's an example of how to use callouts effectively.
+
+> [!BUG]
+> Known issue: this only happens on Tuesdays during a full moon.
+
+> [!SUCCESS]
+> All tests passing. Ship it!
+
+> [!QUESTION]
+> Is this the best markdown editor ever? Signs point to yes.
+
+### Foldable callouts
+
+Add a `-` after the type to make it collapsible:
+
+> [!TIP]- Click to expand
+> This content is hidden by default! Great for FAQs, spoilers, or optional details.
+
+---
+
 ## Code
 
 Inline: use `cmd + 1` for editor mode and `cmd + 2` for preview mode.
 
-Fenced code block with a language hint:
+Fenced code block with syntax highlighting:
 
-```swift
+```swift title="ClearlyApp.swift"
 import SwiftUI
 
 @main
@@ -109,6 +171,17 @@ xcodegen generate
 xcodebuild -scheme Clearly -configuration Debug build
 ```
 
+### Diff Highlighting
+
+```diff
+- const oldFeature = "basic markdown";
++ const newFeature = "supercharged markdown";
+  
+- // TODO: add syntax highlighting
++ // Done: full Highlight.js integration
++ // Done: line numbers, diff highlighting
+```
+
 ---
 
 ## Tables
@@ -117,12 +190,14 @@ xcodebuild -scheme Clearly -configuration Debug build
 
 | Feature              | Editor | Preview | QuickLook |
 | :------------------- | :----: | :-----: | :-------: |
-| Syntax highlighting  |   ✓    |    —    |     —     |
+| Syntax highlighting  |   ✓    |    ✓    |     ✓     |
 | Live GFM rendering   |   —    |    ✓    |     ✓     |
 | Tables               |   ✓    |    ✓    |     ✓     |
 | Math (KaTeX)         |   ✓    |    ✓    |     ✓     |
 | Mermaid diagrams     |   ✓    |    ✓    |     ✓     |
 | Task lists           |   ✓    |    ✓    |     ✓     |
+| Callouts             |   ✓    |    ✓    |     ✓     |
+| Code highlighting    |   —    |    ✓    |     ✓     |
 
 ### Right-aligned numbers
 
@@ -214,14 +289,32 @@ ___
 
 ![Clearly Screenshot](https://raw.githubusercontent.com/Shpigford/clearly/main/website/screenshot.jpg)
 
+*Click any image in preview mode to view it in a lightbox!*
+
 ---
 
 ## Footnotes
 
 Clearly renders GitHub-style footnotes[^1], including multiple references[^note] in the same paragraph[^1].
 
+*Hover over a footnote reference in preview mode to see a popover with the footnote content!*
+
 [^1]: This is the first footnote. It can contain **formatting** and `code`.
 [^note]: Named footnotes work too — use any label you like.
+
+---
+
+## Collapsible Sections
+
+<details>
+<summary>Click to expand this section</summary>
+
+This content is hidden by default using the HTML `<details>` element. Clearly animates the open/close transition smoothly.
+
+- You can put any markdown here
+- Including lists, code, and more
+
+</details>
 
 ---
 
@@ -237,4 +330,4 @@ HTML passes through for when you need it:
 
 ## The End
 
-That's Clearly — **every markdown feature you actually use**, rendered beautifully, highlighted live, and ready to ship. 🚀
+That's Clearly — **every markdown feature you actually use**, rendered beautifully, highlighted live, and ready to ship. :rocket:

--- a/Shared/Resources/highlight-theme.css
+++ b/Shared/Resources/highlight-theme.css
@@ -1,0 +1,149 @@
+/* Highlight.js theme — GitHub-inspired light/dark */
+
+/* Light mode (default) */
+.hljs {
+    color: #24292e;
+    background: transparent;
+}
+.hljs-comment, .hljs-quote { color: #6a737d; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-meta { color: #d73a49; }
+.hljs-string, .hljs-addition { color: #032f62; }
+.hljs-number, .hljs-literal { color: #005cc5; }
+.hljs-built_in, .hljs-type { color: #6f42c1; }
+.hljs-title, .hljs-title.class_, .hljs-title.function_ { color: #6f42c1; }
+.hljs-attr, .hljs-attribute { color: #005cc5; }
+.hljs-symbol, .hljs-bullet { color: #e36209; }
+.hljs-variable, .hljs-template-variable { color: #e36209; }
+.hljs-link { color: #032f62; text-decoration: underline; }
+.hljs-selector-id, .hljs-selector-class { color: #6f42c1; }
+.hljs-name, .hljs-tag { color: #22863a; }
+.hljs-deletion { color: #b31d28; background-color: rgba(255, 0, 0, 0.05); }
+.hljs-addition { background-color: rgba(0, 255, 0, 0.05); }
+.hljs-section { color: #005cc5; font-weight: bold; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: bold; }
+.hljs-meta .hljs-keyword { color: #005cc5; }
+.hljs-regexp { color: #032f62; }
+.hljs-params { color: #24292e; }
+.hljs-property { color: #005cc5; }
+.hljs-subst { color: #24292e; }
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    .hljs {
+        color: #e1e4e8;
+        background: transparent;
+    }
+    .hljs-comment, .hljs-quote { color: #8b949e; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-meta { color: #ff7b72; }
+    .hljs-string, .hljs-addition { color: #a5d6ff; }
+    .hljs-number, .hljs-literal { color: #79c0ff; }
+    .hljs-built_in, .hljs-type { color: #d2a8ff; }
+    .hljs-title, .hljs-title.class_, .hljs-title.function_ { color: #d2a8ff; }
+    .hljs-attr, .hljs-attribute { color: #79c0ff; }
+    .hljs-symbol, .hljs-bullet { color: #ffa657; }
+    .hljs-variable, .hljs-template-variable { color: #ffa657; }
+    .hljs-link { color: #a5d6ff; }
+    .hljs-selector-id, .hljs-selector-class { color: #d2a8ff; }
+    .hljs-name, .hljs-tag { color: #7ee787; }
+    .hljs-deletion { color: #ffa198; background-color: rgba(255, 0, 0, 0.1); }
+    .hljs-addition { background-color: rgba(0, 255, 0, 0.1); }
+    .hljs-section { color: #79c0ff; }
+    .hljs-meta .hljs-keyword { color: #79c0ff; }
+    .hljs-regexp { color: #a5d6ff; }
+    .hljs-property { color: #79c0ff; }
+    .hljs-subst { color: #e1e4e8; }
+}
+
+/* Print: force light colors */
+@media print {
+    .hljs { color: #222222 !important; }
+    .hljs-comment, .hljs-quote { color: #6a737d !important; }
+    .hljs-keyword, .hljs-selector-tag { color: #d73a49 !important; }
+    .hljs-string { color: #032f62 !important; }
+    .hljs-number, .hljs-literal { color: #005cc5 !important; }
+    .hljs-built_in, .hljs-type, .hljs-title { color: #6f42c1 !important; }
+    .hljs-name, .hljs-tag { color: #22863a !important; }
+}
+
+/* Line numbers */
+pre code {
+    line-height: 1.45;
+}
+.code-line {
+    display: block;
+    margin: 0;
+    padding: 0;
+}
+.code-numbered .code-line {
+    counter-increment: line;
+}
+.code-numbered .code-line::before {
+    content: counter(line);
+    display: inline-block;
+    width: 2.5em;
+    text-align: right;
+    padding-right: 1em;
+    margin-right: 0.5em;
+    color: #AEAEB2;
+    user-select: none;
+    -webkit-user-select: none;
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+}
+@media (prefers-color-scheme: dark) {
+    .code-numbered .code-line::before {
+        color: #48484A;
+        border-right-color: rgba(255, 255, 255, 0.06);
+    }
+}
+@media print {
+    .code-numbered .code-line::before {
+        color: #AEAEB2 !important;
+        border-right-color: rgba(0, 0, 0, 0.06) !important;
+    }
+}
+
+/* Diff highlighting */
+.diff-add {
+    background-color: rgba(46, 160, 67, 0.15);
+    display: block;
+}
+.diff-del {
+    background-color: rgba(248, 81, 73, 0.15);
+    display: block;
+}
+.diff-hunk {
+    color: #8b949e;
+    display: block;
+}
+@media (prefers-color-scheme: dark) {
+    .diff-add { background-color: rgba(46, 160, 67, 0.2); }
+    .diff-del { background-color: rgba(248, 81, 73, 0.2); }
+}
+
+/* Code filename header */
+.code-filename {
+    font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
+    font-size: 0.8em;
+    padding: 0.5em 1.25em;
+    background: #EDEDF0;
+    border: none;
+    border-radius: 10px 10px 0 0;
+    color: #86868B;
+}
+.code-filename + pre {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+@media (prefers-color-scheme: dark) {
+    .code-filename {
+        background: rgba(255, 255, 255, 0.07);
+        color: #AEAEB2;
+    }
+}
+@media print {
+    .code-filename {
+        background: #EDEDF0 !important;
+        color: #86868B !important;
+    }
+}

--- a/Shared/Resources/highlight.min.js
+++ b/Shared/Resources/highlight.min.js
@@ -1,0 +1,1328 @@
+/*!
+  Highlight.js v11.11.1 (git: 08cb242e7d)
+  (c) 2006-2024 Josh Goebel <hello@joshgoebel.com> and other contributors
+  License: BSD-3-Clause
+ */
+var hljs=function(){"use strict";function e(n){
+return n instanceof Map?n.clear=n.delete=n.set=()=>{
+throw Error("map is read-only")}:n instanceof Set&&(n.add=n.clear=n.delete=()=>{
+throw Error("set is read-only")
+}),Object.freeze(n),Object.getOwnPropertyNames(n).forEach((t=>{
+const a=n[t],i=typeof a;"object"!==i&&"function"!==i||Object.isFrozen(a)||e(a)
+})),n}class n{constructor(e){
+void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+ignoreMatch(){this.isMatchIgnored=!0}}function t(e){
+return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+}function a(e,...n){const t=Object.create(null);for(const n in e)t[n]=e[n]
+;return n.forEach((e=>{for(const n in e)t[n]=e[n]})),t}const i=e=>!!e.scope
+;class r{constructor(e,n){
+this.buffer="",this.classPrefix=n.classPrefix,e.walk(this)}addText(e){
+this.buffer+=t(e)}openNode(e){if(!i(e))return;const n=((e,{prefix:n})=>{
+if(e.startsWith("language:"))return e.replace("language:","language-")
+;if(e.includes(".")){const t=e.split(".")
+;return[`${n}${t.shift()}`,...t.map(((e,n)=>`${e}${"_".repeat(n+1)}`))].join(" ")
+}return`${n}${e}`})(e.scope,{prefix:this.classPrefix});this.span(n)}
+closeNode(e){i(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+this.buffer+=`<span class="${e}">`}}const s=(e={})=>{const n={children:[]}
+;return Object.assign(n,e),n};class o{constructor(){
+this.rootNode=s(),this.stack=[this.rootNode]}get top(){
+return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+this.top.children.push(e)}openNode(e){const n=s({scope:e})
+;this.add(n),this.stack.push(n)}closeNode(){
+if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,n){
+return"string"==typeof n?e.addText(n):n.children&&(e.openNode(n),
+n.children.forEach((n=>this._walk(e,n))),e.closeNode(n)),e}static _collapse(e){
+"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+o._collapse(e)})))}}class l extends o{constructor(e){super(),this.options=e}
+addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+this.closeNode()}__addSublanguage(e,n){const t=e.root
+;n&&(t.scope="language:"+n),this.add(t)}toHTML(){
+return new r(this,this.options).value()}finalize(){
+return this.closeAllNodes(),!0}}function c(e){
+return e?"string"==typeof e?e:e.source:null}function d(e){return b("(?=",e,")")}
+function g(e){return b("(?:",e,")*")}function u(e){return b("(?:",e,")?")}
+function b(...e){return e.map((e=>c(e))).join("")}function m(...e){const n=(e=>{
+const n=e[e.length-1]
+;return"object"==typeof n&&n.constructor===Object?(e.splice(e.length-1,1),n):{}
+})(e);return"("+(n.capture?"":"?:")+e.map((e=>c(e))).join("|")+")"}
+function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+const _=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+;function h(e,{joinWith:n}){let t=0;return e.map((e=>{t+=1;const n=t
+;let a=c(e),i="";for(;a.length>0;){const e=_.exec(a);if(!e){i+=a;break}
+i+=a.substring(0,e.index),
+a=a.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?i+="\\"+(Number(e[1])+n):(i+=e[0],
+"("===e[0]&&t++)}return i})).map((e=>`(${e})`)).join(n)}
+const f="[a-zA-Z]\\w*",E="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",w="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",v="\\b(0b[01]+)",N={
+begin:"\\\\[\\s\\S]",relevance:0},k={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[N]},x={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[N]},O=(e,n,t={})=>{const i=a({scope:"comment",begin:e,end:n,
+contains:[]},t);i.contains.push({scope:"doctag",
+begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+;const r=m("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+;return i.contains.push({begin:b(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
+},M=O("//","$"),A=O("/\\*","\\*/"),S=O("#","$");var C=Object.freeze({
+__proto__:null,APOS_STRING_MODE:k,BACKSLASH_ESCAPE:N,BINARY_NUMBER_MODE:{
+scope:"number",begin:v,relevance:0},BINARY_NUMBER_RE:v,COMMENT:O,
+C_BLOCK_COMMENT_MODE:A,C_LINE_COMMENT_MODE:M,C_NUMBER_MODE:{scope:"number",
+begin:w,relevance:0},C_NUMBER_RE:w,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+"on:begin":(e,n)=>{n.data._beginMatch=e[1]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}}),HASH_COMMENT_MODE:S,IDENT_RE:f,
+MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+E,relevance:0},
+NUMBER_MODE:{scope:"number",begin:y,relevance:0},NUMBER_RE:y,
+PHRASAL_WORDS_MODE:{
+begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+},QUOTE_STRING_MODE:x,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+end:/\/[gimuy]*/,contains:[N,{begin:/\[/,end:/\]/,relevance:0,contains:[N]}]},
+RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+SHEBANG:(e={})=>{const n=/^#![ ]*\//
+;return e.binary&&(e.begin=b(n,/.*\b/,e.binary,/\b.*/)),a({scope:"meta",begin:n,
+end:/$/,relevance:0,"on:begin":(e,n)=>{0!==e.index&&n.ignoreMatch()}},e)},
+TITLE_MODE:{scope:"title",begin:f,relevance:0},UNDERSCORE_IDENT_RE:E,
+UNDERSCORE_TITLE_MODE:{scope:"title",begin:E,relevance:0}});function T(e,n){
+"."===e.input[e.index-1]&&n.ignoreMatch()}function R(e,n){
+void 0!==e.className&&(e.scope=e.className,delete e.className)}function D(e,n){
+n&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+e.__beforeBegin=T,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+void 0===e.relevance&&(e.relevance=0))}function I(e,n){
+Array.isArray(e.illegal)&&(e.illegal=m(...e.illegal))}function L(e,n){
+if(e.match){
+if(e.begin||e.end)throw Error("begin & end are not supported with match")
+;e.begin=e.match,delete e.match}}function B(e,n){
+void 0===e.relevance&&(e.relevance=1)}const $=(e,n)=>{if(!e.beforeMatch)return
+;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+;const t=Object.assign({},e);Object.keys(e).forEach((n=>{delete e[n]
+})),e.keywords=t.keywords,e.begin=b(t.beforeMatch,d(t.begin)),e.starts={
+relevance:0,contains:[Object.assign(t,{endsParent:!0})]
+},e.relevance=0,delete t.beforeMatch
+},F=["of","and","for","in","not","or","if","then","parent","list","value"]
+;function z(e,n,t="keyword"){const a=Object.create(null)
+;return"string"==typeof e?i(t,e.split(" ")):Array.isArray(e)?i(t,e):Object.keys(e).forEach((t=>{
+Object.assign(a,z(e[t],n,t))})),a;function i(e,t){
+n&&(t=t.map((e=>e.toLowerCase()))),t.forEach((n=>{const t=n.split("|")
+;a[t[0]]=[e,j(t[0],t[1])]}))}}function j(e,n){
+return n?Number(n):(e=>F.includes(e.toLowerCase()))(e)?0:1}const U={},P=e=>{
+console.error(e)},K=(e,...n)=>{console.log("WARN: "+e,...n)},q=(e,n)=>{
+U[`${e}/${n}`]||(console.log(`Deprecated as of ${e}. ${n}`),U[`${e}/${n}`]=!0)
+},H=Error();function G(e,n,{key:t}){let a=0;const i=e[t],r={},s={}
+;for(let e=1;e<=n.length;e++)s[e+a]=i[e],r[e+a]=!0,a+=p(n[e-1])
+;e[t]=s,e[t]._emit=r,e[t]._multi=!0}function Z(e){(e=>{
+e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+}),(e=>{if(Array.isArray(e.begin)){
+if(e.skip||e.excludeBegin||e.returnBegin)throw P("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+H
+;if("object"!=typeof e.beginScope||null===e.beginScope)throw P("beginScope must be object"),
+H;G(e,e.begin,{key:"beginScope"}),e.begin=h(e.begin,{joinWith:""})}})(e),(e=>{
+if(Array.isArray(e.end)){
+if(e.skip||e.excludeEnd||e.returnEnd)throw P("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+H
+;if("object"!=typeof e.endScope||null===e.endScope)throw P("endScope must be object"),
+H;G(e,e.end,{key:"endScope"}),e.end=h(e.end,{joinWith:""})}})(e)}function W(e){
+function n(n,t){
+return RegExp(c(n),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(t?"g":""))
+}class t{constructor(){
+this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+addRule(e,n){
+n.position=this.position++,this.matchIndexes[this.matchAt]=n,this.regexes.push([n,e]),
+this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+;const e=this.regexes.map((e=>e[1]));this.matcherRe=n(h(e,{joinWith:"|"
+}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+;const n=this.matcherRe.exec(e);if(!n)return null
+;const t=n.findIndex(((e,n)=>n>0&&void 0!==e)),a=this.matchIndexes[t]
+;return n.splice(0,t),Object.assign(n,a)}}class i{constructor(){
+this.rules=[],this.multiRegexes=[],
+this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+if(this.multiRegexes[e])return this.multiRegexes[e];const n=new t
+;return this.rules.slice(e).forEach((([e,t])=>n.addRule(e,t))),
+n.compile(),this.multiRegexes[e]=n,n}resumingScanAtSamePosition(){
+return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,n){
+this.rules.push([e,n]),"begin"===n.type&&this.count++}exec(e){
+const n=this.getMatcher(this.regexIndex);n.lastIndex=this.lastIndex
+;let t=n.exec(e)
+;if(this.resumingScanAtSamePosition())if(t&&t.index===this.lastIndex);else{
+const n=this.getMatcher(0);n.lastIndex=this.lastIndex+1,t=n.exec(e)}
+return t&&(this.regexIndex+=t.position+1,
+this.regexIndex===this.count&&this.considerAll()),t}}
+if(e.compilerExtensions||(e.compilerExtensions=[]),
+e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+;return e.classNameAliases=a(e.classNameAliases||{}),function t(r,s){const o=r
+;if(r.isCompiled)return o
+;[R,L,Z,$].forEach((e=>e(r,s))),e.compilerExtensions.forEach((e=>e(r,s))),
+r.__beforeBegin=null,[D,I,B].forEach((e=>e(r,s))),r.isCompiled=!0;let l=null
+;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
+l=r.keywords.$pattern,
+delete r.keywords.$pattern),l=l||/\w+/,r.keywords&&(r.keywords=z(r.keywords,e.case_insensitive)),
+o.keywordPatternRe=n(l,!0),
+s&&(r.begin||(r.begin=/\B|\b/),o.beginRe=n(o.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
+r.end&&(o.endRe=n(o.end)),
+o.terminatorEnd=c(o.end)||"",r.endsWithParent&&s.terminatorEnd&&(o.terminatorEnd+=(r.end?"|":"")+s.terminatorEnd)),
+r.illegal&&(o.illegalRe=n(r.illegal)),
+r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((n=>a(e,{
+variants:null},n)))),e.cachedVariants?e.cachedVariants:Q(e)?a(e,{
+starts:e.starts?a(e.starts):null
+}):Object.isFrozen(e)?a(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{t(e,o)
+})),r.starts&&t(r.starts,s),o.matcher=(e=>{const n=new i
+;return e.contains.forEach((e=>n.addRule(e.begin,{rule:e,type:"begin"
+}))),e.terminatorEnd&&n.addRule(e.terminatorEnd,{type:"end"
+}),e.illegal&&n.addRule(e.illegal,{type:"illegal"}),n})(o),o}(e)}function Q(e){
+return!!e&&(e.endsWithParent||Q(e.starts))}class X extends Error{
+constructor(e,n){super(e),this.name="HTMLInjectionError",this.html=n}}
+const V=t,J=a,Y=Symbol("nomatch"),ee=t=>{
+const a=Object.create(null),i=Object.create(null),r=[];let s=!0
+;const o="Could not find the language '{}', did you forget to load/include a language module?",c={
+disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+cssSelector:"pre code",languages:null,__emitter:l};function _(e){
+return p.noHighlightRe.test(e)}function h(e,n,t){let a="",i=""
+;"object"==typeof n?(a=e,
+t=n.ignoreIllegals,i=n.language):(q("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+q("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+i=e,a=n),void 0===t&&(t=!0);const r={code:a,language:i};O("before:highlight",r)
+;const s=r.result?r.result:f(r.language,r.code,t)
+;return s.code=r.code,O("after:highlight",s),s}function f(e,t,i,r){
+const l=Object.create(null);function c(){if(!O.keywords)return void A.addText(S)
+;let e=0;O.keywordPatternRe.lastIndex=0;let n=O.keywordPatternRe.exec(S),t=""
+;for(;n;){t+=S.substring(e,n.index)
+;const i=v.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,O.keywords[a]);if(r){
+const[e,a]=r
+;if(A.addText(t),t="",l[i]=(l[i]||0)+1,l[i]<=7&&(C+=a),e.startsWith("_"))t+=n[0];else{
+const t=v.classNameAliases[e]||e;g(n[0],t)}}else t+=n[0]
+;e=O.keywordPatternRe.lastIndex,n=O.keywordPatternRe.exec(S)}var a
+;t+=S.substring(e),A.addText(t)}function d(){null!=O.subLanguage?(()=>{
+if(""===S)return;let e=null;if("string"==typeof O.subLanguage){
+if(!a[O.subLanguage])return void A.addText(S)
+;e=f(O.subLanguage,S,!0,M[O.subLanguage]),M[O.subLanguage]=e._top
+}else e=E(S,O.subLanguage.length?O.subLanguage:null)
+;O.relevance>0&&(C+=e.relevance),A.__addSublanguage(e._emitter,e.language)
+})():c(),S=""}function g(e,n){
+""!==e&&(A.startScope(n),A.addText(e),A.endScope())}function u(e,n){let t=1
+;const a=n.length-1;for(;t<=a;){if(!e._emit[t]){t++;continue}
+const a=v.classNameAliases[e[t]]||e[t],i=n[t];a?g(i,a):(S=i,c(),S=""),t++}}
+function b(e,n){
+return e.scope&&"string"==typeof e.scope&&A.openNode(v.classNameAliases[e.scope]||e.scope),
+e.beginScope&&(e.beginScope._wrap?(g(S,v.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+S=""):e.beginScope._multi&&(u(e.beginScope,n),S="")),O=Object.create(e,{parent:{
+value:O}}),O}function m(e,t,a){let i=((e,n)=>{const t=e&&e.exec(n)
+;return t&&0===t.index})(e.endRe,a);if(i){if(e["on:end"]){const a=new n(e)
+;e["on:end"](t,a),a.isMatchIgnored&&(i=!1)}if(i){
+for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+if(e.endsWithParent)return m(e.parent,t,a)}function _(e){
+return 0===O.matcher.regexIndex?(S+=e[0],1):(D=!0,0)}function h(e){
+const n=e[0],a=t.substring(e.index),i=m(O,e,a);if(!i)return Y;const r=O
+;O.endScope&&O.endScope._wrap?(d(),
+g(n,O.endScope._wrap)):O.endScope&&O.endScope._multi?(d(),
+u(O.endScope,e)):r.skip?S+=n:(r.returnEnd||r.excludeEnd||(S+=n),
+d(),r.excludeEnd&&(S=n));do{
+O.scope&&A.closeNode(),O.skip||O.subLanguage||(C+=O.relevance),O=O.parent
+}while(O!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:n.length}
+let y={};function w(a,r){const o=r&&r[0];if(S+=a,null==o)return d(),0
+;if("begin"===y.type&&"end"===r.type&&y.index===r.index&&""===o){
+if(S+=t.slice(r.index,r.index+1),!s){const n=Error(`0 width match regex (${e})`)
+;throw n.languageName=e,n.badRule=y.rule,n}return 1}
+if(y=r,"begin"===r.type)return(e=>{
+const t=e[0],a=e.rule,i=new n(a),r=[a.__beforeBegin,a["on:begin"]]
+;for(const n of r)if(n&&(n(e,i),i.isMatchIgnored))return _(t)
+;return a.skip?S+=t:(a.excludeBegin&&(S+=t),
+d(),a.returnBegin||a.excludeBegin||(S=t)),b(a,e),a.returnBegin?0:t.length})(r)
+;if("illegal"===r.type&&!i){
+const e=Error('Illegal lexeme "'+o+'" for mode "'+(O.scope||"<unnamed>")+'"')
+;throw e.mode=O,e}if("end"===r.type){const e=h(r);if(e!==Y)return e}
+if("illegal"===r.type&&""===o)return S+="\n",1
+;if(R>1e5&&R>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
+;return S+=o,o.length}const v=N(e)
+;if(!v)throw P(o.replace("{}",e)),Error('Unknown language: "'+e+'"')
+;const k=W(v);let x="",O=r||k;const M={},A=new p.__emitter(p);(()=>{const e=[]
+;for(let n=O;n!==v;n=n.parent)n.scope&&e.unshift(n.scope)
+;e.forEach((e=>A.openNode(e)))})();let S="",C=0,T=0,R=0,D=!1;try{
+if(v.__emitTokens)v.__emitTokens(t,A);else{for(O.matcher.considerAll();;){
+R++,D?D=!1:O.matcher.considerAll(),O.matcher.lastIndex=T
+;const e=O.matcher.exec(t);if(!e)break;const n=w(t.substring(T,e.index),e)
+;T=e.index+n}w(t.substring(T))}return A.finalize(),x=A.toHTML(),{language:e,
+value:x,relevance:C,illegal:!1,_emitter:A,_top:O}}catch(n){
+if(n.message&&n.message.includes("Illegal"))return{language:e,value:V(t),
+illegal:!0,relevance:0,_illegalBy:{message:n.message,index:T,
+context:t.slice(T-100,T+100),mode:n.mode,resultSoFar:x},_emitter:A};if(s)return{
+language:e,value:V(t),illegal:!1,relevance:0,errorRaised:n,_emitter:A,_top:O}
+;throw n}}function E(e,n){n=n||p.languages||Object.keys(a);const t=(e=>{
+const n={value:V(e),illegal:!1,relevance:0,_top:c,_emitter:new p.__emitter(p)}
+;return n._emitter.addText(e),n})(e),i=n.filter(N).filter(x).map((n=>f(n,e,!1)))
+;i.unshift(t);const r=i.sort(((e,n)=>{
+if(e.relevance!==n.relevance)return n.relevance-e.relevance
+;if(e.language&&n.language){if(N(e.language).supersetOf===n.language)return 1
+;if(N(n.language).supersetOf===e.language)return-1}return 0})),[s,o]=r,l=s
+;return l.secondBest=o,l}function y(e){let n=null;const t=(e=>{
+let n=e.className+" ";n+=e.parentNode?e.parentNode.className:""
+;const t=p.languageDetectRe.exec(n);if(t){const n=N(t[1])
+;return n||(K(o.replace("{}",t[1])),
+K("Falling back to no-highlight mode for this block.",e)),n?t[1]:"no-highlight"}
+return n.split(/\s+/).find((e=>_(e)||N(e)))})(e);if(_(t))return
+;if(O("before:highlightElement",{el:e,language:t
+}),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+console.warn("The element with unescaped HTML:"),
+console.warn(e)),p.throwUnescapedHTML))throw new X("One of your code blocks includes unescaped HTML.",e.innerHTML)
+;n=e;const a=n.textContent,r=t?h(a,{language:t,ignoreIllegals:!0}):E(a)
+;e.innerHTML=r.value,e.dataset.highlighted="yes",((e,n,t)=>{const a=n&&i[n]||t
+;e.classList.add("hljs"),e.classList.add("language-"+a)
+})(e,t,r.language),e.result={language:r.language,re:r.relevance,
+relevance:r.relevance},r.secondBest&&(e.secondBest={
+language:r.secondBest.language,relevance:r.secondBest.relevance
+}),O("after:highlightElement",{el:e,result:r,text:a})}let w=!1;function v(){
+if("loading"===document.readyState)return w||window.addEventListener("DOMContentLoaded",(()=>{
+v()}),!1),void(w=!0);document.querySelectorAll(p.cssSelector).forEach(y)}
+function N(e){return e=(e||"").toLowerCase(),a[e]||a[i[e]]}
+function k(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+i[e.toLowerCase()]=n}))}function x(e){const n=N(e)
+;return n&&!n.disableAutodetect}function O(e,n){const t=e;r.forEach((e=>{
+e[t]&&e[t](n)}))}Object.assign(t,{highlight:h,highlightAuto:E,highlightAll:v,
+highlightElement:y,
+highlightBlock:e=>(q("10.7.0","highlightBlock will be removed entirely in v12.0"),
+q("10.7.0","Please use highlightElement now."),y(e)),configure:e=>{p=J(p,e)},
+initHighlighting:()=>{
+v(),q("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+initHighlightingOnLoad:()=>{
+v(),q("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+},registerLanguage:(e,n)=>{let i=null;try{i=n(t)}catch(n){
+if(P("Language definition for '{}' could not be registered.".replace("{}",e)),
+!s)throw n;P(n),i=c}
+i.name||(i.name=e),a[e]=i,i.rawDefinition=n.bind(null,t),i.aliases&&k(i.aliases,{
+languageName:e})},unregisterLanguage:e=>{delete a[e]
+;for(const n of Object.keys(i))i[n]===e&&delete i[n]},
+listLanguages:()=>Object.keys(a),getLanguage:N,registerAliases:k,
+autoDetection:x,inherit:J,addPlugin:e=>{(e=>{
+e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=n=>{
+e["before:highlightBlock"](Object.assign({block:n.el},n))
+}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=n=>{
+e["after:highlightBlock"](Object.assign({block:n.el},n))})})(e),r.push(e)},
+removePlugin:e=>{const n=r.indexOf(e);-1!==n&&r.splice(n,1)}}),t.debugMode=()=>{
+s=!1},t.safeMode=()=>{s=!0},t.versionString="11.11.1",t.regex={concat:b,
+lookahead:d,either:m,optional:u,anyNumberOfTimes:g}
+;for(const n in C)"object"==typeof C[n]&&e(C[n]);return Object.assign(t,C),t
+},ne=ee({});ne.newInstance=()=>ee({});const te=e=>({IMPORTANT:{scope:"meta",
+begin:"!important"},BLOCK_COMMENT:e.C_BLOCK_COMMENT_MODE,HEXCOLOR:{
+scope:"number",begin:/#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/},
+FUNCTION_DISPATCH:{className:"built_in",begin:/[\w-]+(?=\()/},
+ATTRIBUTE_SELECTOR_MODE:{scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
+contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
+scope:"number",
+begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+relevance:0},CSS_VARIABLE:{className:"attr",begin:/--[A-Za-z_][A-Za-z0-9_-]*/}
+}),ae=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","optgroup","option","p","picture","q","quote","samp","section","select","source","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video","defs","g","marker","mask","pattern","svg","switch","symbol","feBlend","feColorMatrix","feComponentTransfer","feComposite","feConvolveMatrix","feDiffuseLighting","feDisplacementMap","feFlood","feGaussianBlur","feImage","feMerge","feMorphology","feOffset","feSpecularLighting","feTile","feTurbulence","linearGradient","radialGradient","stop","circle","ellipse","image","line","path","polygon","polyline","rect","text","use","textPath","tspan","foreignObject","clipPath"],ie=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"].sort().reverse(),re=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"].sort().reverse(),se=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"].sort().reverse(),oe=["accent-color","align-content","align-items","align-self","alignment-baseline","all","anchor-name","animation","animation-composition","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-range","animation-range-end","animation-range-start","animation-timeline","animation-timing-function","appearance","aspect-ratio","backdrop-filter","backface-visibility","background","background-attachment","background-blend-mode","background-clip","background-color","background-image","background-origin","background-position","background-position-x","background-position-y","background-repeat","background-size","baseline-shift","block-size","border","border-block","border-block-color","border-block-end","border-block-end-color","border-block-end-style","border-block-end-width","border-block-start","border-block-start-color","border-block-start-style","border-block-start-width","border-block-style","border-block-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-end-end-radius","border-end-start-radius","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-inline","border-inline-color","border-inline-end","border-inline-end-color","border-inline-end-style","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-style","border-inline-start-width","border-inline-style","border-inline-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-start-end-radius","border-start-start-radius","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-align","box-decoration-break","box-direction","box-flex","box-flex-group","box-lines","box-ordinal-group","box-orient","box-pack","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","caret-color","clear","clip","clip-path","clip-rule","color","color-interpolation","color-interpolation-filters","color-profile","color-rendering","color-scheme","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","contain","contain-intrinsic-block-size","contain-intrinsic-height","contain-intrinsic-inline-size","contain-intrinsic-size","contain-intrinsic-width","container","container-name","container-type","content","content-visibility","counter-increment","counter-reset","counter-set","cue","cue-after","cue-before","cursor","cx","cy","direction","display","dominant-baseline","empty-cells","enable-background","field-sizing","fill","fill-opacity","fill-rule","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","flood-color","flood-opacity","flow","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-optical-sizing","font-palette","font-size","font-size-adjust","font-smooth","font-smoothing","font-stretch","font-style","font-synthesis","font-synthesis-position","font-synthesis-small-caps","font-synthesis-style","font-synthesis-weight","font-variant","font-variant-alternates","font-variant-caps","font-variant-east-asian","font-variant-emoji","font-variant-ligatures","font-variant-numeric","font-variant-position","font-variation-settings","font-weight","forced-color-adjust","gap","glyph-orientation-horizontal","glyph-orientation-vertical","grid","grid-area","grid-auto-columns","grid-auto-flow","grid-auto-rows","grid-column","grid-column-end","grid-column-start","grid-gap","grid-row","grid-row-end","grid-row-start","grid-template","grid-template-areas","grid-template-columns","grid-template-rows","hanging-punctuation","height","hyphenate-character","hyphenate-limit-chars","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","initial-letter","initial-letter-align","inline-size","inset","inset-area","inset-block","inset-block-end","inset-block-start","inset-inline","inset-inline-end","inset-inline-start","isolation","justify-content","justify-items","justify-self","kerning","left","letter-spacing","lighting-color","line-break","line-height","line-height-step","list-style","list-style-image","list-style-position","list-style-type","margin","margin-block","margin-block-end","margin-block-start","margin-bottom","margin-inline","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","margin-trim","marker","marker-end","marker-mid","marker-start","marks","mask","mask-border","mask-border-mode","mask-border-outset","mask-border-repeat","mask-border-slice","mask-border-source","mask-border-width","mask-clip","mask-composite","mask-image","mask-mode","mask-origin","mask-position","mask-repeat","mask-size","mask-type","masonry-auto-flow","math-depth","math-shift","math-style","max-block-size","max-height","max-inline-size","max-width","min-block-size","min-height","min-inline-size","min-width","mix-blend-mode","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","offset","offset-anchor","offset-distance","offset-path","offset-position","offset-rotate","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-anchor","overflow-block","overflow-clip-margin","overflow-inline","overflow-wrap","overflow-x","overflow-y","overlay","overscroll-behavior","overscroll-behavior-block","overscroll-behavior-inline","overscroll-behavior-x","overscroll-behavior-y","padding","padding-block","padding-block-end","padding-block-start","padding-bottom","padding-inline","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","page","page-break-after","page-break-before","page-break-inside","paint-order","pause","pause-after","pause-before","perspective","perspective-origin","place-content","place-items","place-self","pointer-events","position","position-anchor","position-visibility","print-color-adjust","quotes","r","resize","rest","rest-after","rest-before","right","rotate","row-gap","ruby-align","ruby-position","scale","scroll-behavior","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-align","scroll-snap-stop","scroll-snap-type","scroll-timeline","scroll-timeline-axis","scroll-timeline-name","scrollbar-color","scrollbar-gutter","scrollbar-width","shape-image-threshold","shape-margin","shape-outside","shape-rendering","speak","speak-as","src","stop-color","stop-opacity","stroke","stroke-dasharray","stroke-dashoffset","stroke-linecap","stroke-linejoin","stroke-miterlimit","stroke-opacity","stroke-width","tab-size","table-layout","text-align","text-align-all","text-align-last","text-anchor","text-combine-upright","text-decoration","text-decoration-color","text-decoration-line","text-decoration-skip","text-decoration-skip-ink","text-decoration-style","text-decoration-thickness","text-emphasis","text-emphasis-color","text-emphasis-position","text-emphasis-style","text-indent","text-justify","text-orientation","text-overflow","text-rendering","text-shadow","text-size-adjust","text-transform","text-underline-offset","text-underline-position","text-wrap","text-wrap-mode","text-wrap-style","timeline-scope","top","touch-action","transform","transform-box","transform-origin","transform-style","transition","transition-behavior","transition-delay","transition-duration","transition-property","transition-timing-function","translate","unicode-bidi","user-modify","user-select","vector-effect","vertical-align","view-timeline","view-timeline-axis","view-timeline-inset","view-timeline-name","view-transition-name","visibility","voice-balance","voice-duration","voice-family","voice-pitch","voice-range","voice-rate","voice-stress","voice-volume","white-space","white-space-collapse","widows","width","will-change","word-break","word-spacing","word-wrap","writing-mode","x","y","z-index","zoom"].sort().reverse(),le=re.concat(se).sort().reverse()
+;var ce="[0-9](_*[0-9])*",de=`\\.(${ce})`,ge="[0-9a-fA-F](_*[0-9a-fA-F])*",ue={
+className:"number",variants:[{
+begin:`(\\b(${ce})((${de})|\\.)?|(${de}))[eE][+-]?(${ce})[fFdD]?\\b`},{
+begin:`\\b(${ce})((${de})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{
+begin:`(${de})[fFdD]?\\b`},{begin:`\\b(${ce})[fFdD]\\b`},{
+begin:`\\b0[xX]((${ge})\\.?|(${ge})?\\.(${ge}))[pP][+-]?(${ce})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${ge})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function be(e,n,t){return-1===t?"":e.replace(n,(a=>be(e,n,t-1)))}
+const me="[A-Za-z$_][0-9A-Za-z$_]*",pe=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends","using"],_e=["true","false","null","undefined","NaN","Infinity"],he=["Object","Function","Boolean","Symbol","Math","Date","Number","BigInt","String","RegExp","Array","Float32Array","Float64Array","Int8Array","Uint8Array","Uint8ClampedArray","Int16Array","Int32Array","Uint16Array","Uint32Array","BigInt64Array","BigUint64Array","Set","Map","WeakSet","WeakMap","ArrayBuffer","SharedArrayBuffer","Atomics","DataView","JSON","Promise","Generator","GeneratorFunction","AsyncFunction","Reflect","Proxy","Intl","WebAssembly"],fe=["Error","EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],Ee=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],ye=["arguments","this","super","console","window","document","localStorage","sessionStorage","module","global"],we=[].concat(Ee,he,fe)
+;function ve(e){const n=e.regex,t=me,a={begin:/<[A-Za-z0-9\\._:-]+/,
+end:/\/[A-Za-z0-9\\._:-]+>|\/>/,isTrulyOpeningTag:(e,n)=>{
+const t=e[0].length+e.index,a=e.input[t]
+;if("<"===a||","===a)return void n.ignoreMatch();let i
+;">"===a&&(((e,{after:n})=>{const t="</"+e[0].slice(1)
+;return-1!==e.input.indexOf(t,n)})(e,{after:t})||n.ignoreMatch())
+;const r=e.input.substring(t)
+;((i=r.match(/^\s*=/))||(i=r.match(/^\s+extends\s+/))&&0===i.index)&&n.ignoreMatch()
+}},i={$pattern:me,keyword:pe,literal:_e,built_in:we,"variable.language":ye
+},r="[0-9](_?[0-9])*",s=`\\.(${r})`,o="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",l={
+className:"number",variants:[{
+begin:`(\\b(${o})((${s})|\\.)?|(${s}))[eE][+-]?(${r})\\b`},{
+begin:`\\b(${o})\\b((${s})\\b|\\.)?|(${s})\\b`},{
+begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
+begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
+begin:"\\b0[0-7]+n?\\b"}],relevance:0},c={className:"subst",begin:"\\$\\{",
+end:"\\}",keywords:i,contains:[]},d={begin:".?html`",end:"",starts:{end:"`",
+returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"xml"}},g={
+begin:".?css`",end:"",starts:{end:"`",returnEnd:!1,
+contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"css"}},u={begin:".?gql`",end:"",
+starts:{end:"`",returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],
+subLanguage:"graphql"}},b={className:"string",begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE,c]},m={className:"comment",
+variants:[e.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
+begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
+excludeBegin:!0,relevance:0},{className:"variable",begin:t+"(?=\\s*(-)|$)",
+endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
+}),e.C_BLOCK_COMMENT_MODE,e.C_LINE_COMMENT_MODE]
+},p=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,{match:/\$\d+/},l]
+;c.contains=p.concat({begin:/\{/,end:/\}/,keywords:i,contains:["self"].concat(p)
+});const _=[].concat(m,c.contains),h=_.concat([{begin:/(\s*)\(/,end:/\)/,
+keywords:i,contains:["self"].concat(_)}]),f={className:"params",begin:/(\s*)\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h},E={variants:[{
+match:[/class/,/\s+/,t,/\s+/,/extends/,/\s+/,n.concat(t,"(",n.concat(/\./,t),")*")],
+scope:{1:"keyword",3:"title.class",5:"keyword",7:"title.class.inherited"}},{
+match:[/class/,/\s+/,t],scope:{1:"keyword",3:"title.class"}}]},y={relevance:0,
+match:n.either(/\bJSON/,/\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,/\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,/\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/),
+className:"title.class",keywords:{_:[...he,...fe]}},w={variants:[{
+match:[/function/,/\s+/,t,/(?=\s*\()/]},{match:[/function/,/\s*(?=\()/]}],
+className:{1:"keyword",3:"title.function"},label:"func.def",contains:[f],
+illegal:/%/},v={
+match:n.concat(/\b/,(N=[...Ee,"super","import"].map((e=>e+"\\s*\\(")),
+n.concat("(?!",N.join("|"),")")),t,n.lookahead(/\s*\(/)),
+className:"title.function",relevance:0};var N;const k={
+begin:n.concat(/\./,n.lookahead(n.concat(t,/(?![0-9A-Za-z$_(])/))),end:t,
+excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},x={
+match:[/get|set/,/\s+/,t,/(?=\()/],className:{1:"keyword",3:"title.function"},
+contains:[{begin:/\(\)/},f]
+},O="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",M={
+match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(O)],
+keywords:"async",className:{1:"keyword",3:"title.function"},contains:[f]}
+;return{name:"JavaScript",aliases:["js","jsx","mjs","cjs"],keywords:i,exports:{
+PARAMS_CONTAINS:h,CLASS_REFERENCE:y},illegal:/#(?![$_A-z])/,
+contains:[e.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
+label:"use_strict",className:"meta",relevance:10,
+begin:/^\s*['"]use (strict|asm)['"]/
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,m,{match:/\$\d+/},l,y,{
+scope:"attr",match:t+n.lookahead(":"),relevance:0},M,{
+begin:"("+e.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
+keywords:"return throw case",relevance:0,contains:[m,e.REGEXP_MODE,{
+className:"function",begin:O,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"params",variants:[{begin:e.UNDERSCORE_IDENT_RE,relevance:0},{
+className:null,begin:/\(\s*\)/,skip:!0},{begin:/(\s*)\(/,end:/\)/,
+excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h}]}]},{begin:/,/,relevance:0
+},{match:/\s+/,relevance:0},{variants:[{begin:"<>",end:"</>"},{
+match:/<[A-Za-z0-9\\._:-]+\s*\/>/},{begin:a.begin,
+"on:begin":a.isTrulyOpeningTag,end:a.end}],subLanguage:"xml",contains:[{
+begin:a.begin,end:a.end,skip:!0,contains:["self"]}]}]},w,{
+beginKeywords:"while if switch catch for"},{
+begin:"\\b(?!function)"+e.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
+returnBegin:!0,label:"func.def",contains:[f,e.inherit(e.TITLE_MODE,{begin:t,
+className:"title.function"})]},{match:/\.\.\./,relevance:0},k,{match:"\\$"+t,
+relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
+contains:[f]},v,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},E,x,{match:/\$[(.]/}]}}
+const Ne=e=>b(/\b/,e,/\w$/.test(e)?/\b/:/\B/),ke=["Protocol","Type"].map(Ne),xe=["init","self"].map(Ne),Oe=["Any","Self"],Me=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","borrowing","break","case","catch","class","consume","consuming","continue","convenience","copy","default","defer","deinit","didSet","distributed","do","dynamic","each","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","macro","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","package","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Ae=["false","nil","true"],Se=["assignment","associativity","higherThan","left","lowerThan","none","right"],Ce=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warning"],Te=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Re=m(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),De=m(Re,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),Ie=b(Re,De,"*"),Le=m(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),Be=m(Le,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),$e=b(Le,Be,"*"),Fe=b(/[A-Z]/,Be,"*"),ze=["attached","autoclosure",b(/convention\(/,m("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","freestanding","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",b(/objc\(/,$e,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","Sendable","testable","UIApplicationMain","unchecked","unknown","usableFromInline","warn_unqualified_access"],je=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
+;var Ue=Object.freeze({__proto__:null,grmr_bash:e=>{const n=e.regex,t={},a={
+begin:/\$\{/,end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]}
+;Object.assign(t,{className:"variable",variants:[{
+begin:n.concat(/\$[\w\d#@][\w\d_]*/,"(?![\\w\\d])(?![$])")},a]});const i={
+className:"subst",begin:/\$\(/,end:/\)/,contains:[e.BACKSLASH_ESCAPE]
+},r=e.inherit(e.COMMENT(),{match:[/(^|\s)/,/#.*$/],scope:{2:"comment"}}),s={
+begin:/<<-?\s*(?=\w+)/,starts:{contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,
+end:/(\w+)/,className:"string"})]}},o={className:"string",begin:/"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,t,i]};i.contains.push(o);const l={begin:/\$?\(\(/,
+end:/\)\)/,contains:[{begin:/\d+#[0-9a-f]+/,className:"number"},e.NUMBER_MODE,t]
+},c=e.SHEBANG({binary:"(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",relevance:10
+}),d={className:"function",begin:/\w[\w\d_]*\s*\(\s*\)\s*\{/,returnBegin:!0,
+contains:[e.inherit(e.TITLE_MODE,{begin:/\w[\w\d_]*/})],relevance:0};return{
+name:"Bash",aliases:["sh","zsh"],keywords:{$pattern:/\b[a-z][a-z0-9._-]+\b/,
+keyword:["if","then","else","elif","fi","time","for","while","until","in","do","done","case","esac","coproc","function","select"],
+literal:["true","false"],
+built_in:["break","cd","continue","eval","exec","exit","export","getopts","hash","pwd","readonly","return","shift","test","times","trap","umask","unset","alias","bind","builtin","caller","command","declare","echo","enable","help","let","local","logout","mapfile","printf","read","readarray","source","sudo","type","typeset","ulimit","unalias","set","shopt","autoload","bg","bindkey","bye","cap","chdir","clone","comparguments","compcall","compctl","compdescribe","compfiles","compgroups","compquote","comptags","comptry","compvalues","dirs","disable","disown","echotc","echoti","emulate","fc","fg","float","functions","getcap","getln","history","integer","jobs","kill","limit","log","noglob","popd","print","pushd","pushln","rehash","sched","setcap","setopt","stat","suspend","ttyctl","unfunction","unhash","unlimit","unsetopt","vared","wait","whence","where","which","zcompile","zformat","zftp","zle","zmodload","zparseopts","zprof","zpty","zregexparse","zsocket","zstyle","ztcp","chcon","chgrp","chown","chmod","cp","dd","df","dir","dircolors","ln","ls","mkdir","mkfifo","mknod","mktemp","mv","realpath","rm","rmdir","shred","sync","touch","truncate","vdir","b2sum","base32","base64","cat","cksum","comm","csplit","cut","expand","fmt","fold","head","join","md5sum","nl","numfmt","od","paste","ptx","pr","sha1sum","sha224sum","sha256sum","sha384sum","sha512sum","shuf","sort","split","sum","tac","tail","tr","tsort","unexpand","uniq","wc","arch","basename","chroot","date","dirname","du","echo","env","expr","factor","groups","hostid","id","link","logname","nice","nohup","nproc","pathchk","pinky","printenv","printf","pwd","readlink","runcon","seq","sleep","stat","stdbuf","stty","tee","test","timeout","tty","uname","unlink","uptime","users","who","whoami","yes"]
+},contains:[c,e.SHEBANG(),d,l,r,s,{match:/(\/[a-z._-]+)+/},o,{match:/\\"/},{
+className:"string",begin:/'/,end:/'/},{match:/\\'/},t]}},grmr_c:e=>{
+const n=e.regex,t=e.COMMENT("//","$",{contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",variants:[{begin:"\\b[a-z\\d_]*_t\\b"},{
+match:/\batomic_[a-z]{3,6}\b/}]},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{match:/\b(0b[01']+)/},{
+match:/(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/
+},{
+match:/(-?)\b(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/
+},{match:/(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/}],relevance:0
+},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef elifdef elifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+keyword:["asm","auto","break","case","continue","default","do","else","enum","extern","for","fortran","goto","if","inline","register","restrict","return","sizeof","typeof","typeof_unqual","struct","switch","typedef","union","volatile","while","_Alignas","_Alignof","_Atomic","_Generic","_Noreturn","_Static_assert","_Thread_local","alignas","alignof","noreturn","static_assert","thread_local","_Pragma"],
+type:["float","double","signed","unsigned","int","short","long","char","void","_Bool","_BitInt","_Complex","_Imaginary","_Decimal32","_Decimal64","_Decimal96","_Decimal128","_Decimal64x","_Decimal128x","_Float16","_Float32","_Float64","_Float128","_Float32x","_Float64x","_Float128x","const","static","constexpr","complex","bool","imaginary"],
+literal:"true false NULL",
+built_in:"std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr"
+},b=[c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],m={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:b.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:b.concat(["self"]),relevance:0}]),relevance:0},p={
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[e.inherit(d,{className:"title.function"})],
+relevance:0},{relevance:0,match:/,/},{className:"params",begin:/\(/,end:/\)/,
+keywords:u,relevance:0,contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,
+end:/\)/,keywords:u,relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]
+}]},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C",aliases:["h"],keywords:u,
+disableAutodetect:!0,illegal:"</",contains:[].concat(m,p,b,[c,{
+begin:e.IDENT_RE+"::",keywords:u},{className:"class",
+beginKeywords:"enum class struct union",end:/[{;:<>=]/,contains:[{
+beginKeywords:"final class struct"},e.TITLE_MODE]}]),exports:{preprocessor:c,
+strings:o,keywords:u}}},grmr_cpp:e=>{const n=e.regex,t=e.COMMENT("//","$",{
+contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="(?!struct)("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",begin:"\\b[a-z\\d_]*_t\\b"},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{
+begin:"[+-]?(?:(?:[0-9](?:'?[0-9])*\\.(?:[0-9](?:'?[0-9])*)?|\\.[0-9](?:'?[0-9])*)(?:[Ee][+-]?[0-9](?:'?[0-9])*)?|[0-9](?:'?[0-9])*[Ee][+-]?[0-9](?:'?[0-9])*|0[Xx](?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*(?:\\.(?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)?)?|\\.[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)[Pp][+-]?[0-9](?:'?[0-9])*)(?:[Ff](?:16|32|64|128)?|(BF|bf)16|[Ll]|)"
+},{
+begin:"[+-]?\\b(?:0[Bb][01](?:'?[01])*|0[Xx][0-9A-Fa-f](?:'?[0-9A-Fa-f])*|0(?:'?[0-7])*|[1-9](?:'?[0-9])*)(?:[Uu](?:LL?|ll?)|[Uu][Zz]?|(?:LL?|ll?)[Uu]?|[Zz][Uu]|)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+type:["bool","char","char16_t","char32_t","char8_t","double","float","int","long","short","void","wchar_t","unsigned","signed","const","static"],
+keyword:["alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto","bitand","bitor","break","case","catch","class","co_await","co_return","co_yield","compl","concept","const_cast|10","consteval","constexpr","constinit","continue","decltype","default","delete","do","dynamic_cast|10","else","enum","explicit","export","extern","false","final","for","friend","goto","if","import","inline","module","mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","override","private","protected","public","reflexpr","register","reinterpret_cast|10","requires","return","sizeof","static_assert","static_cast|10","struct","switch","synchronized","template","this","thread_local","throw","transaction_safe","transaction_safe_dynamic","true","try","typedef","typeid","typename","union","using","virtual","volatile","while","xor","xor_eq"],
+literal:["NULL","false","nullopt","nullptr","true"],built_in:["_Pragma"],
+_type_hints:["any","auto_ptr","barrier","binary_semaphore","bitset","complex","condition_variable","condition_variable_any","counting_semaphore","deque","false_type","flat_map","flat_set","future","imaginary","initializer_list","istringstream","jthread","latch","lock_guard","multimap","multiset","mutex","optional","ostringstream","packaged_task","pair","promise","priority_queue","queue","recursive_mutex","recursive_timed_mutex","scoped_lock","set","shared_future","shared_lock","shared_mutex","shared_timed_mutex","shared_ptr","stack","string_view","stringstream","timed_mutex","thread","true_type","tuple","unique_lock","unique_ptr","unordered_map","unordered_multimap","unordered_multiset","unordered_set","variant","vector","weak_ptr","wstring","wstring_view"]
+},b={className:"function.dispatch",relevance:0,keywords:{
+_hint:["abort","abs","acos","apply","as_const","asin","atan","atan2","calloc","ceil","cerr","cin","clog","cos","cosh","cout","declval","endl","exchange","exit","exp","fabs","floor","fmod","forward","fprintf","fputs","free","frexp","fscanf","future","invoke","isalnum","isalpha","iscntrl","isdigit","isgraph","islower","isprint","ispunct","isspace","isupper","isxdigit","labs","launder","ldexp","log","log10","make_pair","make_shared","make_shared_for_overwrite","make_tuple","make_unique","malloc","memchr","memcmp","memcpy","memset","modf","move","pow","printf","putchar","puts","realloc","scanf","sin","sinh","snprintf","sprintf","sqrt","sscanf","std","stderr","stdin","stdout","strcat","strchr","strcmp","strcpy","strcspn","strlen","strncat","strncmp","strncpy","strpbrk","strrchr","strspn","strstr","swap","tan","tanh","terminate","to_underlying","tolower","toupper","vfprintf","visit","vprintf","vsprintf"]
+},
+begin:n.concat(/\b/,/(?!decltype)/,/(?!if)/,/(?!for)/,/(?!switch)/,/(?!while)/,e.IDENT_RE,n.lookahead(/(<[^<>]+>|)\s*\(/))
+},m=[b,c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],p={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:m.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:m.concat(["self"]),relevance:0}]),relevance:0},_={className:"function",
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[d],relevance:0},{begin:/::/,relevance:0},{
+begin:/:/,endsWithParent:!0,contains:[o,l]},{relevance:0,match:/,/},{
+className:"params",begin:/\(/,end:/\)/,keywords:u,relevance:0,
+contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,end:/\)/,keywords:u,
+relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]}]
+},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C++",
+aliases:["cc","c++","h++","hpp","hh","hxx","cxx"],keywords:u,illegal:"</",
+classNameAliases:{"function.dispatch":"built_in"},
+contains:[].concat(p,_,b,m,[c,{
+begin:"\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function|flat_map|flat_set)\\s*<(?!<)",
+end:">",keywords:u,contains:["self",s]},{begin:e.IDENT_RE+"::",keywords:u},{
+match:[/\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,/\s+/,/\w+/],
+className:{1:"keyword",3:"title.class"}}])}},grmr_csharp:e=>{const n={
+keyword:["abstract","as","base","break","case","catch","class","const","continue","do","else","event","explicit","extern","finally","fixed","for","foreach","goto","if","implicit","in","interface","internal","is","lock","namespace","new","operator","out","override","params","private","protected","public","readonly","record","ref","return","scoped","sealed","sizeof","stackalloc","static","struct","switch","this","throw","try","typeof","unchecked","unsafe","using","virtual","void","volatile","while"].concat(["add","alias","and","ascending","args","async","await","by","descending","dynamic","equals","file","from","get","global","group","init","into","join","let","nameof","not","notnull","on","or","orderby","partial","record","remove","required","scoped","select","set","unmanaged","value|0","var","when","where","with","yield"]),
+built_in:["bool","byte","char","decimal","delegate","double","dynamic","enum","float","int","long","nint","nuint","object","sbyte","short","string","ulong","uint","ushort"],
+literal:["default","false","null","true"]},t=e.inherit(e.TITLE_MODE,{
+begin:"[a-zA-Z](\\.?\\w)*"}),a={className:"number",variants:[{
+begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)"},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},i={className:"string",begin:'@"',end:'"',contains:[{begin:'""'}]
+},r=e.inherit(i,{illegal:/\n/}),s={className:"subst",begin:/\{/,end:/\}/,
+keywords:n},o=e.inherit(s,{illegal:/\n/}),l={className:"string",begin:/\$"/,
+end:'"',illegal:/\n/,contains:[{begin:/\{\{/},{begin:/\}\}/
+},e.BACKSLASH_ESCAPE,o]},c={className:"string",begin:/\$@"/,end:'"',contains:[{
+begin:/\{\{/},{begin:/\}\}/},{begin:'""'},s]},d=e.inherit(c,{illegal:/\n/,
+contains:[{begin:/\{\{/},{begin:/\}\}/},{begin:'""'},o]})
+;s.contains=[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.C_BLOCK_COMMENT_MODE],
+o.contains=[d,l,r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.inherit(e.C_BLOCK_COMMENT_MODE,{
+illegal:/\n/})];const g={variants:[{className:"string",
+begin:/"""("*)(?!")(.|\n)*?"""\1/,relevance:1
+},c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},u={begin:"<",end:">",
+contains:[{beginKeywords:"in out"},t]
+},b=e.IDENT_RE+"(<"+e.IDENT_RE+"(\\s*,\\s*"+e.IDENT_RE+")*>)?(\\[\\])?",m={
+begin:"@"+e.IDENT_RE,relevance:0};return{name:"C#",aliases:["cs","c#"],
+keywords:n,illegal:/::/,contains:[e.COMMENT("///","$",{returnBegin:!0,
+contains:[{className:"doctag",variants:[{begin:"///",relevance:0},{
+begin:"\x3c!--|--\x3e"},{begin:"</?",end:">"}]}]
+}),e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"meta",begin:"#",
+end:"$",keywords:{
+keyword:"if else elif endif define undef warning error line region endregion pragma checksum"
+}},g,a,{beginKeywords:"class interface",relevance:0,end:/[{;=]/,
+illegal:/[^\s:,]/,contains:[{beginKeywords:"where class"
+},t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{beginKeywords:"namespace",
+relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"record",relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"meta",
+begin:"^\\s*\\[(?=[\\w])",excludeBegin:!0,end:"\\]",excludeEnd:!0,contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+beginKeywords:"new return throw await else",relevance:0},{className:"function",
+begin:"("+b+"\\s+)+"+e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+end:/\s*[{;=]/,excludeEnd:!0,keywords:n,contains:[{
+beginKeywords:"public private protected static internal protected abstract async extern override unsafe virtual new sealed partial",
+relevance:0},{begin:e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+contains:[e.TITLE_MODE,u],relevance:0},{match:/\(\)/},{className:"params",
+begin:/\(/,end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:n,relevance:0,
+contains:[g,a,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},m]}},grmr_css:e=>{
+const n=e.regex,t=te(e),a=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE];return{
+name:"CSS",case_insensitive:!0,illegal:/[=|'\$]/,keywords:{
+keyframePosition:"from to"},classNameAliases:{keyframePosition:"selector-tag"},
+contains:[t.BLOCK_COMMENT,{begin:/-(webkit|moz|ms|o)-(?=[a-z])/
+},t.CSS_NUMBER_MODE,{className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0
+},{className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
+},t.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
+begin:":("+re.join("|")+")"},{begin:":(:)?("+se.join("|")+")"}]
+},t.CSS_VARIABLE,{className:"attribute",begin:"\\b("+oe.join("|")+")\\b"},{
+begin:/:/,end:/[;}{]/,
+contains:[t.BLOCK_COMMENT,t.HEXCOLOR,t.IMPORTANT,t.CSS_NUMBER_MODE,...a,{
+begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
+},contains:[...a,{className:"string",begin:/[^)]/,endsWithParent:!0,
+excludeEnd:!0}]},t.FUNCTION_DISPATCH]},{begin:n.lookahead(/@/),end:"[{;]",
+relevance:0,illegal:/:/,contains:[{className:"keyword",begin:/@-?\w[\w]*(-\w+)*/
+},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,relevance:0,keywords:{
+$pattern:/[a-z-]+/,keyword:"and or not only",attribute:ie.join(" ")},contains:[{
+begin:/[a-z-]+(?=:)/,className:"attribute"},...a,t.CSS_NUMBER_MODE]}]},{
+className:"selector-tag",begin:"\\b("+ae.join("|")+")\\b"}]}},grmr_diff:e=>{
+const n=e.regex;return{name:"Diff",aliases:["patch"],contains:[{
+className:"meta",relevance:10,
+match:n.either(/^@@ +-\d+,\d+ +\+\d+,\d+ +@@/,/^\*\*\* +\d+,\d+ +\*\*\*\*$/,/^--- +\d+,\d+ +----$/)
+},{className:"comment",variants:[{
+begin:n.either(/Index: /,/^index/,/={3,}/,/^-{3}/,/^\*{3} /,/^\+{3}/,/^diff --git/),
+end:/$/},{match:/^\*{15}$/}]},{className:"addition",begin:/^\+/,end:/$/},{
+className:"deletion",begin:/^-/,end:/$/},{className:"addition",begin:/^!/,
+end:/$/}]}},grmr_go:e=>{const n={
+keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
+type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
+literal:["true","false","iota","nil"],
+built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
+};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
+variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
+className:"number",variants:[{
+match:/-?\b0[xX]\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\d(_?\d)*i?/,relevance:0
+},{
+match:/-?\b0[xX](_?[a-fA-F0-9])+((\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\d(_?\d)*)?i?/,
+relevance:0},{match:/-?\b0[oO](_?[0-7])*i?/,relevance:0},{
+match:/-?\.\d(_?\d)*([eE][+-]?\d(_?\d)*)?i?/,relevance:0},{
+match:/-?\b\d(_?\d)*(\.(\d(_?\d)*)?)?([eE][+-]?\d(_?\d)*)?i?/,relevance:0}]},{
+begin:/:=/},{className:"function",beginKeywords:"func",end:"\\s*(\\{|$)",
+excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,illegal:/["']/}]}]}},grmr_graphql:e=>{const n=e.regex
+;return{name:"GraphQL",aliases:["gql"],case_insensitive:!0,disableAutodetect:!1,
+keywords:{
+keyword:["query","mutation","subscription","type","input","schema","directive","interface","union","scalar","fragment","enum","on"],
+literal:["true","false","null"]},
+contains:[e.HASH_COMMENT_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+scope:"punctuation",match:/[.]{3}/,relevance:0},{scope:"punctuation",
+begin:/[\!\(\)\:\=\[\]\{\|\}]{1}/,relevance:0},{scope:"variable",begin:/\$/,
+end:/\W/,excludeEnd:!0,relevance:0},{scope:"meta",match:/@\w+/,excludeEnd:!0},{
+scope:"symbol",begin:n.concat(/[_A-Za-z][_0-9A-Za-z]*/,n.lookahead(/\s*:/)),
+relevance:0}],illegal:[/[;<']/,/BEGIN/]}},grmr_ini:e=>{const n=e.regex,t={
+className:"number",relevance:0,variants:[{begin:/([+-]+)?[\d]+_[\d_]+/},{
+begin:e.NUMBER_RE}]},a=e.COMMENT();a.variants=[{begin:/;/,end:/$/},{begin:/#/,
+end:/$/}];const i={className:"variable",variants:[{begin:/\$[\w\d"][\w\d_]*/},{
+begin:/\$\{(.*?)\}/}]},r={className:"literal",
+begin:/\bon|off|true|false|yes|no\b/},s={className:"string",
+contains:[e.BACKSLASH_ESCAPE],variants:[{begin:"'''",end:"'''",relevance:10},{
+begin:'"""',end:'"""',relevance:10},{begin:'"',end:'"'},{begin:"'",end:"'"}]
+},o={begin:/\[/,end:/\]/,contains:[a,r,i,s,t,"self"],relevance:0
+},l=n.either(/[A-Za-z0-9_-]+/,/"(\\"|[^"])*"/,/'[^']*'/);return{
+name:"TOML, also INI",aliases:["toml"],case_insensitive:!0,illegal:/\S/,
+contains:[a,{className:"section",begin:/\[+/,end:/\]+/},{
+begin:n.concat(l,"(\\s*\\.\\s*",l,")*",n.lookahead(/\s*=\s*[^#\s]/)),
+className:"attr",starts:{end:/$/,contains:[a,o,r,i,s,t]}}]}},grmr_java:e=>{
+const n=e.regex,t="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",a=t+be("(?:<"+t+"~~~(?:\\s*,\\s*"+t+"~~~)*>)?",/~~~/g,2),i={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits","goto","when"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},r={className:"meta",begin:"@"+t,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},s={className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:i,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,t],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[n.concat(/(?!else)/,t),/\s+/,t,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,t],className:{1:"keyword",
+3:"title.class"},contains:[s,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+a+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:i,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,
+contains:[r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,ue,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},ue,r]}},grmr_javascript:ve,
+grmr_json:e=>{const n=["true","false","null"],t={scope:"literal",
+beginKeywords:n.join(" ")};return{name:"JSON",aliases:["jsonc"],keywords:{
+literal:n},contains:[{className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+relevance:1.01},{match:/[{}[\],:]/,className:"punctuation",relevance:0
+},e.QUOTE_STRING_MODE,t,e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],
+illegal:"\\S"}},grmr_kotlin:e=>{const n={
+keyword:"abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
+built_in:"Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+literal:"true false null"},t={className:"symbol",begin:e.UNDERSCORE_IDENT_RE+"@"
+},a={className:"subst",begin:/\$\{/,end:/\}/,contains:[e.C_NUMBER_MODE]},i={
+className:"variable",begin:"\\$"+e.UNDERSCORE_IDENT_RE},r={className:"string",
+variants:[{begin:'"""',end:'"""(?=[^"])',contains:[i,a]},{begin:"'",end:"'",
+illegal:/\n/,contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"',illegal:/\n/,
+contains:[e.BACKSLASH_ESCAPE,i,a]}]};a.contains.push(r);const s={
+className:"meta",
+begin:"@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*"+e.UNDERSCORE_IDENT_RE+")?"
+},o={className:"meta",begin:"@"+e.UNDERSCORE_IDENT_RE,contains:[{begin:/\(/,
+end:/\)/,contains:[e.inherit(r,{className:"string"}),"self"]}]
+},l=ue,c=e.COMMENT("/\\*","\\*/",{contains:[e.C_BLOCK_COMMENT_MODE]}),d={
+variants:[{className:"type",begin:e.UNDERSCORE_IDENT_RE},{begin:/\(/,end:/\)/,
+contains:[]}]},g=d;return g.variants[1].contains=[d],d.variants[1].contains=[g],
+{name:"Kotlin",aliases:["kt","kts"],keywords:n,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"}]}),e.C_LINE_COMMENT_MODE,c,{className:"keyword",
+begin:/\b(break|continue|return|this)\b/,starts:{contains:[{className:"symbol",
+begin:/@\w+/}]}},t,s,o,{className:"function",beginKeywords:"fun",end:"[(]|$",
+returnBegin:!0,excludeEnd:!0,keywords:n,relevance:5,contains:[{
+begin:e.UNDERSCORE_IDENT_RE+"\\s*\\(",returnBegin:!0,relevance:0,
+contains:[e.UNDERSCORE_TITLE_MODE]},{className:"type",begin:/</,end:/>/,
+keywords:"reified",relevance:0},{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,relevance:0,contains:[{begin:/:/,end:/[=,\/]/,
+endsWithParent:!0,contains:[d,e.C_LINE_COMMENT_MODE,c],relevance:0
+},e.C_LINE_COMMENT_MODE,c,s,o,r,e.C_NUMBER_MODE]},c]},{
+begin:[/class|interface|trait/,/\s+/,e.UNDERSCORE_IDENT_RE],beginScope:{
+3:"title.class"},keywords:"class interface trait",end:/[:\{(]|$/,excludeEnd:!0,
+illegal:"extends implements",contains:[{
+beginKeywords:"public protected internal private constructor"
+},e.UNDERSCORE_TITLE_MODE,{className:"type",begin:/</,end:/>/,excludeBegin:!0,
+excludeEnd:!0,relevance:0},{className:"type",begin:/[,:]\s*/,end:/[<\(,){\s]|$/,
+excludeBegin:!0,returnEnd:!0},s,o]},r,{className:"meta",begin:"^#!/usr/bin/env",
+end:"$",illegal:"\n"},l]}},grmr_less:e=>{
+const n=te(e),t=le,a="[\\w-]+",i="("+a+"|@\\{"+a+"\\})",r=[],s=[],o=e=>({
+className:"string",begin:"~?"+e+".*?"+e}),l=(e,n,t)=>({className:e,begin:n,
+relevance:t}),c={$pattern:/[a-z-]+/,keyword:"and or not only",
+attribute:ie.join(" ")},d={begin:"\\(",end:"\\)",contains:s,keywords:c,
+relevance:0}
+;s.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,o("'"),o('"'),n.CSS_NUMBER_MODE,{
+begin:"(url|data-uri)\\(",starts:{className:"string",end:"[\\)\\n]",
+excludeEnd:!0}
+},n.HEXCOLOR,d,l("variable","@@?"+a,10),l("variable","@\\{"+a+"\\}"),l("built_in","~?`[^`]*?`"),{
+className:"attribute",begin:a+"\\s*:",end:":",returnBegin:!0,excludeEnd:!0
+},n.IMPORTANT,{beginKeywords:"and not"},n.FUNCTION_DISPATCH);const g=s.concat({
+begin:/\{/,end:/\}/,contains:r}),u={beginKeywords:"when",endsWithParent:!0,
+contains:[{beginKeywords:"and not"}].concat(s)},b={begin:i+"\\s*:",
+returnBegin:!0,end:/[;}]/,relevance:0,contains:[{begin:/-(webkit|moz|ms|o)-/
+},n.CSS_VARIABLE,{className:"attribute",begin:"\\b("+oe.join("|")+")\\b",
+end:/(?=:)/,starts:{endsWithParent:!0,illegal:"[<=$]",relevance:0,contains:s}}]
+},m={className:"keyword",
+begin:"@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
+starts:{end:"[;{}]",keywords:c,returnEnd:!0,contains:s,relevance:0}},p={
+className:"variable",variants:[{begin:"@"+a+"\\s*:",relevance:15},{begin:"@"+a
+}],starts:{end:"[;}]",returnEnd:!0,contains:g}},_={variants:[{
+begin:"[\\.#:&\\[>]",end:"[;{}]"},{begin:i,end:/\{/}],returnBegin:!0,
+returnEnd:!0,illegal:"[<='$\"]",relevance:0,
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,u,l("keyword","all\\b"),l("variable","@\\{"+a+"\\}"),{
+begin:"\\b("+ae.join("|")+")\\b",className:"selector-tag"
+},n.CSS_NUMBER_MODE,l("selector-tag",i,0),l("selector-id","#"+i),l("selector-class","\\."+i,0),l("selector-tag","&",0),n.ATTRIBUTE_SELECTOR_MODE,{
+className:"selector-pseudo",begin:":("+re.join("|")+")"},{
+className:"selector-pseudo",begin:":(:)?("+se.join("|")+")"},{begin:/\(/,
+end:/\)/,relevance:0,contains:g},{begin:"!important"},n.FUNCTION_DISPATCH]},h={
+begin:a+":(:)?"+`(${t.join("|")})`,returnBegin:!0,contains:[_]}
+;return r.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,m,p,h,b,_,u,n.FUNCTION_DISPATCH),
+{name:"Less",case_insensitive:!0,illegal:"[=>'/<($\"]",contains:r}},
+grmr_lua:e=>{const n="\\[=*\\[",t="\\]=*\\]",a={begin:n,end:t,contains:["self"]
+},i=[e.COMMENT("--(?!"+n+")","$"),e.COMMENT("--"+n,t,{contains:[a],relevance:10
+})];return{name:"Lua",aliases:["pluto"],keywords:{
+$pattern:e.UNDERSCORE_IDENT_RE,literal:"true false nil",
+keyword:"and break do else elseif end for goto if in local not or repeat return then until while",
+built_in:"_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove"
+},contains:i.concat([{className:"function",beginKeywords:"function",end:"\\)",
+contains:[e.inherit(e.TITLE_MODE,{
+begin:"([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*"}),{className:"params",
+begin:"\\(",endsWithParent:!0,contains:i}].concat(i)
+},e.C_NUMBER_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{className:"string",
+begin:n,end:t,contains:[a],relevance:5}])}},grmr_makefile:e=>{const n={
+className:"variable",variants:[{begin:"\\$\\("+e.UNDERSCORE_IDENT_RE+"\\)",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\$[@%<?\^\+\*]/}]},t={className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE,n]},a={className:"variable",
+begin:/\$\([\w-]+\s/,end:/\)/,keywords:{
+built_in:"subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value"
+},contains:[n,t]},i={begin:"^"+e.UNDERSCORE_IDENT_RE+"\\s*(?=[:+?]?=)"},r={
+className:"section",begin:/^[^\s]+:/,end:/$/,contains:[n]};return{
+name:"Makefile",aliases:["mk","mak","make"],keywords:{$pattern:/[\w-]+/,
+keyword:"define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath"
+},contains:[e.HASH_COMMENT_MODE,n,t,a,i,{className:"meta",begin:/^\.PHONY:/,
+end:/$/,keywords:{$pattern:/[\.\w]+/,keyword:".PHONY"}},r]}},grmr_markdown:e=>{
+const n={begin:/<\/?[A-Za-z_]/,end:">",subLanguage:"xml",relevance:0},t={
+variants:[{begin:/\[.+?\]\[.*?\]/,relevance:0},{
+begin:/\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
+relevance:2},{
+begin:e.regex.concat(/\[.+?\]\(/,/[A-Za-z][A-Za-z0-9+.-]*/,/:\/\/.*?\)/),
+relevance:2},{begin:/\[.+?\]\([./?&#].*?\)/,relevance:1},{
+begin:/\[.*?\]\(.*?\)/,relevance:0}],returnBegin:!0,contains:[{match:/\[(?=\])/
+},{className:"string",relevance:0,begin:"\\[",end:"\\]",excludeBegin:!0,
+returnEnd:!0},{className:"link",relevance:0,begin:"\\]\\(",end:"\\)",
+excludeBegin:!0,excludeEnd:!0},{className:"symbol",relevance:0,begin:"\\]\\[",
+end:"\\]",excludeBegin:!0,excludeEnd:!0}]},a={className:"strong",contains:[],
+variants:[{begin:/_{2}(?!\s)/,end:/_{2}/},{begin:/\*{2}(?!\s)/,end:/\*{2}/}]
+},i={className:"emphasis",contains:[],variants:[{begin:/\*(?![*\s])/,end:/\*/},{
+begin:/_(?![_\s])/,end:/_/,relevance:0}]},r=e.inherit(a,{contains:[]
+}),s=e.inherit(i,{contains:[]});a.contains.push(s),i.contains.push(r)
+;let o=[n,t];return[a,i,r,s].forEach((e=>{e.contains=e.contains.concat(o)
+})),o=o.concat(a,i),{name:"Markdown",aliases:["md","mkdown","mkd"],contains:[{
+className:"section",variants:[{begin:"^#{1,6}",end:"$",contains:o},{
+begin:"(?=^.+?\\n[=-]{2,}$)",contains:[{begin:"^[=-]*$"},{begin:"^",end:"\\n",
+contains:o}]}]},n,{className:"bullet",begin:"^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
+end:"\\s+",excludeEnd:!0},a,i,{className:"quote",begin:"^>\\s+",contains:o,
+end:"$"},{className:"code",variants:[{begin:"(`{3,})[^`](.|\\n)*?\\1`*[ ]*"},{
+begin:"(~{3,})[^~](.|\\n)*?\\1~*[ ]*"},{begin:"```",end:"```+[ ]*$"},{
+begin:"~~~",end:"~~~+[ ]*$"},{begin:"`.+?`"},{begin:"(?=^( {4}|\\t))",
+contains:[{begin:"^( {4}|\\t)",end:"(\\n)$"}],relevance:0}]},{
+begin:"^[-\\*]{3,}",end:"$"},t,{begin:/^\[[^\n]+\]:/,returnBegin:!0,contains:[{
+className:"symbol",begin:/\[/,end:/\]/,excludeBegin:!0,excludeEnd:!0},{
+className:"link",begin:/:\s*/,end:/$/,excludeBegin:!0}]},{scope:"literal",
+match:/&([a-zA-Z0-9]+|#[0-9]{1,7}|#[Xx][0-9a-fA-F]{1,6});/}]}},
+grmr_objectivec:e=>{const n=/[a-zA-Z@][a-zA-Z0-9_]*/,t={$pattern:n,
+keyword:["@interface","@class","@protocol","@implementation"]};return{
+name:"Objective-C",aliases:["mm","objc","obj-c","obj-c++","objective-c++"],
+keywords:{"variable.language":["this","super"],$pattern:n,
+keyword:["while","export","sizeof","typedef","const","struct","for","union","volatile","static","mutable","if","do","return","goto","enum","else","break","extern","asm","case","default","register","explicit","typename","switch","continue","inline","readonly","assign","readwrite","self","@synchronized","id","typeof","nonatomic","IBOutlet","IBAction","strong","weak","copy","in","out","inout","bycopy","byref","oneway","__strong","__weak","__block","__autoreleasing","@private","@protected","@public","@try","@property","@end","@throw","@catch","@finally","@autoreleasepool","@synthesize","@dynamic","@selector","@optional","@required","@encode","@package","@import","@defs","@compatibility_alias","__bridge","__bridge_transfer","__bridge_retained","__bridge_retain","__covariant","__contravariant","__kindof","_Nonnull","_Nullable","_Null_unspecified","__FUNCTION__","__PRETTY_FUNCTION__","__attribute__","getter","setter","retain","unsafe_unretained","nonnull","nullable","null_unspecified","null_resettable","class","instancetype","NS_DESIGNATED_INITIALIZER","NS_UNAVAILABLE","NS_REQUIRES_SUPER","NS_RETURNS_INNER_POINTER","NS_INLINE","NS_AVAILABLE","NS_DEPRECATED","NS_ENUM","NS_OPTIONS","NS_SWIFT_UNAVAILABLE","NS_ASSUME_NONNULL_BEGIN","NS_ASSUME_NONNULL_END","NS_REFINED_FOR_SWIFT","NS_SWIFT_NAME","NS_SWIFT_NOTHROW","NS_DURING","NS_HANDLER","NS_ENDHANDLER","NS_VALUERETURN","NS_VOIDRETURN"],
+literal:["false","true","FALSE","TRUE","nil","YES","NO","NULL"],
+built_in:["dispatch_once_t","dispatch_queue_t","dispatch_sync","dispatch_async","dispatch_once"],
+type:["int","float","char","unsigned","signed","short","long","double","wchar_t","unichar","void","bool","BOOL","id|0","_Bool"]
+},illegal:"</",contains:[{className:"built_in",
+begin:"\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,e.C_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{
+className:"string",variants:[{begin:'@"',end:'"',illegal:"\\n",
+contains:[e.BACKSLASH_ESCAPE]}]},{className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,
+keywords:{
+keyword:"if else elif endif define undef warning error line pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(e.QUOTE_STRING_MODE,{
+className:"string"}),{className:"string",begin:/<.*?>/,end:/$/,illegal:"\\n"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"class",
+begin:"("+t.keyword.join("|")+")\\b",end:/(\{|$)/,excludeEnd:!0,keywords:t,
+contains:[e.UNDERSCORE_TITLE_MODE]},{begin:"\\."+e.UNDERSCORE_IDENT_RE,
+relevance:0}]}},grmr_perl:e=>{const n=e.regex,t=/[dualxmsipngr]{0,12}/,a={
+$pattern:/[\w.]+/,
+keyword:"abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot class close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl field fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map method mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0"
+},i={className:"subst",begin:"[$@]\\{",end:"\\}",keywords:a},r={begin:/->\{/,
+end:/\}/},s={scope:"attr",match:/\s+:\s*\w+(\s*\(.*?\))?/},o={scope:"variable",
+variants:[{begin:/\$\d/},{
+begin:n.concat(/[$%@](?!")(\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,"(?![A-Za-z])(?![@$%])")
+},{begin:/[$%@](?!")[^\s\w{=]|\$=/,relevance:0}],contains:[s]},l={
+className:"number",variants:[{match:/0?\.[0-9][0-9_]+\b/},{
+match:/\bv?(0|[1-9][0-9_]*(\.[0-9_]+)?|[1-9][0-9_]*)\b/},{
+match:/\b0[0-7][0-7_]*\b/},{match:/\b0x[0-9a-fA-F][0-9a-fA-F_]*\b/},{
+match:/\b0b[0-1][0-1_]*\b/}],relevance:0
+},c=[e.BACKSLASH_ESCAPE,i,o],d=[/!/,/\//,/\|/,/\?/,/'/,/"/,/#/],g=(e,a,i="\\1")=>{
+const r="\\1"===i?i:n.concat(i,a)
+;return n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,r,/(?:\\.|[^\\\/])*?/,i,t)
+},u=(e,a,i)=>n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,i,t),b=[o,e.HASH_COMMENT_MODE,e.COMMENT(/^=\w/,/=cut/,{
+endsWithParent:!0}),r,{className:"string",contains:c,variants:[{
+begin:"q[qwxr]?\\s*\\(",end:"\\)",relevance:5},{begin:"q[qwxr]?\\s*\\[",
+end:"\\]",relevance:5},{begin:"q[qwxr]?\\s*\\{",end:"\\}",relevance:5},{
+begin:"q[qwxr]?\\s*\\|",end:"\\|",relevance:5},{begin:"q[qwxr]?\\s*<",end:">",
+relevance:5},{begin:"qw\\s+q",end:"q",relevance:5},{begin:"'",end:"'",
+contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"'},{begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\{\w+\}/,relevance:0},{
+begin:"-?\\w+\\s*=>",relevance:0}]},l,{
+begin:"(\\/\\/|"+e.RE_STARTERS_RE+"|\\b(split|return|print|reverse|grep)\\b)\\s*",
+keywords:"split return print reverse grep",relevance:0,
+contains:[e.HASH_COMMENT_MODE,{className:"regexp",variants:[{
+begin:g("s|tr|y",n.either(...d,{capture:!0}))},{begin:g("s|tr|y","\\(","\\)")},{
+begin:g("s|tr|y","\\[","\\]")},{begin:g("s|tr|y","\\{","\\}")}],relevance:2},{
+className:"regexp",variants:[{begin:/(m|qr)\/\//,relevance:0},{
+begin:u("(?:m|qr)?",/\//,/\//)},{begin:u("m|qr",n.either(...d,{capture:!0
+}),/\1/)},{begin:u("m|qr",/\(/,/\)/)},{begin:u("m|qr",/\[/,/\]/)},{
+begin:u("m|qr",/\{/,/\}/)}]}]},{className:"function",beginKeywords:"sub method",
+end:"(\\s*\\(.*?\\))?[;{]",excludeEnd:!0,relevance:5,contains:[e.TITLE_MODE,s]
+},{className:"class",beginKeywords:"class",end:"[;{]",excludeEnd:!0,relevance:5,
+contains:[e.TITLE_MODE,s,l]},{begin:"-\\w\\b",relevance:0},{begin:"^__DATA__$",
+end:"^__END__$",subLanguage:"mojolicious",contains:[{begin:"^@@.*",end:"$",
+className:"comment"}]}];return i.contains=b,r.contains=b,{name:"Perl",
+aliases:["pl","pm"],keywords:a,contains:b}},grmr_php:e=>{
+const n=e.regex,t=/(?![A-Za-z0-9])(?![$])/,a=n.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,t),i=n.concat(/(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,t),r=n.concat(/[A-Z]+/,t),s={
+scope:"variable",match:"\\$+"+a},o={scope:"subst",variants:[{begin:/\$\w+/},{
+begin:/\{\$/,end:/\}/}]},l=e.inherit(e.APOS_STRING_MODE,{illegal:null
+}),c="[ \t\n]",d={scope:"string",variants:[e.inherit(e.QUOTE_STRING_MODE,{
+illegal:null,contains:e.QUOTE_STRING_MODE.contains.concat(o)}),l,{
+begin:/<<<[ \t]*(?:(\w+)|"(\w+)")\n/,end:/[ \t]*(\w+)\b/,
+contains:e.QUOTE_STRING_MODE.contains.concat(o),"on:begin":(e,n)=>{
+n.data._beginMatch=e[1]||e[2]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}},e.END_SAME_AS_BEGIN({
+begin:/<<<[ \t]*'(\w+)'\n/,end:/[ \t]*(\w+)\b/})]},g={scope:"number",variants:[{
+begin:"\\b0[bB][01]+(?:_[01]+)*\\b"},{begin:"\\b0[oO][0-7]+(?:_[0-7]+)*\\b"},{
+begin:"\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b"},{
+begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?"
+}],relevance:0
+},u=["false","null","true"],b=["__CLASS__","__DIR__","__FILE__","__FUNCTION__","__COMPILER_HALT_OFFSET__","__LINE__","__METHOD__","__NAMESPACE__","__TRAIT__","die","echo","exit","include","include_once","print","require","require_once","array","abstract","and","as","binary","bool","boolean","break","callable","case","catch","class","clone","const","continue","declare","default","do","double","else","elseif","empty","enddeclare","endfor","endforeach","endif","endswitch","endwhile","enum","eval","extends","final","finally","float","for","foreach","from","global","goto","if","implements","instanceof","insteadof","int","integer","interface","isset","iterable","list","match|0","mixed","new","never","object","or","private","protected","public","readonly","real","return","string","switch","throw","trait","try","unset","use","var","void","while","xor","yield"],m=["Error|0","AppendIterator","ArgumentCountError","ArithmeticError","ArrayIterator","ArrayObject","AssertionError","BadFunctionCallException","BadMethodCallException","CachingIterator","CallbackFilterIterator","CompileError","Countable","DirectoryIterator","DivisionByZeroError","DomainException","EmptyIterator","ErrorException","Exception","FilesystemIterator","FilterIterator","GlobIterator","InfiniteIterator","InvalidArgumentException","IteratorIterator","LengthException","LimitIterator","LogicException","MultipleIterator","NoRewindIterator","OutOfBoundsException","OutOfRangeException","OuterIterator","OverflowException","ParentIterator","ParseError","RangeException","RecursiveArrayIterator","RecursiveCachingIterator","RecursiveCallbackFilterIterator","RecursiveDirectoryIterator","RecursiveFilterIterator","RecursiveIterator","RecursiveIteratorIterator","RecursiveRegexIterator","RecursiveTreeIterator","RegexIterator","RuntimeException","SeekableIterator","SplDoublyLinkedList","SplFileInfo","SplFileObject","SplFixedArray","SplHeap","SplMaxHeap","SplMinHeap","SplObjectStorage","SplObserver","SplPriorityQueue","SplQueue","SplStack","SplSubject","SplTempFileObject","TypeError","UnderflowException","UnexpectedValueException","UnhandledMatchError","ArrayAccess","BackedEnum","Closure","Fiber","Generator","Iterator","IteratorAggregate","Serializable","Stringable","Throwable","Traversable","UnitEnum","WeakReference","WeakMap","Directory","__PHP_Incomplete_Class","parent","php_user_filter","self","static","stdClass"],p={
+keyword:b,literal:(e=>{const n=[];return e.forEach((e=>{
+n.push(e),e.toLowerCase()===e?n.push(e.toUpperCase()):n.push(e.toLowerCase())
+})),n})(u),built_in:m},_=e=>e.map((e=>e.replace(/\|\d+$/,""))),h={variants:[{
+match:[/new/,n.concat(c,"+"),n.concat("(?!",_(m).join("\\b|"),"\\b)"),i],scope:{
+1:"keyword",4:"title.class"}}]},f=n.concat(a,"\\b(?!\\()"),E={variants:[{
+match:[n.concat(/::/,n.lookahead(/(?!class\b)/)),f],scope:{2:"variable.constant"
+}},{match:[/::/,/class/],scope:{2:"variable.language"}},{
+match:[i,n.concat(/::/,n.lookahead(/(?!class\b)/)),f],scope:{1:"title.class",
+3:"variable.constant"}},{match:[i,n.concat("::",n.lookahead(/(?!class\b)/))],
+scope:{1:"title.class"}},{match:[i,/::/,/class/],scope:{1:"title.class",
+3:"variable.language"}}]},y={scope:"attr",
+match:n.concat(a,n.lookahead(":"),n.lookahead(/(?!::)/))},w={relevance:0,
+begin:/\(/,end:/\)/,keywords:p,contains:[y,s,E,e.C_BLOCK_COMMENT_MODE,d,g,h]
+},v={relevance:0,
+match:[/\b/,n.concat("(?!fn\\b|function\\b|",_(b).join("\\b|"),"|",_(m).join("\\b|"),"\\b)"),a,n.concat(c,"*"),n.lookahead(/(?=\()/)],
+scope:{3:"title.function.invoke"},contains:[w]};w.contains.push(v)
+;const N=[y,E,e.C_BLOCK_COMMENT_MODE,d,g,h],k={
+begin:n.concat(/#\[\s*\\?/,n.either(i,r)),beginScope:"meta",end:/]/,
+endScope:"meta",keywords:{literal:u,keyword:["new","array"]},contains:[{
+begin:/\[/,end:/]/,keywords:{literal:u,keyword:["new","array"]},
+contains:["self",...N]},...N,{scope:"meta",variants:[{match:i},{match:r}]}]}
+;return{case_insensitive:!1,keywords:p,
+contains:[k,e.HASH_COMMENT_MODE,e.COMMENT("//","$"),e.COMMENT("/\\*","\\*/",{
+contains:[{scope:"doctag",match:"@[A-Za-z]+"}]}),{match:/__halt_compiler\(\);/,
+keywords:"__halt_compiler",starts:{scope:"comment",end:e.MATCH_NOTHING_RE,
+contains:[{match:/\?>/,scope:"meta",endsParent:!0}]}},{scope:"meta",variants:[{
+begin:/<\?php/,relevance:10},{begin:/<\?=/},{begin:/<\?/,relevance:.1},{
+begin:/\?>/}]},{scope:"variable.language",match:/\$this\b/},s,v,E,{
+match:[/const/,/\s/,a],scope:{1:"keyword",3:"variable.constant"}},h,{
+scope:"function",relevance:0,beginKeywords:"fn function",end:/[;{]/,
+excludeEnd:!0,illegal:"[$%\\[]",contains:[{beginKeywords:"use"
+},e.UNDERSCORE_TITLE_MODE,{begin:"=>",endsParent:!0},{scope:"params",
+begin:"\\(",end:"\\)",excludeBegin:!0,excludeEnd:!0,keywords:p,
+contains:["self",k,s,E,e.C_BLOCK_COMMENT_MODE,d,g]}]},{scope:"class",variants:[{
+beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
+illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
+beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
+beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
+contains:[e.inherit(e.UNDERSCORE_TITLE_MODE,{scope:"title.class"})]},{
+beginKeywords:"use",relevance:0,end:";",contains:[{
+match:/\b(as|const|function)\b/,scope:"keyword"},e.UNDERSCORE_TITLE_MODE]},d,g]}
+},grmr_php_template:e=>({name:"PHP template",subLanguage:"xml",contains:[{
+begin:/<\?(php|=)?/,end:/\?>/,subLanguage:"php",contains:[{begin:"/\\*",
+end:"\\*/",skip:!0},{begin:'b"',end:'"',skip:!0},{begin:"b'",end:"'",skip:!0
+},e.inherit(e.APOS_STRING_MODE,{illegal:null,className:null,contains:null,
+skip:!0}),e.inherit(e.QUOTE_STRING_MODE,{illegal:null,className:null,
+contains:null,skip:!0})]}]}),grmr_plaintext:e=>({name:"Plain text",
+aliases:["text","txt"],disableAutodetect:!0}),grmr_python:e=>{
+const n=e.regex,t=/[\p{XID_Start}_]\p{XID_Continue}*/u,a=["and","as","assert","async","await","break","case","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","match","nonlocal|10","not","or","pass","raise","return","try","while","with","yield"],i={
+$pattern:/[A-Za-z]\w+|__\w+__/,keyword:a,
+built_in:["__import__","abs","all","any","ascii","bin","bool","breakpoint","bytearray","bytes","callable","chr","classmethod","compile","complex","delattr","dict","dir","divmod","enumerate","eval","exec","filter","float","format","frozenset","getattr","globals","hasattr","hash","help","hex","id","input","int","isinstance","issubclass","iter","len","list","locals","map","max","memoryview","min","next","object","oct","open","ord","pow","print","property","range","repr","reversed","round","set","setattr","slice","sorted","staticmethod","str","sum","super","tuple","type","vars","zip"],
+literal:["__debug__","Ellipsis","False","None","NotImplemented","True"],
+type:["Any","Callable","Coroutine","Dict","List","Literal","Generic","Optional","Sequence","Set","Tuple","Type","Union"]
+},r={className:"meta",begin:/^(>>>|\.\.\.) /},s={className:"subst",begin:/\{/,
+end:/\}/,keywords:i,illegal:/#/},o={begin:/\{\{/,relevance:0},l={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,end:/"""/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([fF][rR]|[rR][fF]|[fF])'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"""/,
+end:/"""/,contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([uU]|[rR])'/,end:/'/,
+relevance:10},{begin:/([uU]|[rR])"/,end:/"/,relevance:10},{
+begin:/([bB]|[bB][rR]|[rR][bB])'/,end:/'/},{begin:/([bB]|[bB][rR]|[rR][bB])"/,
+end:/"/},{begin:/([fF][rR]|[rR][fF]|[fF])'/,end:/'/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},c="[0-9](_?[0-9])*",d=`(\\b(${c}))?\\.(${c})|\\b(${c})\\.`,g="\\b|"+a.join("|"),u={
+className:"number",relevance:0,variants:[{
+begin:`(\\b(${c})|(${d}))[eE][+-]?(${c})[jJ]?(?=${g})`},{begin:`(${d})[jJ]?`},{
+begin:`\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${g})`},{
+begin:`\\b0[bB](_?[01])+[lL]?(?=${g})`},{begin:`\\b0[oO](_?[0-7])+[lL]?(?=${g})`
+},{begin:`\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${g})`},{begin:`\\b(${c})[jJ](?=${g})`
+}]},b={className:"comment",begin:n.lookahead(/# type:/),end:/$/,keywords:i,
+contains:[{begin:/# type:/},{begin:/#/,end:/\b\B/,endsWithParent:!0}]},m={
+className:"params",variants:[{className:"",begin:/\(\s*\)/,skip:!0},{begin:/\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,
+contains:["self",r,u,l,e.HASH_COMMENT_MODE]}]};return s.contains=[l,u,r],{
+name:"Python",aliases:["py","gyp","ipython"],unicodeRegex:!0,keywords:i,
+illegal:/(<\/|\?)|=>/,contains:[r,u,{scope:"variable.language",match:/\bself\b/
+},{beginKeywords:"if",relevance:0},{match:/\bor\b/,scope:"keyword"
+},l,b,e.HASH_COMMENT_MODE,{match:[/\bdef/,/\s+/,t],scope:{1:"keyword",
+3:"title.function"},contains:[m]},{variants:[{
+match:[/\bclass/,/\s+/,t,/\s*/,/\(\s*/,t,/\s*\)/]},{match:[/\bclass/,/\s+/,t]}],
+scope:{1:"keyword",3:"title.class",6:"title.class.inherited"}},{
+className:"meta",begin:/^[\t ]*@/,end:/(?=#)|$/,contains:[u,m,l]}]}},
+grmr_python_repl:e=>({aliases:["pycon"],contains:[{className:"meta.prompt",
+starts:{end:/ |$/,starts:{end:"$",subLanguage:"python"}},variants:[{
+begin:/^>>>(?=[ ]|$)/},{begin:/^\.\.\.(?=[ ]|$)/}]}]}),grmr_r:e=>{
+const n=e.regex,t=/(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/,a=n.either(/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,/0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/,/(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/),i=/[=!<>:]=|\|\||&&|:::?|<-|<<-|->>|->|\|>|[-+*\/?!$&|:<=>@^~]|\*\*/,r=n.either(/[()]/,/[{}]/,/\[\[/,/[[\]]/,/\\/,/,/)
+;return{name:"R",keywords:{$pattern:t,
+keyword:"function if in break next repeat else for while",
+literal:"NULL NA TRUE FALSE Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
+built_in:"LETTERS letters month.abb month.name pi T F abs acos acosh all any anyNA Arg as.call as.character as.complex as.double as.environment as.integer as.logical as.null.default as.numeric as.raw asin asinh atan atanh attr attributes baseenv browser c call ceiling class Conj cos cosh cospi cummax cummin cumprod cumsum digamma dim dimnames emptyenv exp expression floor forceAndCall gamma gc.time globalenv Im interactive invisible is.array is.atomic is.call is.character is.complex is.double is.environment is.expression is.finite is.function is.infinite is.integer is.language is.list is.logical is.matrix is.na is.name is.nan is.null is.numeric is.object is.pairlist is.raw is.recursive is.single is.symbol lazyLoadDBfetch length lgamma list log max min missing Mod names nargs nzchar oldClass on.exit pos.to.env proc.time prod quote range Re rep retracemem return round seq_along seq_len seq.int sign signif sin sinh sinpi sqrt standardGeneric substitute sum switch tan tanh tanpi tracemem trigamma trunc unclass untracemem UseMethod xtfrm"
+},contains:[e.COMMENT(/#'/,/$/,{contains:[{scope:"doctag",match:/@examples/,
+starts:{end:n.lookahead(n.either(/\n^#'\s*(?=@[a-zA-Z]+)/,/\n^(?!#')/)),
+endsParent:!0}},{scope:"doctag",begin:"@param",end:/$/,contains:[{
+scope:"variable",variants:[{match:t},{match:/`(?:\\.|[^`\\])+`/}],endsParent:!0
+}]},{scope:"doctag",match:/@[a-zA-Z]+/},{scope:"keyword",match:/\\[a-zA-Z]+/}]
+}),e.HASH_COMMENT_MODE,{scope:"string",contains:[e.BACKSLASH_ESCAPE],
+variants:[e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\(/,end:/\)(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\{/,end:/\}(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\[/,end:/\](-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\(/,end:/\)(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\{/,end:/\}(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\[/,end:/\](-*)'/}),{begin:'"',end:'"',
+relevance:0},{begin:"'",end:"'",relevance:0}]},{relevance:0,variants:[{scope:{
+1:"operator",2:"number"},match:[i,a]},{scope:{1:"operator",2:"number"},
+match:[/%[^%]*%/,a]},{scope:{1:"punctuation",2:"number"},match:[r,a]},{scope:{
+2:"number"},match:[/[^a-zA-Z0-9._]|^/,a]}]},{scope:{3:"operator"},
+match:[t,/\s+/,/<-/,/\s+/]},{scope:"operator",relevance:0,variants:[{match:i},{
+match:/%[^%]*%/}]},{scope:"punctuation",relevance:0,match:r},{begin:"`",end:"`",
+contains:[{begin:/\\./}]}]}},grmr_ruby:e=>{
+const n=e.regex,t="([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)",a=n.either(/\b([A-Z]+[a-z0-9]+)+/,/\b([A-Z]+[a-z0-9]+)+[A-Z]+/),i=n.concat(a,/(::\w+)*/),r={
+"variable.constant":["__FILE__","__LINE__","__ENCODING__"],
+"variable.language":["self","super"],
+keyword:["alias","and","begin","BEGIN","break","case","class","defined","do","else","elsif","end","END","ensure","for","if","in","module","next","not","or","redo","require","rescue","retry","return","then","undef","unless","until","when","while","yield","include","extend","prepend","public","private","protected","raise","throw"],
+built_in:["proc","lambda","attr_accessor","attr_reader","attr_writer","define_method","private_constant","module_function"],
+literal:["true","false","nil"]},s={className:"doctag",begin:"@[A-Za-z]+"},o={
+begin:"#<",end:">"},l=[e.COMMENT("#","$",{contains:[s]
+}),e.COMMENT("^=begin","^=end",{contains:[s],relevance:10
+}),e.COMMENT("^__END__",e.MATCH_NOTHING_RE)],c={className:"subst",begin:/#\{/,
+end:/\}/,keywords:r},d={className:"string",contains:[e.BACKSLASH_ESCAPE,c],
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/`/,end:/`/},{
+begin:/%[qQwWx]?\(/,end:/\)/},{begin:/%[qQwWx]?\[/,end:/\]/},{
+begin:/%[qQwWx]?\{/,end:/\}/},{begin:/%[qQwWx]?</,end:/>/},{begin:/%[qQwWx]?\//,
+end:/\//},{begin:/%[qQwWx]?%/,end:/%/},{begin:/%[qQwWx]?-/,end:/-/},{
+begin:/%[qQwWx]?\|/,end:/\|/},{begin:/\B\?(\\\d{1,3})/},{
+begin:/\B\?(\\x[A-Fa-f0-9]{1,2})/},{begin:/\B\?(\\u\{?[A-Fa-f0-9]{1,6}\}?)/},{
+begin:/\B\?(\\M-\\C-|\\M-\\c|\\c\\M-|\\M-|\\C-\\M-)[\x20-\x7e]/},{
+begin:/\B\?\\(c|C-)[\x20-\x7e]/},{begin:/\B\?\\?\S/},{
+begin:n.concat(/<<[-~]?'?/,n.lookahead(/(\w+)(?=\W)[^\n]*\n(?:[^\n]*\n)*?\s*\1\b/)),
+contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,end:/(\w+)/,
+contains:[e.BACKSLASH_ESCAPE,c]})]}]},g="[0-9](_?[0-9])*",u={className:"number",
+relevance:0,variants:[{
+begin:`\\b([1-9](_?[0-9])*|0)(\\.(${g}))?([eE][+-]?(${g})|r)?i?\\b`},{
+begin:"\\b0[dD][0-9](_?[0-9])*r?i?\\b"},{begin:"\\b0[bB][0-1](_?[0-1])*r?i?\\b"
+},{begin:"\\b0[oO][0-7](_?[0-7])*r?i?\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*r?i?\\b"},{
+begin:"\\b0(_?[0-7])+r?i?\\b"}]},b={variants:[{match:/\(\)/},{
+className:"params",begin:/\(/,end:/(?=\))/,excludeBegin:!0,endsParent:!0,
+keywords:r}]},m=[d,{variants:[{match:[/class\s+/,i,/\s+<\s+/,i]},{
+match:[/\b(class|module)\s+/,i]}],scope:{2:"title.class",
+4:"title.class.inherited"},keywords:r},{match:[/(include|extend)\s+/,i],scope:{
+2:"title.class"},keywords:r},{relevance:0,match:[i,/\.new[. (]/],scope:{
+1:"title.class"}},{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},{relevance:0,match:a,scope:"title.class"},{
+match:[/def/,/\s+/,t],scope:{1:"keyword",3:"title.function"},contains:[b]},{
+begin:e.IDENT_RE+"::"},{className:"symbol",
+begin:e.UNDERSCORE_IDENT_RE+"(!|\\?)?:",relevance:0},{className:"symbol",
+begin:":(?!\\s)",contains:[d,{begin:t}],relevance:0},u,{className:"variable",
+begin:"(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])(?![A-Za-z])(?![@$?'])"},{
+className:"params",begin:/\|(?!=)/,end:/\|/,excludeBegin:!0,excludeEnd:!0,
+relevance:0,keywords:r},{begin:"("+e.RE_STARTERS_RE+"|unless)\\s*",
+keywords:"unless",contains:[{className:"regexp",contains:[e.BACKSLASH_ESCAPE,c],
+illegal:/\n/,variants:[{begin:"/",end:"/[a-z]*"},{begin:/%r\{/,end:/\}[a-z]*/},{
+begin:"%r\\(",end:"\\)[a-z]*"},{begin:"%r!",end:"![a-z]*"},{begin:"%r\\[",
+end:"\\][a-z]*"}]}].concat(o,l),relevance:0}].concat(o,l)
+;c.contains=m,b.contains=m;const p=[{begin:/^\s*=>/,starts:{end:"$",contains:m}
+},{className:"meta.prompt",
+begin:"^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+[>*]|(\\w+-)?\\d+\\.\\d+\\.\\d+(p\\d+)?[^\\d][^>]+>)(?=[ ])",
+starts:{end:"$",keywords:r,contains:m}}];return l.unshift(o),{name:"Ruby",
+aliases:["rb","gemspec","podspec","thor","irb"],keywords:r,illegal:/\/\*/,
+contains:[e.SHEBANG({binary:"ruby"})].concat(p).concat(l).concat(m)}},
+grmr_rust:e=>{
+const n=e.regex,t=/(r#)?/,a=n.concat(t,e.UNDERSCORE_IDENT_RE),i=n.concat(t,e.IDENT_RE),r={
+className:"title.function.invoke",relevance:0,
+begin:n.concat(/\b/,/(?!let|for|while|if|else|match\b)/,i,n.lookahead(/\s*\(/))
+},s="([ui](8|16|32|64|128|size)|f(32|64))?",o=["drop ","Copy","Send","Sized","Sync","Drop","Fn","FnMut","FnOnce","ToOwned","Clone","Debug","PartialEq","PartialOrd","Eq","Ord","AsRef","AsMut","Into","From","Default","Iterator","Extend","IntoIterator","DoubleEndedIterator","ExactSizeIterator","SliceConcatExt","ToString","assert!","assert_eq!","bitflags!","bytes!","cfg!","col!","concat!","concat_idents!","debug_assert!","debug_assert_eq!","env!","eprintln!","panic!","file!","format!","format_args!","include_bytes!","include_str!","line!","local_data_key!","module_path!","option_env!","print!","println!","select!","stringify!","try!","unimplemented!","unreachable!","vec!","write!","writeln!","macro_rules!","assert_ne!","debug_assert_ne!"],l=["i8","i16","i32","i64","i128","isize","u8","u16","u32","u64","u128","usize","f32","f64","str","char","bool","Box","Option","Result","String","Vec"]
+;return{name:"Rust",aliases:["rs"],keywords:{$pattern:e.IDENT_RE+"!?",type:l,
+keyword:["abstract","as","async","await","become","box","break","const","continue","crate","do","dyn","else","enum","extern","false","final","fn","for","if","impl","in","let","loop","macro","match","mod","move","mut","override","priv","pub","ref","return","self","Self","static","struct","super","trait","true","try","type","typeof","union","unsafe","unsized","use","virtual","where","while","yield"],
+literal:["true","false","Some","None","Ok","Err"],built_in:o},illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.COMMENT("/\\*","\\*/",{contains:["self"]
+}),e.inherit(e.QUOTE_STRING_MODE,{begin:/b?"/,illegal:null}),{
+className:"symbol",begin:/'[a-zA-Z_][a-zA-Z0-9_]*(?!')/},{scope:"string",
+variants:[{begin:/b?r(#*)"(.|\n)*?"\1(?!#)/},{begin:/b?'/,end:/'/,contains:[{
+scope:"char.escape",match:/\\('|\w|x\w{2}|u\w{4}|U\w{8})/}]}]},{
+className:"number",variants:[{begin:"\\b0b([01_]+)"+s},{begin:"\\b0o([0-7_]+)"+s
+},{begin:"\\b0x([A-Fa-f0-9_]+)"+s},{
+begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+s}],relevance:0},{
+begin:[/fn/,/\s+/,a],className:{1:"keyword",3:"title.function"}},{
+className:"meta",begin:"#!?\\[",end:"\\]",contains:[{className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE]}]},{
+begin:[/let/,/\s+/,/(?:mut\s+)?/,a],className:{1:"keyword",3:"keyword",
+4:"variable"}},{begin:[/for/,/\s+/,a,/\s+/,/in/],className:{1:"keyword",
+3:"variable",5:"keyword"}},{begin:[/type/,/\s+/,a],className:{1:"keyword",
+3:"title.class"}},{begin:[/(?:trait|enum|struct|union|impl|for)/,/\s+/,a],
+className:{1:"keyword",3:"title.class"}},{begin:e.IDENT_RE+"::",keywords:{
+keyword:"Self",built_in:o,type:l}},{className:"punctuation",begin:"->"},r]}},
+grmr_scss:e=>{const n=te(e),t=se,a=re,i="@[a-z-]+",r={className:"variable",
+begin:"(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",relevance:0};return{name:"SCSS",
+case_insensitive:!0,illegal:"[=/|']",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,n.CSS_NUMBER_MODE,{
+className:"selector-id",begin:"#[A-Za-z0-9_-]+",relevance:0},{
+className:"selector-class",begin:"\\.[A-Za-z0-9_-]+",relevance:0
+},n.ATTRIBUTE_SELECTOR_MODE,{className:"selector-tag",
+begin:"\\b("+ae.join("|")+")\\b",relevance:0},{className:"selector-pseudo",
+begin:":("+a.join("|")+")"},{className:"selector-pseudo",
+begin:":(:)?("+t.join("|")+")"},r,{begin:/\(/,end:/\)/,
+contains:[n.CSS_NUMBER_MODE]},n.CSS_VARIABLE,{className:"attribute",
+begin:"\\b("+oe.join("|")+")\\b"},{
+begin:"\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b"
+},{begin:/:/,end:/[;}{]/,relevance:0,
+contains:[n.BLOCK_COMMENT,r,n.HEXCOLOR,n.CSS_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.IMPORTANT,n.FUNCTION_DISPATCH]
+},{begin:"@(page|font-face)",keywords:{$pattern:i,keyword:"@page @font-face"}},{
+begin:"@",end:"[{;]",returnBegin:!0,keywords:{$pattern:/[a-z-]+/,
+keyword:"and or not only",attribute:ie.join(" ")},contains:[{begin:i,
+className:"keyword"},{begin:/[a-z-]+(?=:)/,className:"attribute"
+},r,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.HEXCOLOR,n.CSS_NUMBER_MODE]
+},n.FUNCTION_DISPATCH]}},grmr_shell:e=>({name:"Shell Session",
+aliases:["console","shellsession"],contains:[{className:"meta.prompt",
+begin:/^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,starts:{end:/[^\\](?=\s*$)/,
+subLanguage:"bash"}}]}),grmr_sql:e=>{
+const n=e.regex,t=e.COMMENT("--","$"),a=["abs","acos","array_agg","asin","atan","avg","cast","ceil","ceiling","coalesce","corr","cos","cosh","count","covar_pop","covar_samp","cume_dist","dense_rank","deref","element","exp","extract","first_value","floor","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","last_value","lead","listagg","ln","log","log10","lower","max","min","mod","nth_value","ntile","nullif","percent_rank","percentile_cont","percentile_disc","position","position_regex","power","rank","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","row_number","sin","sinh","sqrt","stddev_pop","stddev_samp","substring","substring_regex","sum","tan","tanh","translate","translate_regex","treat","trim","trim_array","unnest","upper","value_of","var_pop","var_samp","width_bucket"],i=a,r=["abs","acos","all","allocate","alter","and","any","are","array","array_agg","array_max_cardinality","as","asensitive","asin","asymmetric","at","atan","atomic","authorization","avg","begin","begin_frame","begin_partition","between","bigint","binary","blob","boolean","both","by","call","called","cardinality","cascaded","case","cast","ceil","ceiling","char","char_length","character","character_length","check","classifier","clob","close","coalesce","collate","collect","column","commit","condition","connect","constraint","contains","convert","copy","corr","corresponding","cos","cosh","count","covar_pop","covar_samp","create","cross","cube","cume_dist","current","current_catalog","current_date","current_default_transform_group","current_path","current_role","current_row","current_schema","current_time","current_timestamp","current_path","current_role","current_transform_group_for_type","current_user","cursor","cycle","date","day","deallocate","dec","decimal","decfloat","declare","default","define","delete","dense_rank","deref","describe","deterministic","disconnect","distinct","double","drop","dynamic","each","element","else","empty","end","end_frame","end_partition","end-exec","equals","escape","every","except","exec","execute","exists","exp","external","extract","false","fetch","filter","first_value","float","floor","for","foreign","frame_row","free","from","full","function","fusion","get","global","grant","group","grouping","groups","having","hold","hour","identity","in","indicator","initial","inner","inout","insensitive","insert","int","integer","intersect","intersection","interval","into","is","join","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","language","large","last_value","lateral","lead","leading","left","like","like_regex","listagg","ln","local","localtime","localtimestamp","log","log10","lower","match","match_number","match_recognize","matches","max","member","merge","method","min","minute","mod","modifies","module","month","multiset","national","natural","nchar","nclob","new","no","none","normalize","not","nth_value","ntile","null","nullif","numeric","octet_length","occurrences_regex","of","offset","old","omit","on","one","only","open","or","order","out","outer","over","overlaps","overlay","parameter","partition","pattern","per","percent","percent_rank","percentile_cont","percentile_disc","period","portion","position","position_regex","power","precedes","precision","prepare","primary","procedure","ptf","range","rank","reads","real","recursive","ref","references","referencing","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","release","result","return","returns","revoke","right","rollback","rollup","row","row_number","rows","running","savepoint","scope","scroll","search","second","seek","select","sensitive","session_user","set","show","similar","sin","sinh","skip","smallint","some","specific","specifictype","sql","sqlexception","sqlstate","sqlwarning","sqrt","start","static","stddev_pop","stddev_samp","submultiset","subset","substring","substring_regex","succeeds","sum","symmetric","system","system_time","system_user","table","tablesample","tan","tanh","then","time","timestamp","timezone_hour","timezone_minute","to","trailing","translate","translate_regex","translation","treat","trigger","trim","trim_array","true","truncate","uescape","union","unique","unknown","unnest","update","upper","user","using","value","values","value_of","var_pop","var_samp","varbinary","varchar","varying","versioning","when","whenever","where","width_bucket","window","with","within","without","year","add","asc","collation","desc","final","first","last","view"].filter((e=>!a.includes(e))),s={
+match:n.concat(/\b/,n.either(...i),/\s*\(/),relevance:0,keywords:{built_in:i}}
+;function o(e){
+return n.concat(/\b/,n.either(...e.map((e=>e.replace(/\s+/,"\\s+")))),/\b/)}
+const l={scope:"keyword",
+match:o(["create table","insert into","primary key","foreign key","not null","alter table","add constraint","grouping sets","on overflow","character set","respect nulls","ignore nulls","nulls first","nulls last","depth first","breadth first"]),
+relevance:0};return{name:"SQL",case_insensitive:!0,illegal:/[{}]|<\//,keywords:{
+$pattern:/\b[\w\.]+/,keyword:((e,{exceptions:n,when:t}={})=>{const a=t
+;return n=n||[],e.map((e=>e.match(/\|\d+$/)||n.includes(e)?e:a(e)?e+"|0":e))
+})(r,{when:e=>e.length<3}),literal:["true","false","unknown"],
+type:["bigint","binary","blob","boolean","char","character","clob","date","dec","decfloat","decimal","float","int","integer","interval","nchar","nclob","national","numeric","real","row","smallint","time","timestamp","varchar","varying","varbinary"],
+built_in:["current_catalog","current_date","current_default_transform_group","current_path","current_role","current_schema","current_transform_group_for_type","current_user","session_user","system_time","system_user","current_time","localtime","current_timestamp","localtimestamp"]
+},contains:[{scope:"type",
+match:o(["double precision","large object","with timezone","without timezone"])
+},l,s,{scope:"variable",match:/@[a-z0-9][a-z0-9_]*/},{scope:"string",variants:[{
+begin:/'/,end:/'/,contains:[{match:/''/}]}]},{begin:/"/,end:/"/,contains:[{
+match:/""/}]},e.C_NUMBER_MODE,e.C_BLOCK_COMMENT_MODE,t,{scope:"operator",
+match:/[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,relevance:0}]}},
+grmr_swift:e=>{const n={match:/\s+/,relevance:0},t=e.COMMENT("/\\*","\\*/",{
+contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={match:[/\./,m(...ke,...xe)],
+className:{2:"keyword"}},r={match:b(/\./,m(...Me)),relevance:0
+},s=Me.filter((e=>"string"==typeof e)).concat(["_|0"]),o={variants:[{
+className:"keyword",
+match:m(...Me.filter((e=>"string"!=typeof e)).concat(Oe).map(Ne),...xe)}]},l={
+$pattern:m(/\b\w+/,/#\w+/),keyword:s.concat(Ce),literal:Ae},c=[i,r,o],g=[{
+match:b(/\./,m(...Te)),relevance:0},{className:"built_in",
+match:b(/\b/,m(...Te),/(?=\()/)}],u={match:/->/,relevance:0},p=[u,{
+className:"operator",relevance:0,variants:[{match:Ie},{match:`\\.(\\.|${De})+`}]
+}],_="([0-9]_*)+",h="([0-9a-fA-F]_*)+",f={className:"number",relevance:0,
+variants:[{match:`\\b(${_})(\\.(${_}))?([eE][+-]?(${_}))?\\b`},{
+match:`\\b0x(${h})(\\.(${h}))?([pP][+-]?(${_}))?\\b`},{match:/\b0o([0-7]_*)+\b/
+},{match:/\b0b([01]_*)+\b/}]},E=(e="")=>({className:"subst",variants:[{
+match:b(/\\/,e,/[0\\tnr"']/)},{match:b(/\\/,e,/u\{[0-9a-fA-F]{1,8}\}/)}]
+}),y=(e="")=>({className:"subst",match:b(/\\/,e,/[\t ]*(?:[\r\n]|\r\n)/)
+}),w=(e="")=>({className:"subst",label:"interpol",begin:b(/\\/,e,/\(/),end:/\)/
+}),v=(e="")=>({begin:b(e,/"""/),end:b(/"""/,e),contains:[E(e),y(e),w(e)]
+}),N=(e="")=>({begin:b(e,/"/),end:b(/"/,e),contains:[E(e),w(e)]}),k={
+className:"string",
+variants:[v(),v("#"),v("##"),v("###"),N(),N("#"),N("##"),N("###")]
+},x=[e.BACKSLASH_ESCAPE,{begin:/\[/,end:/\]/,relevance:0,
+contains:[e.BACKSLASH_ESCAPE]}],O={begin:/\/[^\s](?=[^/\n]*\/)/,end:/\//,
+contains:x},M=e=>{const n=b(e,/\//),t=b(/\//,e);return{begin:n,end:t,
+contains:[...x,{scope:"comment",begin:`#(?!.*${t})`,end:/$/}]}},A={
+scope:"regexp",variants:[M("###"),M("##"),M("#"),O]},S={match:b(/`/,$e,/`/)
+},C=[S,{className:"variable",match:/\$\d+/},{className:"variable",
+match:`\\$${Be}+`}],T=[{match:/(@|#(un)?)available/,scope:"keyword",starts:{
+contains:[{begin:/\(/,end:/\)/,keywords:je,contains:[...p,f,k]}]}},{
+scope:"keyword",match:b(/@/,m(...ze),d(m(/\(/,/\s+/)))},{scope:"meta",
+match:b(/@/,$e)}],R={match:d(/\b[A-Z]/),relevance:0,contains:[{className:"type",
+match:b(/(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)/,Be,"+")
+},{className:"type",match:Fe,relevance:0},{match:/[?!]+/,relevance:0},{
+match:/\.\.\./,relevance:0},{match:b(/\s+&\s+/,d(Fe)),relevance:0}]},D={
+begin:/</,end:/>/,keywords:l,contains:[...a,...c,...T,u,R]};R.contains.push(D)
+;const I={begin:/\(/,end:/\)/,relevance:0,keywords:l,contains:["self",{
+match:b($e,/\s*:/),keywords:"_|0",relevance:0
+},...a,A,...c,...g,...p,f,k,...C,...T,R]},L={begin:/</,end:/>/,
+keywords:"repeat each",contains:[...a,R]},B={begin:/\(/,end:/\)/,keywords:l,
+contains:[{begin:m(d(b($e,/\s*:/)),d(b($e,/\s+/,$e,/\s*:/))),end:/:/,
+relevance:0,contains:[{className:"keyword",match:/\b_\b/},{className:"params",
+match:$e}]},...a,...c,...p,f,k,...T,R,I],endsParent:!0,illegal:/["']/},$={
+match:[/(func|macro)/,/\s+/,m(S.match,$e,Ie)],className:{1:"keyword",
+3:"title.function"},contains:[L,B,n],illegal:[/\[/,/%/]},F={
+match:[/\b(?:subscript|init[?!]?)/,/\s*(?=[<(])/],className:{1:"keyword"},
+contains:[L,B,n],illegal:/\[|%/},z={match:[/operator/,/\s+/,Ie],className:{
+1:"keyword",3:"title"}},j={begin:[/precedencegroup/,/\s+/,Fe],className:{
+1:"keyword",3:"title"},contains:[R],keywords:[...Se,...Ae],end:/}/},U={
+begin:[/(struct|protocol|class|extension|enum|actor)/,/\s+/,$e,/\s*/],
+beginScope:{1:"keyword",3:"title.class"},keywords:l,contains:[L,...c,{begin:/:/,
+end:/\{/,keywords:l,contains:[{scope:"title.class.inherited",match:Fe},...c],
+relevance:0}]};for(const e of k.variants){
+const n=e.contains.find((e=>"interpol"===e.label));n.keywords=l
+;const t=[...c,...g,...p,f,k,...C];n.contains=[...t,{begin:/\(/,end:/\)/,
+contains:["self",...t]}]}return{name:"Swift",keywords:l,contains:[...a,$,F,{
+match:[/class\b/,/\s+/,/func\b/,/\s+/,/\b[A-Za-z_][A-Za-z0-9_]*\b/],scope:{
+1:"keyword",3:"keyword",5:"title.function"}},{match:[/class\b/,/\s+/,/var\b/],
+scope:{1:"keyword",3:"keyword"}},U,z,j,{beginKeywords:"import",end:/$/,
+contains:[...a],relevance:0},A,...c,...g,...p,f,k,...C,...T,R,I]}},
+grmr_typescript:e=>{
+const n=e.regex,t=ve(e),a=me,i=["any","void","number","boolean","string","object","never","symbol","bigint","unknown"],r={
+begin:[/namespace/,/\s+/,e.IDENT_RE],beginScope:{1:"keyword",3:"title.class"}
+},s={beginKeywords:"interface",end:/\{/,excludeEnd:!0,keywords:{
+keyword:"interface extends",built_in:i},contains:[t.exports.CLASS_REFERENCE]
+},o={$pattern:me,
+keyword:pe.concat(["type","interface","public","private","protected","implements","declare","abstract","readonly","enum","override","satisfies"]),
+literal:_e,built_in:we.concat(i),"variable.language":ye},l={className:"meta",
+begin:"@"+a},c=(e,n,t)=>{const a=e.contains.findIndex((e=>e.label===n))
+;if(-1===a)throw Error("can not find mode to replace");e.contains.splice(a,1,t)}
+;Object.assign(t.keywords,o),t.exports.PARAMS_CONTAINS.push(l)
+;const d=t.contains.find((e=>"attr"===e.scope)),g=Object.assign({},d,{
+match:n.concat(a,n.lookahead(/\s*\?:/))})
+;return t.exports.PARAMS_CONTAINS.push([t.exports.CLASS_REFERENCE,d,g]),
+t.contains=t.contains.concat([l,r,s,g]),
+c(t,"shebang",e.SHEBANG()),c(t,"use_strict",{className:"meta",relevance:10,
+begin:/^\s*['"]use strict['"]/
+}),t.contains.find((e=>"func.def"===e.label)).relevance=0,Object.assign(t,{
+name:"TypeScript",aliases:["ts","tsx","mts","cts"]}),t},grmr_vbnet:e=>{
+const n=e.regex,t=/\d{1,2}\/\d{1,2}\/\d{4}/,a=/\d{4}-\d{1,2}-\d{1,2}/,i=/(\d|1[012])(:\d+){0,2} *(AM|PM)/,r=/\d{1,2}(:\d{1,2}){1,2}/,s={
+className:"literal",variants:[{begin:n.concat(/# */,n.either(a,t),/ *#/)},{
+begin:n.concat(/# */,r,/ *#/)},{begin:n.concat(/# */,i,/ *#/)},{
+begin:n.concat(/# */,n.either(a,t),/ +/,n.either(i,r),/ *#/)}]
+},o=e.COMMENT(/'''/,/$/,{contains:[{className:"doctag",begin:/<\/?/,end:/>/}]
+}),l=e.COMMENT(null,/$/,{variants:[{begin:/'/},{begin:/([\t ]|^)REM(?=\s)/}]})
+;return{name:"Visual Basic .NET",aliases:["vb"],case_insensitive:!0,
+classNameAliases:{label:"symbol"},keywords:{
+keyword:"addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
+built_in:"addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
+type:"boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
+literal:"true false nothing"},
+illegal:"//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",contains:[{
+className:"string",begin:/"(""|[^/n])"C\b/},{className:"string",begin:/"/,
+end:/"/,illegal:/\n/,contains:[{begin:/""/}]},s,{className:"number",relevance:0,
+variants:[{begin:/\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/
+},{begin:/\b\d[\d_]*((U?[SIL])|[%&])?/},{begin:/&H[\dA-F_]+((U?[SIL])|[%&])?/},{
+begin:/&O[0-7_]+((U?[SIL])|[%&])?/},{begin:/&B[01_]+((U?[SIL])|[%&])?/}]},{
+className:"label",begin:/^\w+:/},o,l,{className:"meta",
+begin:/[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
+end:/$/,keywords:{
+keyword:"const disable else elseif enable end externalsource if region then"},
+contains:[l]}]}},grmr_wasm:e=>{e.regex;const n=e.COMMENT(/\(;/,/;\)/)
+;return n.contains.push("self"),{name:"WebAssembly",keywords:{$pattern:/[\w.]+/,
+keyword:["anyfunc","block","br","br_if","br_table","call","call_indirect","data","drop","elem","else","end","export","func","global.get","global.set","local.get","local.set","local.tee","get_global","get_local","global","if","import","local","loop","memory","memory.grow","memory.size","module","mut","nop","offset","param","result","return","select","set_global","set_local","start","table","tee_local","then","type","unreachable"]
+},contains:[e.COMMENT(/;;/,/$/),n,{match:[/(?:offset|align)/,/\s*/,/=/],
+className:{1:"keyword",3:"operator"}},{className:"variable",begin:/\$[\w_]+/},{
+match:/(\((?!;)|\))+/,className:"punctuation",relevance:0},{
+begin:[/(?:func|call|call_indirect)/,/\s+/,/\$[^\s)]+/],className:{1:"keyword",
+3:"title.function"}},e.QUOTE_STRING_MODE,{match:/(i32|i64|f32|f64)(?!\.)/,
+className:"type"},{className:"keyword",
+match:/\b(f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))\b/
+},{className:"number",relevance:0,
+match:/[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/
+}]}},grmr_xml:e=>{
+const n=e.regex,t=n.concat(/[\p{L}_]/u,n.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),a={
+className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},i={begin:/\s/,
+contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
+},r=e.inherit(i,{begin:/\(/,end:/\)/}),s=e.inherit(e.APOS_STRING_MODE,{
+className:"string"}),o=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),l={
+endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
+begin:/[\p{L}0-9._:-]+/u,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
+className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[a]},{
+begin:/'/,end:/'/,contains:[a]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
+name:"HTML, XML",
+aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
+case_insensitive:!0,unicodeRegex:!0,contains:[{className:"meta",begin:/<![a-z]/,
+end:/>/,relevance:10,contains:[i,o,s,r,{begin:/\[/,end:/\]/,contains:[{
+className:"meta",begin:/<![a-z]/,end:/>/,contains:[i,r,o,s]}]}]
+},e.COMMENT(/<!--/,/-->/,{relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,
+relevance:10},a,{className:"meta",end:/\?>/,variants:[{begin:/<\?xml/,
+relevance:10,contains:[o]},{begin:/<\?[a-z][a-z0-9]+/}]},{className:"tag",
+begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[l],starts:{
+end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
+begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[l],starts:{
+end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
+className:"tag",begin:/<>|<\/>/},{className:"tag",
+begin:n.concat(/</,n.lookahead(n.concat(t,n.either(/\/>/,/>/,/\s/)))),
+end:/\/?>/,contains:[{className:"name",begin:t,relevance:0,starts:l}]},{
+className:"tag",begin:n.concat(/<\//,n.lookahead(n.concat(t,/>/))),contains:[{
+className:"name",begin:t,relevance:0},{begin:/>/,relevance:0,endsParent:!0}]}]}
+},grmr_yaml:e=>{
+const n="true false yes no null",t="[\\w#;/?:@&=+$,.~*'()[\\]]+",a={
+className:"string",relevance:0,variants:[{begin:/"/,end:/"/},{begin:/\S+/}],
+contains:[e.BACKSLASH_ESCAPE,{className:"template-variable",variants:[{
+begin:/\{\{/,end:/\}\}/},{begin:/%\{/,end:/\}/}]}]},i=e.inherit(a,{variants:[{
+begin:/'/,end:/'/,contains:[{begin:/''/,relevance:0}]},{begin:/"/,end:/"/},{
+begin:/[^\s,{}[\]]+/}]}),r={end:",",endsWithParent:!0,excludeEnd:!0,keywords:n,
+relevance:0},s={begin:/\{/,end:/\}/,contains:[r],illegal:"\\n",relevance:0},o={
+begin:"\\[",end:"\\]",contains:[r],illegal:"\\n",relevance:0},l=[{
+className:"attr",variants:[{begin:/[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)/},{
+begin:/"[\w*@][\w*@ :()\./-]*":(?=[ \t]|$)/},{
+begin:/'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)/}]},{className:"meta",
+begin:"^---\\s*$",relevance:10},{className:"string",
+begin:"[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*"},{
+begin:"<%[%=-]?",end:"[%-]?%>",subLanguage:"ruby",excludeBegin:!0,excludeEnd:!0,
+relevance:0},{className:"type",begin:"!\\w+!"+t},{className:"type",
+begin:"!<"+t+">"},{className:"type",begin:"!"+t},{className:"type",begin:"!!"+t
+},{className:"meta",begin:"&"+e.UNDERSCORE_IDENT_RE+"$"},{className:"meta",
+begin:"\\*"+e.UNDERSCORE_IDENT_RE+"$"},{className:"bullet",begin:"-(?=[ ]|$)",
+relevance:0},e.HASH_COMMENT_MODE,{beginKeywords:n,keywords:{literal:n}},{
+className:"number",
+begin:"\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b"
+},{className:"number",begin:e.C_NUMBER_RE+"\\b",relevance:0},s,o,{
+className:"string",relevance:0,begin:/'/,end:/'/,contains:[{match:/''/,
+scope:"char.escape",relevance:0}]},a],c=[...l]
+;return c.pop(),c.push(i),r.contains=c,{name:"YAML",case_insensitive:!0,
+aliases:["yml"],contains:l}}});const Pe=ne;for(const e of Object.keys(Ue)){
+const n=e.replace("grmr_","").replace("_","-");Pe.registerLanguage(n,Ue[e])}
+return Pe}()
+;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);
+/*! `graphql` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{const a=e.regex;return{name:"GraphQL",
+aliases:["gql"],case_insensitive:!0,disableAutodetect:!1,keywords:{
+keyword:["query","mutation","subscription","type","input","schema","directive","interface","union","scalar","fragment","enum","on"],
+literal:["true","false","null"]},
+contains:[e.HASH_COMMENT_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+scope:"punctuation",match:/[.]{3}/,relevance:0},{scope:"punctuation",
+begin:/[\!\(\)\:\=\[\]\{\|\}]{1}/,relevance:0},{scope:"variable",begin:/\$/,
+end:/\W/,excludeEnd:!0,relevance:0},{scope:"meta",match:/@\w+/,excludeEnd:!0},{
+scope:"symbol",begin:a.concat(/[_A-Za-z][_0-9A-Za-z]*/,a.lookahead(/\s*:/)),
+relevance:0}],illegal:[/[;<']/,/BEGIN/]}}})();hljs.registerLanguage("graphql",e)
+})();
+/*! `lua` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{const t="\\[=*\\[",a="\\]=*\\]",n={
+begin:t,end:a,contains:["self"]
+},o=[e.COMMENT("--(?!"+t+")","$"),e.COMMENT("--"+t,a,{contains:[n],relevance:10
+})];return{name:"Lua",aliases:["pluto"],keywords:{
+$pattern:e.UNDERSCORE_IDENT_RE,literal:"true false nil",
+keyword:"and break do else elseif end for goto if in local not or repeat return then until while",
+built_in:"_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove"
+},contains:o.concat([{className:"function",beginKeywords:"function",end:"\\)",
+contains:[e.inherit(e.TITLE_MODE,{
+begin:"([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*"}),{className:"params",
+begin:"\\(",endsWithParent:!0,contains:o}].concat(o)
+},e.C_NUMBER_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{className:"string",
+begin:t,end:a,contains:[n],relevance:5}])}}})();hljs.registerLanguage("lua",e)
+})();
+/*! `elixir` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const n=e.regex,a="[a-zA-Z_][a-zA-Z0-9_.]*(!|\\?)?",i={$pattern:a,
+keyword:["after","alias","and","case","catch","cond","defstruct","defguard","do","else","end","fn","for","if","import","in","not","or","quote","raise","receive","require","reraise","rescue","try","unless","unquote","unquote_splicing","use","when","with|0"],
+literal:["false","nil","true"]},s={className:"subst",begin:/#\{/,end:/\}/,
+keywords:i},c={match:/\\[\s\S]/,scope:"char.escape",relevance:0
+},r="[/|([{<\"']",t=[{begin:/"/,end:/"/},{begin:/'/,end:/'/},{begin:/\//,
+end:/\//},{begin:/\|/,end:/\|/},{begin:/\(/,end:/\)/},{begin:/\[/,end:/\]/},{
+begin:/\{/,end:/\}/},{begin:/</,end:/>/}],d=e=>({scope:"char.escape",
+begin:n.concat(/\\/,e),relevance:0}),o={className:"string",
+begin:"~[a-z](?="+r+")",contains:t.map((n=>e.inherit(n,{contains:[d(n.end),c,s]
+})))},b={className:"string",begin:"~[A-Z](?="+r+")",
+contains:t.map((n=>e.inherit(n,{contains:[d(n.end)]})))},g={className:"regex",
+variants:[{begin:"~r(?="+r+")",contains:t.map((a=>e.inherit(a,{
+end:n.concat(a.end,/[uismxfU]{0,7}/),contains:[d(a.end),c,s]})))},{
+begin:"~R(?="+r+")",contains:t.map((a=>e.inherit(a,{
+end:n.concat(a.end,/[uismxfU]{0,7}/),contains:[d(a.end)]})))}]},l={
+className:"string",contains:[e.BACKSLASH_ESCAPE,s],variants:[{begin:/"""/,
+end:/"""/},{begin:/'''/,end:/'''/},{begin:/~S"""/,end:/"""/,contains:[]},{
+begin:/~S"/,end:/"/,contains:[]},{begin:/~S'''/,end:/'''/,contains:[]},{
+begin:/~S'/,end:/'/,contains:[]},{begin:/'/,end:/'/},{begin:/"/,end:/"/}]},m={
+className:"function",beginKeywords:"def defp defmacro defmacrop",end:/\B\b/,
+contains:[e.inherit(e.TITLE_MODE,{begin:a,endsParent:!0})]},u=e.inherit(m,{
+className:"class",beginKeywords:"defimpl defmodule defprotocol defrecord",
+end:/\bdo\b|$|;/}),f=[l,g,b,o,e.HASH_COMMENT_MODE,u,m,{begin:"::"},{
+className:"symbol",begin:":(?![\\s:])",contains:[l,{
+begin:"[a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?"
+}],relevance:0},{className:"symbol",begin:a+":(?!:)",relevance:0},{
+className:"title.class",begin:/(\b[A-Z][a-zA-Z0-9_]+)/,relevance:0},{
+className:"number",
+begin:"(\\b0o[0-7_]+)|(\\b0b[01_]+)|(\\b0x[0-9a-fA-F_]+)|(-?\\b[0-9][0-9_]*(\\.[0-9_]+([eE][-+]?[0-9]+)?)?)",
+relevance:0},{className:"variable",begin:"(\\$\\W)|((\\$|@@?)(\\w+))"}]
+;return s.contains=f,{name:"Elixir",aliases:["ex","exs"],keywords:i,contains:f}}
+})();hljs.registerLanguage("elixir",e)})();
+/*! `dockerfile` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>({name:"Dockerfile",aliases:["docker"],
+case_insensitive:!0,
+keywords:["from","maintainer","expose","env","arg","user","onbuild","stopsignal"],
+contains:[e.HASH_COMMENT_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+beginKeywords:"run cmd entrypoint volume add copy workdir label healthcheck shell",
+starts:{end:/[^\\]$/,subLanguage:"bash"}}],illegal:"</"})})()
+;hljs.registerLanguage("dockerfile",e)})();
+/*! `ini` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{const n=e.regex,a={className:"number",
+relevance:0,variants:[{begin:/([+-]+)?[\d]+_[\d_]+/},{begin:e.NUMBER_RE}]
+},s=e.COMMENT();s.variants=[{begin:/;/,end:/$/},{begin:/#/,end:/$/}];const i={
+className:"variable",variants:[{begin:/\$[\w\d"][\w\d_]*/},{begin:/\$\{(.*?)\}/
+}]},t={className:"literal",begin:/\bon|off|true|false|yes|no\b/},r={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{begin:"'''",
+end:"'''",relevance:10},{begin:'"""',end:'"""',relevance:10},{begin:'"',end:'"'
+},{begin:"'",end:"'"}]},l={begin:/\[/,end:/\]/,contains:[s,t,i,r,a,"self"],
+relevance:0},c=n.either(/[A-Za-z0-9_-]+/,/"(\\"|[^"])*"/,/'[^']*'/);return{
+name:"TOML, also INI",aliases:["toml"],case_insensitive:!0,illegal:/\S/,
+contains:[s,{className:"section",begin:/\[+/,end:/\]+/},{
+begin:n.concat(c,"(\\s*\\.\\s*",c,")*",n.lookahead(/\s*=\s*[^#\s]/)),
+className:"attr",starts:{end:/$/,contains:[s,l,t,i,r,a]}}]}}})()
+;hljs.registerLanguage("ini",e)})();

--- a/Shared/SyntaxHighlightSupport.swift
+++ b/Shared/SyntaxHighlightSupport.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum SyntaxHighlightSupport {
+    static func scriptHTML(for htmlBody: String) -> String {
+        guard htmlBody.contains("class=\"language-") else { return "" }
+        guard let cssURL = Bundle.main.url(forResource: "highlight-theme.css", withExtension: nil)?.absoluteString,
+              let jsURL = Bundle.main.url(forResource: "highlight.min.js", withExtension: nil)?.absoluteString else {
+            return ""
+        }
+
+        return """
+        <link rel="stylesheet" href="\(cssURL)">
+        <script src="\(jsURL)"></script>
+        <script>
+        (function() {
+            if (!window.hljs) return;
+            hljs.configure({ ignoreUnescapedHTML: true });
+            document.querySelectorAll('pre code[class*="language-"]').forEach(function(el) {
+                // Skip mermaid blocks (handled by MermaidSupport)
+                if (el.classList.contains('language-mermaid')) return;
+                var isDiff = el.classList.contains('language-diff');
+                hljs.highlightElement(el);
+                // Wrap lines for line numbers and diff highlighting
+                var lines = el.innerHTML.split('\\n');
+                // Remove trailing empty line
+                if (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+                    lines.pop();
+                }
+                var wrapped = lines.map(function(line) {
+                    var cls = 'code-line';
+                    if (isDiff) {
+                        var stripped = line.replace(/<[^>]*>/g, '');
+                        if (stripped.charAt(0) === '+') cls += ' diff-add';
+                        else if (stripped.charAt(0) === '-') cls += ' diff-del';
+                        else if (stripped.startsWith('@@')) cls += ' diff-hunk';
+                    }
+                    return '<span class="' + cls + '">' + line + '</span>';
+                }).join('');
+                el.innerHTML = wrapped;
+                // Add numbered class for line numbers (skip diff blocks)
+                if (!isDiff) {
+                    el.classList.add('code-numbered');
+                }
+            });
+        })();
+        </script>
+        """
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -36,6 +36,10 @@ targets:
       - path: Shared/Resources/fonts
         buildPhase: resources
         type: folder
+      - path: Shared/Resources/highlight.min.js
+        buildPhase: resources
+      - path: Shared/Resources/highlight-theme.css
+        buildPhase: resources
       - path: Shared/Resources/demo.md
         buildPhase: resources
     dependencies:
@@ -77,6 +81,10 @@ targets:
       - path: Shared/Resources/fonts
         buildPhase: resources
         type: folder
+      - path: Shared/Resources/highlight.min.js
+        buildPhase: resources
+      - path: Shared/Resources/highlight-theme.css
+        buildPhase: resources
     dependencies:
       - package: cmark-gfm
         product: cmark

--- a/website/index.html
+++ b/website/index.html
@@ -198,11 +198,27 @@
                 </div>
                 <div class="feature">
                     <h3>Syntax Highlighting</h3>
-                    <p>Headings, bold, italic, links, code blocks, and more — highlighted as you type.</p>
+                    <p>Headings, bold, italic, links, code blocks, tables, footnotes, highlights, and more — highlighted as you type.</p>
                 </div>
                 <div class="feature">
                     <h3>Instant Preview</h3>
-                    <p>Full GitHub Flavored Markdown support, including Mermaid diagrams and KaTeX math.</p>
+                    <p>Full GitHub Flavored Markdown with Mermaid diagrams, KaTeX math, syntax-highlighted code blocks, callouts, and more.</p>
+                </div>
+                <div class="feature">
+                    <h3>Code Highlighting</h3>
+                    <p>27+ languages with line numbers and diff highlighting. Filename headers on code blocks. Copy with one click.</p>
+                </div>
+                <div class="feature">
+                    <h3>Callouts &amp; Admonitions</h3>
+                    <p>GitHub and Obsidian-style callouts — NOTE, TIP, WARNING, and 15 types. Foldable with a click.</p>
+                </div>
+                <div class="feature">
+                    <h3>Interactive Preview</h3>
+                    <p>Toggle task checkboxes, click images to zoom, hover footnotes for popovers, double-click to jump to source.</p>
+                </div>
+                <div class="feature">
+                    <h3>Extended Markdown</h3>
+                    <p>==Highlights==, ^superscript^, ~subscript~, :emoji: shortcodes, and auto-generated table of contents.</p>
                 </div>
                 <div class="feature">
                     <h3>Editor &amp; Preview Toggle</h3>


### PR DESCRIPTION
## Summary
- Adds extended markdown syntax: ==highlights==, ^superscript^/~subscript~, :emoji: shortcodes, callouts/admonitions (15 types, foldable), and [TOC] auto-generation
- Bundles Highlight.js for syntax-highlighted code blocks (27+ languages) with line numbers, diff highlighting, and filename headers
- Adds interactive preview features: task checkbox toggle (writes back to source), heading anchor links, image lightbox, footnote popovers, click-to-source (double-click to jump to editor line)
- Fixes editor regex bugs where inline math, code, strikethrough, and links incorrectly matched across newlines
- Adds editor syntax highlighting for images, reference links, tables, footnotes, setext headings, ==highlights==, and HTML tags
- Updates CLAUDE.md, README, demo.md, and marketing site with new features

## Test plan
- [ ] Open Help → Sample Document, switch to Preview (⌘2), verify all new features render
- [ ] Test callouts: `> [!NOTE]`, `> [!WARNING]`, foldable `> [!TIP]-`
- [ ] Test code blocks have syntax coloring, line numbers, and diff highlighting
- [ ] Click task list checkboxes in preview — verify they toggle without page flash
- [ ] Double-click any element in preview — verify it switches to editor and scrolls to the line
- [ ] Hover footnote references — verify popover appears with correct dark mode styling
- [ ] Click images in preview — verify lightbox overlay
- [ ] Verify editor highlights ==marks==, `[^footnotes]`, `![images]()`, table pipes, HTML tags
- [ ] Test light mode, dark mode, and PDF export
- [ ] Test QuickLook (select .md in Finder, press Space)