### PR TITLE
Fix preview cursor leaking into editor mode

### DIFF
--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -60,6 +60,7 @@ struct PreviewView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
+        webView.isHidden = mode != .preview
         webView.underPageBackgroundColor = Theme.backgroundColor
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID


### PR DESCRIPTION
## Summary
- Hides the WKWebView at the AppKit level (`isHidden`) when switching to Editor mode, preventing cursor tracking and mouse events from bleeding through
- SwiftUI's `.allowsHitTesting(false)` only blocks SwiftUI-level events — the underlying WKWebView still processes AppKit cursor tracking, causing the magnifier icon to appear over the editor where images were in the preview

## Test plan
- [ ] Open a document with an image
- [ ] Switch to Preview, hover over image — confirm magnifier cursor
- [ ] Switch to Editor, hover over same area — confirm normal text cursor (no magnifier)
- [ ] Switch back to Preview — confirm content renders without reload
- [ ] Verify scroll sync still works across mode switches

Fixes #117