### PR TITLE
Fix code block copy button, border-radius, and gutter styling

### DIFF
--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -3,8 +3,6 @@ import WebKit
 import Combine
 
 struct PreviewView: NSViewRepresentable {
-    private static let copyButtonContentWorld = WKContentWorld.world(name: "ClearlyCopyButtons")
-
     let markdown: String
     var fontSize: CGFloat = 18
     var mode: ViewMode
@@ -30,7 +28,6 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "linkClicked")
         config.userContentController.add(context.coordinator, name: "scrollSync")
         config.userContentController.add(context.coordinator, name: "copyToClipboard")
-        config.userContentController.add(context.coordinator, contentWorld: Self.copyButtonContentWorld, name: "copyToClipboard")
         config.userContentController.add(context.coordinator, name: "taskToggle")
         config.userContentController.add(context.coordinator, name: "clickToSource")
         config.userContentController.addUserScript(Self.copyButtonUserScript())
@@ -95,7 +92,6 @@ struct PreviewView: NSViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard", contentWorld: Self.copyButtonContentWorld)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "clickToSource")
     }
@@ -551,9 +547,23 @@ struct PreviewView: NSViewRepresentable {
             var copyIcon = '\(copyIcon)';
             var checkIcon = '\(checkIcon)';
             document.querySelectorAll('pre').forEach(function(pre) {
-                if (pre.closest('.frontmatter') || pre.querySelector('.code-copy-btn')) return;
+                if (pre.closest('.frontmatter') || pre.closest('.code-block-wrapper')) return;
+                var wrapper = document.createElement('div');
+                wrapper.className = 'code-block-wrapper';
+                var prev = pre.previousElementSibling;
+                var hasFilename = prev && prev.classList.contains('code-filename');
+                if (hasFilename) {
+                    pre.parentNode.insertBefore(wrapper, prev);
+                    wrapper.appendChild(prev);
+                } else {
+                    pre.parentNode.insertBefore(wrapper, pre);
+                }
+                wrapper.appendChild(pre);
                 var btn = document.createElement('button');
                 btn.className = 'code-copy-btn';
+                if (hasFilename) {
+                    btn.style.top = (prev.offsetHeight + 6) + 'px';
+                }
                 btn.type = 'button';
                 btn.setAttribute('aria-label', 'Copy code');
                 btn.innerHTML = copyIcon;
@@ -561,7 +571,13 @@ struct PreviewView: NSViewRepresentable {
                     e.preventDefault();
                     e.stopPropagation();
                     var code = pre.querySelector('code');
-                    var text = code ? code.textContent : pre.textContent;
+                    var lines = code ? code.querySelectorAll('.code-line') : null;
+                    var text;
+                    if (lines && lines.length > 0) {
+                        text = Array.from(lines).map(function(l) { return l.textContent; }).join('\\n');
+                    } else {
+                        text = code ? code.textContent : pre.textContent;
+                    }
                     window.webkit.messageHandlers.copyToClipboard.postMessage(text);
                     btn.classList.add('copied');
                     btn.innerHTML = checkIcon;
@@ -570,15 +586,14 @@ struct PreviewView: NSViewRepresentable {
                         btn.innerHTML = copyIcon;
                     }, 1500);
                 });
-                pre.appendChild(btn);
+                wrapper.appendChild(btn);
             });
         })();
         """
         return WKUserScript(
             source: source,
             injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true,
-            in: copyButtonContentWorld
+            forMainFrameOnly: true
         )
     }
 }

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -208,6 +208,16 @@ enum PreviewCSS {
         border-radius: 5px;
     }
 
+    .code-filename {
+        font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
+        font-size: 0.8em;
+        padding: 0.5em 1.25em;
+        background: #EDEDF0;
+        border: none;
+        border-radius: 10px 10px 0 0;
+        color: #86868B;
+    }
+
     pre {
         position: relative;
         background-color: #F5F5F7;
@@ -218,10 +228,30 @@ enum PreviewCSS {
         overflow-x: auto;
     }
 
+    .code-filename + pre {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        margin-top: 0;
+    }
+
+    .code-block-wrapper {
+        position: relative;
+        margin-bottom: 1.25em;
+    }
+
+    .code-block-wrapper > pre {
+        margin-bottom: 0;
+    }
+
+    .code-block-wrapper:hover .code-copy-btn {
+        opacity: 1;
+    }
+
     .code-copy-btn {
         position: absolute;
         top: 6px;
         right: 6px;
+        z-index: 1;
         width: 28px;
         height: 28px;
         padding: 0;
@@ -244,10 +274,6 @@ enum PreviewCSS {
 
     .code-copy-btn.copied {
         color: #34C759;
-    }
-
-    pre:hover .code-copy-btn {
-        opacity: 1;
     }
 
     .code-copy-btn:hover {
@@ -661,6 +687,10 @@ enum PreviewCSS {
             background-color: rgba(255, 255, 255, 0.06);
             color: #F5F5F7;
         }
+        .code-filename {
+            background: rgba(255, 255, 255, 0.07);
+            color: #AEAEB2;
+        }
         pre {
             background-color: rgba(255, 255, 255, 0.05);
             color: #F5F5F7;
@@ -774,6 +804,10 @@ enum PreviewCSS {
     }
 
     @media print {
+        .code-filename {
+            background: #EDEDF0 !important;
+            color: #86868B !important;
+        }
         .code-copy-btn { display: none !important; }
         .table-copy-btn { display: none !important; }
         .sort-indicator { display: none !important; }

--- a/Shared/Resources/highlight-theme.css
+++ b/Shared/Resources/highlight-theme.css
@@ -81,10 +81,10 @@ pre code {
 .code-numbered .code-line::before {
     content: counter(line);
     display: inline-block;
-    width: 2.5em;
+    width: 1.5em;
     text-align: right;
-    padding-right: 1em;
-    margin-right: 0.5em;
+    padding-right: 0.6em;
+    margin-right: 0.4em;
     color: #AEAEB2;
     user-select: none;
     -webkit-user-select: none;


### PR DESCRIPTION
## Summary
- Fix copy-to-clipboard button not appearing on hover by switching from isolated WKContentWorld to the default page world
- Wrap `<pre>` blocks in a non-scrolling `.code-block-wrapper` so the copy button stays pinned to the top-right during horizontal scroll
- Fix copied code losing line breaks when syntax-highlighted lines are wrapped in `<span>` elements
- Add `.code-filename` CSS to inline PreviewCSS so titled code blocks get correct border-radius (flat top corners) and no gap between header and code
- Tighten line number gutter spacing (width, padding, margin)

## Test plan
- [ ] Open a markdown file with a fenced code block that has `title="filename.swift"` — verify the filename header connects seamlessly to the code block with no rounded top corners on the code area
- [ ] Hover over a code block — verify the copy button appears in the top-right
- [ ] Horizontally scroll a wide code block — verify the copy button stays fixed in the viewport
- [ ] Click the copy button and paste — verify line breaks are preserved
- [ ] Check code blocks without a title still render correctly with the copy button in the top-right
- [ ] Verify dark mode styling for filename headers and copy button

Fixes #116