### PR TITLE
Add cross-file SQLite index and Quick Switcher (Cmd+P)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -127,6 +127,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     private var commandQMonitor: Any?
     private var showHiddenFilesMonitor: Any?
     private var sidebarToggleMonitor: Any?
+    private var quickSwitcherMonitor: Any?
     private var themeObserver: Any?
     private var isProgrammaticallyClosingWindows = false
     private(set) var mainWindow: NSWindow?
@@ -300,6 +301,21 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             return event
         }
 
+        quickSwitcherMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
+            if chars == "p" && mods == [.command] {
+                QuickSwitcherManager.shared.toggle()
+                return nil
+            }
+            return event
+        }
+
+        // Inject Quick Open menu item once (View menu isn't wiped by SwiftUI)
+        DispatchQueue.main.async { [weak self] in
+            self?.injectQuickOpenIfNeeded()
+        }
+
     }
 
     // MARK: - Open files from Finder
@@ -358,6 +374,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(sidebarToggleMonitor)
             self.sidebarToggleMonitor = nil
         }
+        if let quickSwitcherMonitor {
+            NSEvent.removeMonitor(quickSwitcherMonitor)
+            self.quickSwitcherMonitor = nil
+        }
         if let themeObserver {
             NotificationCenter.default.removeObserver(themeObserver)
             self.themeObserver = nil
@@ -391,6 +411,23 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func toggleSidebarMenuAction(_ sender: Any?) {
         doToggleSidebar()
+    }
+
+    private func injectQuickOpenIfNeeded() {
+        guard let viewMenu = NSApp.mainMenu?.item(withTitle: "View")?.submenu else { return }
+        guard !viewMenu.items.contains(where: { $0.title == "Quick Open…" }) else { return }
+
+        let item = NSMenuItem(title: "Quick Open…", action: #selector(quickOpenAction(_:)), keyEquivalent: "p")
+        item.keyEquivalentModifierMask = [.command]
+        item.target = self
+
+        // Insert after Toggle Sidebar + separator (index 2)
+        let insertAt = min(2, viewMenu.items.count)
+        viewMenu.insertItem(item, at: insertAt)
+    }
+
+    @objc private func quickOpenAction(_ sender: Any?) {
+        QuickSwitcherManager.shared.toggle()
     }
 
     private func injectViewCommandsIfNeeded() {
@@ -516,7 +553,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         }
         isProgrammaticallyClosingWindows = false
 
-        Task { @MainActor in ScratchpadManager.shared.closeAll() }
+        Task { @MainActor in
+            ScratchpadManager.shared.closeAll()
+            QuickSwitcherManager.shared.dismiss()
+        }
         updateActivationPolicy()
     }
 
@@ -832,9 +872,6 @@ struct ClearlyApp: App {
             CommandGroup(after: .textEditing) {
                 FindCommand()
             }
-            CommandGroup(after: .textFormatting) {
-                FontSizeCommands()
-            }
             CommandGroup(replacing: .help) {
                 Button("Clearly Help") {
                     NSWorkspace.shared.open(URL(string: "https://github.com/Shpigford/clearly/issues")!)
@@ -861,7 +898,9 @@ struct ClearlyApp: App {
                     }
                 }
             }
-            CommandMenu("Format") {
+            CommandGroup(replacing: .textFormatting) {
+                FontSizeCommands()
+                Divider()
                 Button("Bold") {
                     NSApp.sendAction(#selector(ClearlyTextView.toggleBold(_:)), to: nil, from: nil)
                 }
@@ -1071,7 +1110,7 @@ struct PrintCommand: View {
             PDFExporter().printHTML(markdown: text, fontSize: CGFloat(fontSize), fileURL: fileURL)
         }
         .disabled(text == nil)
-        .keyboardShortcut("p", modifiers: .command)
+        .keyboardShortcut("p", modifiers: [.command, .shift])
     }
 }
 

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -289,6 +289,9 @@ struct ContentView: View {
     }
 
     private func setupFileWatcher() {
+        fileWatcher.liveCurrentText = { [workspace] in
+            workspace.liveCurrentFileText()
+        }
         guard let url = workspace.currentFileURL else {
             fileWatcher.watch(nil, currentText: nil)
             return

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -190,20 +190,20 @@ class FlatSectionOutlineView: NSOutlineView {
 
     // Click on expandable rows toggles expansion
     override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        let row = self.row(at: point)
-        if row >= 0, let item = self.item(atRow: row) {
-            let isExpandable = self.dataSource?.outlineView?(self, isItemExpandable: item) ?? false
-            if isExpandable {
-                if isItemExpanded(item) {
-                    collapseItem(item)
-                } else {
-                    expandItem(item)
-                }
-                return
+        let startPoint = convert(event.locationInWindow, from: nil)
+        let clickedRow = self.row(at: startPoint)
+
+        // Always let super handle tracking (enables drag initiation)
+        super.mouseDown(with: event)
+
+        // If clicked on expandable row and didn't drag, toggle expansion
+        if clickedRow >= 0, let item = self.item(atRow: clickedRow),
+           self.dataSource?.outlineView?(self, isItemExpandable: item) ?? false {
+            let endPoint = convert(NSApp.currentEvent?.locationInWindow ?? event.locationInWindow, from: nil)
+            if hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y) < 5 {
+                if isItemExpanded(item) { collapseItem(item) } else { expandItem(item) }
             }
         }
-        super.mouseDown(with: event)
     }
 
     // Allow buttons inside cell views to receive clicks
@@ -254,6 +254,10 @@ struct FileExplorerOutlineView: NSViewRepresentable {
         let menu = NSMenu()
         menu.delegate = context.coordinator
         outlineView.menu = menu
+
+        // Drag and drop
+        outlineView.registerForDraggedTypes([.fileURL])
+        outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
 
         // Double-click does nothing extra (single-click selects)
         outlineView.doubleAction = nil
@@ -532,6 +536,71 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 }
             }
             return nil
+        }
+
+        // MARK: - Drag and Drop
+
+        func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> NSPasteboardWriting? {
+            guard let outlineItem = item as? OutlineItem else { return nil }
+            switch outlineItem.kind {
+            case .fileNode(let node):
+                return node.url as NSURL
+            default:
+                return nil
+            }
+        }
+
+        private func draggedURLs(from info: NSDraggingInfo) -> [URL] {
+            guard let items = info.draggingPasteboard.pasteboardItems else { return [] }
+            return items.compactMap { item in
+                guard let str = item.string(forType: .fileURL) else { return nil }
+                return URL(string: str)
+            }
+        }
+
+        func outlineView(_ outlineView: NSOutlineView, validateDrop info: NSDraggingInfo, proposedItem item: Any?, proposedChildIndex index: Int) -> NSDragOperation {
+            // Determine the actual drop target folder
+            let target: OutlineItem
+            if index == NSOutlineViewDropOnItemIndex,
+               let proposed = item as? OutlineItem, proposed.isDirectory {
+                target = proposed
+            } else {
+                // Proposed "between" rows — retarget to the folder row under the cursor
+                let point = outlineView.convert(info.draggingLocation, from: nil)
+                let row = outlineView.row(at: point)
+                guard row >= 0,
+                      let hovered = outlineView.item(atRow: row) as? OutlineItem,
+                      hovered.isDirectory else { return [] }
+                target = hovered
+            }
+
+            guard let targetURL = target.url else { return [] }
+            let urls = draggedURLs(from: info)
+            guard !urls.isEmpty else { return [] }
+
+            for sourceURL in urls {
+                // Prevent dropping item into its current parent (no-op)
+                if sourceURL.deletingLastPathComponent().path == targetURL.path { return [] }
+                // Prevent dropping a folder into itself or a descendant
+                if targetURL.path == sourceURL.path || targetURL.path.hasPrefix(sourceURL.path + "/") { return [] }
+            }
+
+            outlineView.setDropItem(target, dropChildIndex: NSOutlineViewDropOnItemIndex)
+            return .move
+        }
+
+        func outlineView(_ outlineView: NSOutlineView, acceptDrop info: NSDraggingInfo, item: Any?, childIndex index: Int) -> Bool {
+            guard let target = item as? OutlineItem, let targetURL = target.url else { return false }
+            let urls = draggedURLs(from: info)
+            guard !urls.isEmpty else { return false }
+
+            var success = true
+            for sourceURL in urls {
+                if workspace.moveItem(at: sourceURL, into: targetURL) == nil {
+                    success = false
+                }
+            }
+            return success
         }
 
         // MARK: - Data Source

--- a/Clearly/FileParser.swift
+++ b/Clearly/FileParser.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+// MARK: - Data Types
+
+struct ParsedLink: Equatable {
+    let target: String
+    let heading: String?
+    let alias: String?
+    let lineNumber: Int
+}
+
+struct ParsedTag: Equatable {
+    enum Source: String {
+        case inline
+        case frontmatter
+    }
+    let name: String      // normalized: lowercase, no #
+    let lineNumber: Int
+    let source: Source
+}
+
+struct ParsedHeading: Equatable {
+    let text: String
+    let level: Int        // 1-6
+    let lineNumber: Int
+}
+
+struct ParseResult {
+    let links: [ParsedLink]
+    let tags: [ParsedTag]
+    let headings: [ParsedHeading]
+}
+
+// MARK: - Parser
+
+enum FileParser {
+
+    // MARK: Regexes
+
+    private static let codeBlockRegex = try! NSRegularExpression(
+        pattern: "^((?:`{3,}|~{3,}))[^\n]*\\n([\\s\\S]*?)^\\1[ \\t]*$",
+        options: [.anchorsMatchLines]
+    )
+
+    private static let frontmatterRegex = try! NSRegularExpression(
+        pattern: "\\A---[ \\t]*\\n([\\s\\S]*?)\\n---[ \\t]*(?:\\n|\\z)",
+        options: []
+    )
+
+    private static let wikiLinkRegex = try! NSRegularExpression(
+        pattern: #"\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]"#,
+        options: []
+    )
+
+    private static let tagRegex = try! NSRegularExpression(
+        pattern: #"(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)"#,
+        options: [.anchorsMatchLines]
+    )
+
+    private static let headingRegex = try! NSRegularExpression(
+        pattern: "^(#{1,6})\\s+(.+)$",
+        options: [.anchorsMatchLines]
+    )
+
+    // MARK: Public API
+
+    static func parse(content: String) -> ParseResult {
+        let nsContent = content as NSString
+        let fullRange = NSRange(location: 0, length: nsContent.length)
+
+        // Build skip ranges (code blocks + frontmatter)
+        var skipRanges: [NSRange] = []
+
+        frontmatterRegex.enumerateMatches(in: content, range: fullRange) { match, _, _ in
+            if let range = match?.range { skipRanges.append(range) }
+        }
+        codeBlockRegex.enumerateMatches(in: content, range: fullRange) { match, _, _ in
+            if let range = match?.range { skipRanges.append(range) }
+        }
+
+        let links = extractLinks(from: content, nsContent: nsContent, fullRange: fullRange, skipRanges: skipRanges)
+        let inlineTags = extractTags(from: content, nsContent: nsContent, fullRange: fullRange, skipRanges: skipRanges)
+        let frontmatterTags = extractFrontmatterTags(from: content)
+        let headings = extractHeadings(from: content, nsContent: nsContent, fullRange: fullRange, skipRanges: skipRanges)
+
+        return ParseResult(
+            links: links,
+            tags: inlineTags + frontmatterTags,
+            headings: headings
+        )
+    }
+
+    // MARK: Extraction
+
+    private static func extractLinks(from text: String, nsContent: NSString, fullRange: NSRange, skipRanges: [NSRange]) -> [ParsedLink] {
+        var links: [ParsedLink] = []
+
+        wikiLinkRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !isInsideSkipRange(match.range, skipRanges: skipRanges) else { return }
+
+            let target = nsContent.substring(with: match.range(at: 1))
+                .trimmingCharacters(in: .whitespaces)
+
+            var heading: String?
+            let headingRange = match.range(at: 2)
+            if headingRange.location != NSNotFound {
+                heading = nsContent.substring(with: headingRange)
+                    .trimmingCharacters(in: .whitespaces)
+            }
+
+            var alias: String?
+            let aliasRange = match.range(at: 3)
+            if aliasRange.location != NSNotFound {
+                alias = nsContent.substring(with: aliasRange)
+                    .trimmingCharacters(in: .whitespaces)
+            }
+
+            let line = lineNumber(at: match.range.location, in: nsContent)
+            links.append(ParsedLink(target: target, heading: heading, alias: alias, lineNumber: line))
+        }
+
+        return links
+    }
+
+    private static func extractTags(from text: String, nsContent: NSString, fullRange: NSRange, skipRanges: [NSRange]) -> [ParsedTag] {
+        var tags: [ParsedTag] = []
+
+        tagRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !isInsideSkipRange(match.range, skipRanges: skipRanges) else { return }
+
+            let name = nsContent.substring(with: match.range(at: 1)).lowercased()
+            let line = lineNumber(at: match.range.location, in: nsContent)
+            tags.append(ParsedTag(name: name, lineNumber: line, source: .inline))
+        }
+
+        return tags
+    }
+
+    private static func extractFrontmatterTags(from content: String) -> [ParsedTag] {
+        guard let block = FrontmatterSupport.extract(from: content) else { return [] }
+
+        guard let tagsField = block.fields.first(where: { $0.key.lowercased() == "tags" }) else { return [] }
+
+        let value = tagsField.value
+        var tagNames: [String] = []
+
+        // Handle YAML list: [tag1, tag2] or each line "- tag"
+        if value.hasPrefix("[") && value.hasSuffix("]") {
+            // Inline array: [tag1, tag2, tag3]
+            let inner = String(value.dropFirst().dropLast())
+            tagNames = inner.components(separatedBy: ",").map {
+                $0.trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            }
+        } else {
+            // Could be a single value on the same line or multi-line list
+            let lines = value.components(separatedBy: "\n")
+            for line in lines {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("- ") {
+                    let tag = String(trimmed.dropFirst(2))
+                        .trimmingCharacters(in: .whitespaces)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                    if !tag.isEmpty { tagNames.append(tag) }
+                } else if !trimmed.isEmpty {
+                    // Single value on same line as key
+                    tagNames.append(trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "\"'")))
+                }
+            }
+        }
+
+        return tagNames.compactMap { name in
+            let normalized = name.lowercased().trimmingCharacters(in: .whitespaces)
+            guard !normalized.isEmpty else { return nil }
+            // Frontmatter tags are on line 1 (inside the frontmatter block)
+            return ParsedTag(name: normalized, lineNumber: 1, source: .frontmatter)
+        }
+    }
+
+    private static func extractHeadings(from text: String, nsContent: NSString, fullRange: NSRange, skipRanges: [NSRange]) -> [ParsedHeading] {
+        var headings: [ParsedHeading] = []
+
+        headingRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !isInsideSkipRange(match.range, skipRanges: skipRanges) else { return }
+
+            let level = match.range(at: 1).length
+            let rawTitle = nsContent.substring(with: match.range(at: 2))
+            let title = stripInlineMarkdown(rawTitle)
+            let line = lineNumber(at: match.range.location, in: nsContent)
+
+            headings.append(ParsedHeading(text: title, level: level, lineNumber: line))
+        }
+
+        return headings
+    }
+
+    // MARK: Helpers
+
+    private static func isInsideSkipRange(_ range: NSRange, skipRanges: [NSRange]) -> Bool {
+        for skip in skipRanges {
+            if skip.location <= range.location && NSMaxRange(skip) >= NSMaxRange(range) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Returns 1-based line number for a character offset.
+    private static func lineNumber(at offset: Int, in text: NSString) -> Int {
+        let clamped = min(max(0, offset), text.length)
+        var line = 1
+        var pos = 0
+        while pos < clamped {
+            let lineRange = text.lineRange(for: NSRange(location: pos, length: 0))
+            let nextPos = NSMaxRange(lineRange)
+            if nextPos > clamped { break }
+            line += 1
+            pos = nextPos
+        }
+        return line
+    }
+
+    /// Strip bold, italic, code, strikethrough, link markdown from heading text.
+    private static func stripInlineMarkdown(_ text: String) -> String {
+        var result = text
+        result = result.replacingOccurrences(of: "\\[([^\\]]+)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\([^)]+\\)", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "(\\*\\*|__)(.+?)\\1", with: "$2", options: .regularExpression)
+        result = result.replacingOccurrences(of: "(?<![\\w*])[*_](.+?)[*_](?![\\w*])", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "~~(.+?)~~", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Clearly/FileWatcher.swift
+++ b/Clearly/FileWatcher.swift
@@ -8,6 +8,7 @@ final class FileWatcher: ObservableObject {
     private var currentText: String?
     private var lastKnownDiskText: String?
     var onChange: ((String) -> Void)?
+    var liveCurrentText: (() -> String?)?
 
     func watch(_ url: URL?, currentText: String? = nil) {
         stopMonitoring()
@@ -89,6 +90,9 @@ final class FileWatcher: ObservableObject {
             guard let self else { return }
             guard newText != self.lastKnownDiskText else { return }
 
+            if let liveCurrentText = self.liveCurrentText?() {
+                self.currentText = liveCurrentText
+            }
             let hasUnsavedChanges = self.currentText != self.lastKnownDiskText
             self.lastKnownDiskText = newText
 

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -1,0 +1,594 @@
+import AppKit
+
+// MARK: - Fuzzy Matching
+
+struct FuzzyMatchResult {
+    let score: Int
+    let matchedRanges: [Range<String.Index>]
+}
+
+enum FuzzyMatcher {
+    /// Sequential character matching with gap penalties and separator bonuses.
+    /// Returns nil if not all query characters match.
+    static func match(query: String, target: String) -> FuzzyMatchResult? {
+        let queryLower = query.lowercased()
+        let targetLower = target.lowercased()
+
+        guard !queryLower.isEmpty else { return FuzzyMatchResult(score: 0, matchedRanges: []) }
+
+        var queryIndex = queryLower.startIndex
+        var targetIndex = targetLower.startIndex
+        var score = 0
+        var matchedRanges: [Range<String.Index>] = []
+        var consecutiveMatches = 0
+        var lastMatchIndex: String.Index?
+
+        let separators: Set<Character> = ["/", ".", "_", "-", " "]
+
+        while queryIndex < queryLower.endIndex && targetIndex < targetLower.endIndex {
+            if queryLower[queryIndex] == targetLower[targetIndex] {
+                // Base match score
+                score += 10
+
+                // Consecutive match bonus
+                if let last = lastMatchIndex, targetLower.index(after: last) == targetIndex {
+                    consecutiveMatches += 1
+                    score += consecutiveMatches * 5
+                } else {
+                    consecutiveMatches = 0
+                }
+
+                // Separator bonus (match after separator or at start)
+                if targetIndex == targetLower.startIndex {
+                    score += 15
+                } else {
+                    let prevIndex = targetLower.index(before: targetIndex)
+                    if separators.contains(targetLower[prevIndex]) {
+                        score += 12
+                    }
+                    // CamelCase bonus
+                    let origChar = target[target.index(target.startIndex, offsetBy: targetLower.distance(from: targetLower.startIndex, to: targetIndex))]
+                    if origChar.isUppercase {
+                        score += 8
+                    }
+                }
+
+                // Record range (extend previous if consecutive)
+                let origTargetIndex = target.index(target.startIndex, offsetBy: targetLower.distance(from: targetLower.startIndex, to: targetIndex))
+                let nextOrigIndex = target.index(after: origTargetIndex)
+                if let last = matchedRanges.last, last.upperBound == origTargetIndex {
+                    matchedRanges[matchedRanges.count - 1] = last.lowerBound..<nextOrigIndex
+                } else {
+                    matchedRanges.append(origTargetIndex..<nextOrigIndex)
+                }
+
+                lastMatchIndex = targetIndex
+                queryIndex = queryLower.index(after: queryIndex)
+            } else {
+                // Gap penalty
+                if lastMatchIndex != nil {
+                    score -= 1
+                }
+            }
+            targetIndex = targetLower.index(after: targetIndex)
+        }
+
+        // All query characters must be matched
+        guard queryIndex == queryLower.endIndex else { return nil }
+
+        // Bonus for shorter targets (prefer exact/close matches)
+        let lengthDiff = target.count - query.count
+        score -= lengthDiff
+
+        return FuzzyMatchResult(score: max(0, score), matchedRanges: matchedRanges)
+    }
+}
+
+// MARK: - Quick Switcher File Item
+
+struct QuickSwitcherItem {
+    let filename: String       // e.g. "My Note"
+    let relativePath: String   // e.g. "folder/My Note.md"
+    let fullURL: URL
+    let score: Int
+    let matchedRanges: [Range<String.Index>]
+    let isCreateNew: Bool
+
+    var displayPath: String {
+        let dir = (relativePath as NSString).deletingLastPathComponent
+        return dir.isEmpty ? "" : dir
+    }
+}
+
+// MARK: - Quick Switcher Manager
+
+@MainActor
+final class QuickSwitcherManager: NSObject {
+    static let shared = QuickSwitcherManager()
+
+    private var panel: NSPanel?
+    private var searchField: NSTextField?
+    private var tableView: NSTableView?
+    private var scrollView: NSScrollView?
+    private var separator: NSBox?
+
+    private var items: [QuickSwitcherItem] = []
+    private var allFiles: [(filename: String, path: String, url: URL)] = []
+
+    var isVisible: Bool { panel?.isVisible ?? false }
+
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        if panel == nil {
+            createPanel()
+        }
+        refreshFileList()
+        searchField?.stringValue = ""
+        updateResults(query: "")
+        positionPanel()
+        panel?.makeKeyAndOrderFront(nil)
+        searchField?.becomeFirstResponder()
+    }
+
+    func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    // MARK: - Panel Creation
+
+    private func createPanel() {
+        let panel = KeyablePanel(
+            contentRect: NSRect(x: 0, y: 0, width: 580, height: 48),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isMovableByWindowBackground = false
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = true
+        panel.hasShadow = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.delegate = self
+
+        // Rounded visual effect background
+        let visualEffect = NSVisualEffectView(frame: panel.contentView!.bounds)
+        visualEffect.autoresizingMask = [.width, .height]
+        visualEffect.material = .popover
+        visualEffect.blendingMode = .behindWindow
+        visualEffect.state = .active
+        visualEffect.wantsLayer = true
+        visualEffect.layer?.cornerRadius = 12
+        visualEffect.layer?.masksToBounds = true
+        panel.contentView?.addSubview(visualEffect)
+
+        // Container for search + results
+        let container = NSView(frame: visualEffect.bounds)
+        container.autoresizingMask = [.width, .height]
+        visualEffect.addSubview(container)
+
+        // Search field
+        let field = NSTextField(frame: .zero)
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.placeholderString = "Search notes…"
+        field.font = .systemFont(ofSize: 18, weight: .regular)
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.delegate = self
+        field.cell?.sendsActionOnEndEditing = false
+        container.addSubview(field)
+        self.searchField = field
+
+        // Separator (hidden until results appear)
+        let separator = NSBox(frame: .zero)
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.boxType = .separator
+        separator.isHidden = true
+        container.addSubview(separator)
+        self.separator = separator
+
+        // Table view
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.isEditable = false
+
+        let tableView = NSTableView(frame: .zero)
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.rowHeight = 36
+        tableView.intercellSpacing = NSSize(width: 0, height: 0)
+        tableView.backgroundColor = .clear
+        tableView.style = .plain
+        tableView.selectionHighlightStyle = .regular
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.doubleAction = #selector(tableDoubleClicked)
+        tableView.target = self
+        self.tableView = tableView
+
+        let scrollView = NSScrollView(frame: .zero)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.autohidesScrollers = true
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsetsZero
+        container.addSubview(scrollView)
+        self.scrollView = scrollView
+
+        NSLayoutConstraint.activate([
+            field.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            field.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            field.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            field.heightAnchor.constraint(equalToConstant: 24),
+
+            separator.topAnchor.constraint(equalTo: field.bottomAnchor, constant: 8),
+            separator.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 4),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+        ])
+
+        self.panel = panel
+    }
+
+    private func positionPanel() {
+        guard let panel else { return }
+        let referenceWindow = NSApp.mainWindow ?? NSApp.keyWindow
+        let referenceFrame = referenceWindow?.frame ?? (NSScreen.main?.visibleFrame ?? .zero)
+
+        let x = referenceFrame.midX - panel.frame.width / 2
+        let y = referenceFrame.maxY - panel.frame.height - referenceFrame.height * 0.15
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    // MARK: - Data
+
+    private func refreshFileList() {
+        let workspace = WorkspaceManager.shared
+        var files: [(filename: String, path: String, url: URL)] = []
+
+        for index in workspace.activeVaultIndexes {
+            let rootURL = index.rootURL
+            for file in index.allFiles() {
+                let fullURL = rootURL.appendingPathComponent(file.path)
+                files.append((filename: file.filename, path: file.path, url: fullURL))
+            }
+        }
+
+        // If no indexes yet, fall back to file tree
+        if files.isEmpty {
+            for location in workspace.locations {
+                collectFiles(from: location.fileTree, rootURL: location.url, into: &files)
+            }
+        }
+
+        allFiles = files
+    }
+
+    private func collectFiles(from nodes: [FileNode], rootURL: URL, into files: inout [(filename: String, path: String, url: URL)]) {
+        for node in nodes {
+            if node.isDirectory {
+                collectFiles(from: node.children ?? [], rootURL: rootURL, into: &files)
+            } else {
+                let filename = node.url.deletingPathExtension().lastPathComponent
+                let relativePath = VaultIndex.relativePath(of: node.url, from: rootURL)
+                files.append((filename: filename, path: relativePath, url: node.url))
+            }
+        }
+    }
+
+    private func updateResults(query: String) {
+        if query.isEmpty {
+            // Show recent files
+            let recents = WorkspaceManager.shared.recentFiles
+            items = recents.compactMap { url in
+                let filename = url.deletingPathExtension().lastPathComponent
+                return QuickSwitcherItem(
+                    filename: filename,
+                    relativePath: url.lastPathComponent,
+                    fullURL: url,
+                    score: 100,
+                    matchedRanges: [],
+                    isCreateNew: false
+                )
+            }
+        } else {
+            // Fuzzy match
+            items = allFiles.compactMap { file in
+                guard let result = FuzzyMatcher.match(query: query, target: file.filename) else { return nil }
+                return QuickSwitcherItem(
+                    filename: file.filename,
+                    relativePath: file.path,
+                    fullURL: file.url,
+                    score: result.score,
+                    matchedRanges: result.matchedRanges,
+                    isCreateNew: false
+                )
+            }
+            .sorted { $0.score > $1.score }
+
+            // Limit results
+            if items.count > 50 { items = Array(items.prefix(50)) }
+
+            // Add create-on-miss if no results
+            if items.isEmpty {
+                let createName = query.hasSuffix(".md") ? query : "\(query).md"
+                items = [QuickSwitcherItem(
+                    filename: "Create \(createName)",
+                    relativePath: createName,
+                    fullURL: URL(fileURLWithPath: "/"),
+                    score: -1,
+                    matchedRanges: [],
+                    isCreateNew: true
+                )]
+            }
+        }
+
+        tableView?.reloadData()
+        if !items.isEmpty {
+            tableView?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            tableView?.scrollRowToVisible(0)
+        }
+        resizePanelToFit()
+    }
+
+    private static let maxVisibleRows = 10
+    // topPad(12) + field(24) + gap(8) + separator(1) + gap(4)
+    private static let searchAreaHeight: CGFloat = 49
+
+    private func resizePanelToFit() {
+        guard let panel, let tableView else { return }
+
+        let hasResults = !items.isEmpty
+        separator?.isHidden = !hasResults
+        scrollView?.isHidden = !hasResults
+
+        let totalHeight: CGFloat
+        if hasResults {
+            // Ask the table for its actual content height
+            tableView.tile()
+            let lastVisible = min(items.count, Self.maxVisibleRows) - 1
+            let tableHeight = tableView.rect(ofRow: lastVisible).maxY
+            totalHeight = Self.searchAreaHeight + tableHeight + 6
+        } else {
+            totalHeight = 48
+        }
+
+        var frame = panel.frame
+        let delta = totalHeight - frame.height
+        frame.origin.y -= delta
+        frame.size.height = totalHeight
+        panel.setFrame(frame, display: true, animate: false)
+    }
+
+    // MARK: - Actions
+
+    private func openSelectedItem() {
+        guard let tableView, tableView.selectedRow >= 0, tableView.selectedRow < items.count else { return }
+        let item = items[tableView.selectedRow]
+
+        if item.isCreateNew {
+            if let location = WorkspaceManager.shared.locations.first {
+                if let fileURL = WorkspaceManager.shared.createFile(named: item.relativePath, in: location.url) {
+                    WorkspaceManager.shared.openFile(at: fileURL)
+                }
+            }
+        } else {
+            WorkspaceManager.shared.openFile(at: item.fullURL)
+        }
+
+        dismiss()
+    }
+
+    @objc private func tableDoubleClicked() {
+        openSelectedItem()
+    }
+}
+
+// MARK: - NSWindowDelegate
+
+extension QuickSwitcherManager: NSWindowDelegate {
+    nonisolated func windowDidResignKey(_ notification: Notification) {
+        MainActor.assumeIsolated {
+            dismiss()
+        }
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension QuickSwitcherManager: NSTextFieldDelegate {
+    nonisolated func controlTextDidChange(_ obj: Notification) {
+        MainActor.assumeIsolated {
+            let query = searchField?.stringValue ?? ""
+            updateResults(query: query)
+        }
+    }
+
+    nonisolated func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        return MainActor.assumeIsolated {
+            if commandSelector == #selector(NSResponder.moveDown(_:)) {
+                moveSelection(by: 1)
+                return true
+            }
+            if commandSelector == #selector(NSResponder.moveUp(_:)) {
+                moveSelection(by: -1)
+                return true
+            }
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                openSelectedItem()
+                return true
+            }
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                dismiss()
+                return true
+            }
+            return false
+        }
+    }
+
+    private func moveSelection(by delta: Int) {
+        guard let tableView, !items.isEmpty else { return }
+        let current = tableView.selectedRow
+        let next = max(0, min(items.count - 1, current + delta))
+        tableView.selectRowIndexes(IndexSet(integer: next), byExtendingSelection: false)
+        tableView.scrollRowToVisible(next)
+    }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension QuickSwitcherManager: NSTableViewDataSource {
+    nonisolated func numberOfRows(in tableView: NSTableView) -> Int {
+        MainActor.assumeIsolated {
+            items.count
+        }
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension QuickSwitcherManager: NSTableViewDelegate {
+    nonisolated func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        MainActor.assumeIsolated {
+            guard row < items.count else { return nil }
+            let item = items[row]
+
+            let cellID = NSUserInterfaceItemIdentifier("QuickSwitcherCell")
+            let cell: QuickSwitcherCellView
+            if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? QuickSwitcherCellView {
+                cell = reused
+            } else {
+                cell = QuickSwitcherCellView()
+                cell.identifier = cellID
+            }
+
+            cell.configure(with: item)
+            return cell
+        }
+    }
+
+    nonisolated func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        36
+    }
+
+    nonisolated func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        QuickSwitcherRowView()
+    }
+}
+
+// MARK: - Cell View
+
+private class QuickSwitcherCellView: NSView {
+    private let iconView = NSImageView()
+    private let nameLabel = NSTextField(labelWithString: "")
+    private let pathLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyDown
+        addSubview(iconView)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        addSubview(nameLabel)
+
+        pathLabel.translatesAutoresizingMaskIntoConstraints = false
+        pathLabel.lineBreakMode = .byTruncatingMiddle
+        pathLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        addSubview(pathLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 16),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+            nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            pathLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 8),
+            pathLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+            pathLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    func configure(with item: QuickSwitcherItem) {
+        // Icon
+        if item.isCreateNew {
+            iconView.image = NSImage(systemSymbolName: "doc.badge.plus", accessibilityDescription: "Create")
+            iconView.contentTintColor = Theme.accentColor
+        } else {
+            iconView.image = NSImage(systemSymbolName: "doc.text", accessibilityDescription: "Document")
+            iconView.contentTintColor = .tertiaryLabelColor
+        }
+
+        // Name with highlighted matches
+        let nameString = NSMutableAttributedString(string: item.filename, attributes: [
+            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
+            .foregroundColor: NSColor.labelColor,
+        ])
+
+        for range in item.matchedRanges {
+            let nsRange = NSRange(range, in: item.filename)
+            nameString.addAttributes([
+                .font: NSFont.systemFont(ofSize: 13, weight: .bold),
+                .foregroundColor: Theme.accentColor,
+            ], range: nsRange)
+        }
+
+        nameLabel.attributedStringValue = nameString
+
+        // Path
+        let displayPath = item.displayPath
+        if displayPath.isEmpty {
+            pathLabel.stringValue = ""
+        } else {
+            pathLabel.attributedStringValue = NSAttributedString(string: displayPath, attributes: [
+                .font: NSFont.systemFont(ofSize: 11),
+                .foregroundColor: NSColor.tertiaryLabelColor,
+            ])
+        }
+    }
+}
+
+// MARK: - Row View (selection highlight)
+
+private class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+private class QuickSwitcherRowView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        if selectionHighlightStyle != .none {
+            let selectionColor = NSColor.controlAccentColor.withAlphaComponent(0.15)
+            selectionColor.setFill()
+            let rect = NSInsetRect(bounds, 4, 1)
+            NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6).fill()
+        }
+    }
+}

--- a/Clearly/SidebarViewController.swift
+++ b/Clearly/SidebarViewController.swift
@@ -74,6 +74,10 @@ class SidebarViewController: NSViewController {
         outlineView.menu = menu
         outlineView.doubleAction = nil
 
+        // Drag and drop
+        outlineView.registerForDraggedTypes([.fileURL])
+        outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
+
         sv.documentView = outlineView
         coordinator.outlineView = outlineView
         outlineView.colorCoordinator = coordinator

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -1,0 +1,476 @@
+import Foundation
+import GRDB
+import CryptoKit
+
+// MARK: - Record Types
+
+struct IndexedFile: Equatable {
+    let id: Int64
+    let path: String       // relative to vault root
+    let filename: String   // no extension
+    let contentHash: String
+    let modifiedAt: Date
+    let indexedAt: Date
+}
+
+struct SearchResult {
+    let file: IndexedFile
+    let snippet: String
+}
+
+struct LinkRecord {
+    let id: Int64
+    let sourceFileId: Int64
+    let targetName: String
+    let targetFileId: Int64?
+    let lineNumber: Int?
+    let displayText: String?
+    let context: String?
+    let sourceFilename: String?
+    let sourcePath: String?
+}
+
+// MARK: - VaultIndex
+
+final class VaultIndex {
+
+    private let dbPool: DatabasePool
+    let rootURL: URL
+
+    // MARK: Init
+
+    init(locationURL: URL) throws {
+        self.rootURL = locationURL
+
+        let indexDir = Self.indexDirectory()
+        try FileManager.default.createDirectory(at: indexDir, withIntermediateDirectories: true)
+
+        let hash = Self.pathHash(locationURL.standardizedFileURL.path)
+        let dbPath = indexDir.appendingPathComponent("\(hash).sqlite").path
+
+        dbPool = try DatabasePool(path: dbPath)
+
+        try migrate()
+    }
+
+    // MARK: Schema
+
+    private func migrate() throws {
+        var migrator = DatabaseMigrator()
+
+        migrator.registerMigration("v1") { db in
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS files (
+                    id INTEGER PRIMARY KEY,
+                    path TEXT UNIQUE NOT NULL,
+                    filename TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    modified_at REAL NOT NULL,
+                    indexed_at REAL NOT NULL
+                )
+                """)
+
+            try db.execute(sql: """
+                CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+                    filename,
+                    content,
+                    tokenize='porter unicode61'
+                )
+                """)
+
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS links (
+                    id INTEGER PRIMARY KEY,
+                    source_file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                    target_name TEXT NOT NULL,
+                    target_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
+                    line_number INTEGER,
+                    display_text TEXT,
+                    context TEXT
+                )
+                """)
+
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS tags (
+                    id INTEGER PRIMARY KEY,
+                    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                    tag TEXT NOT NULL,
+                    line_number INTEGER,
+                    source TEXT NOT NULL DEFAULT 'inline'
+                )
+                """)
+
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS headings (
+                    id INTEGER PRIMARY KEY,
+                    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                    text TEXT NOT NULL,
+                    level INTEGER NOT NULL,
+                    line_number INTEGER NOT NULL
+                )
+                """)
+
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag)")
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_tags_file ON tags(file_id)")
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_file_id)")
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_links_target_name ON links(target_name)")
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_links_target_file ON links(target_file_id)")
+        }
+
+        try migrator.migrate(dbPool)
+    }
+
+    // MARK: Write — Full Index
+
+    func indexAllFiles(showHiddenFiles: Bool = false) {
+        let markdownFiles = collectMarkdownFiles(under: rootURL, showHiddenFiles: showHiddenFiles)
+
+        do {
+            try dbPool.write { db in
+                // Get existing files for hash comparison
+                let existingRows = try Row.fetchAll(db, sql: "SELECT id, path, content_hash FROM files")
+                var existingByPath: [String: (id: Int64, hash: String)] = [:]
+                for row in existingRows {
+                    let path: String = row["path"]
+                    let id: Int64 = row["id"]
+                    let hash: String = row["content_hash"]
+                    existingByPath[path] = (id, hash)
+                }
+
+                var processedPaths = Set<String>()
+
+                for fileURL in markdownFiles {
+                    let relativePath = Self.relativePath(of: fileURL, from: rootURL)
+                    processedPaths.insert(relativePath)
+
+                    guard let data = try? Data(contentsOf: fileURL),
+                          let content = String(data: data, encoding: .utf8) else { continue }
+
+                    let hash = Self.contentHash(data)
+
+                    // Skip unchanged files
+                    if let existing = existingByPath[relativePath], existing.hash == hash {
+                        continue
+                    }
+
+                    let filename = fileURL.deletingPathExtension().lastPathComponent
+                    let modDate = Self.fileModDate(fileURL)
+                    let now = Date()
+
+                    if let existing = existingByPath[relativePath] {
+                        // Update existing file
+                        try db.execute(sql: """
+                            UPDATE files SET filename = ?, content_hash = ?, modified_at = ?, indexed_at = ?
+                            WHERE id = ?
+                            """, arguments: [filename, hash, modDate.timeIntervalSince1970, now.timeIntervalSince1970, existing.id])
+
+                        // Sync FTS (delete old, insert new)
+                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
+                        try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                                       arguments: [existing.id, filename, content])
+
+                        // Clear old parsed data
+                        try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existing.id])
+
+                        insertParsedData(db: db, fileId: existing.id, content: content)
+                    } else {
+                        // Insert new file
+                        try db.execute(sql: """
+                            INSERT INTO files (path, filename, content_hash, modified_at, indexed_at)
+                            VALUES (?, ?, ?, ?, ?)
+                            """, arguments: [relativePath, filename, hash, modDate.timeIntervalSince1970, now.timeIntervalSince1970])
+
+                        let fileId = db.lastInsertedRowID
+
+                        // Sync FTS
+                        try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                                       arguments: [fileId, filename, content])
+
+                        insertParsedData(db: db, fileId: fileId, content: content)
+                    }
+                }
+
+                // Remove files that no longer exist on disk
+                let existingPaths = Set(existingByPath.keys)
+                let removedPaths = existingPaths.subtracting(processedPaths)
+                for path in removedPaths {
+                    if let existing = existingByPath[path] {
+                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [existing.id])
+                    }
+                }
+
+                // Resolve wiki-link targets
+                try db.execute(sql: """
+                    UPDATE links SET target_file_id = (
+                        SELECT f.id FROM files f
+                        WHERE LOWER(f.filename) = LOWER(links.target_name)
+                        LIMIT 1
+                    )
+                    """)
+            }
+        } catch {
+            DiagnosticLog.log("VaultIndex: indexAllFiles failed — \(error.localizedDescription)")
+        }
+    }
+
+    private func insertParsedData(db: Database, fileId: Int64, content: String) {
+        let parsed = FileParser.parse(content: content)
+
+        for link in parsed.links {
+            try? db.execute(sql: """
+                INSERT INTO links (source_file_id, target_name, line_number, display_text)
+                VALUES (?, ?, ?, ?)
+                """, arguments: [fileId, link.target, link.lineNumber, link.alias])
+        }
+
+        for tag in parsed.tags {
+            try? db.execute(sql: """
+                INSERT INTO tags (file_id, tag, line_number, source)
+                VALUES (?, ?, ?, ?)
+                """, arguments: [fileId, tag.name, tag.lineNumber, tag.source.rawValue])
+        }
+
+        for heading in parsed.headings {
+            try? db.execute(sql: """
+                INSERT INTO headings (file_id, text, level, line_number)
+                VALUES (?, ?, ?, ?)
+                """, arguments: [fileId, heading.text, heading.level, heading.lineNumber])
+        }
+    }
+
+    // MARK: Read — Files
+
+    func allFiles() -> [IndexedFile] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: "SELECT * FROM files ORDER BY filename")
+                    .map(Self.indexedFile(from:))
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func searchFiles(query: String) -> [SearchResult] {
+        guard !query.isEmpty else { return [] }
+
+        // Escape FTS5 special characters and add prefix matching
+        let sanitized = query
+            .replacingOccurrences(of: "\"", with: "\"\"")
+        let ftsQuery = sanitized
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+            .map { "\"\($0)\"*" }
+            .joined(separator: " ")
+
+        guard !ftsQuery.isEmpty else { return [] }
+
+        do {
+            return try dbPool.read { db in
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT f.*, snippet(files_fts, 1, '<b>', '</b>', '…', 32) AS snippet
+                    FROM files_fts
+                    JOIN files f ON f.id = files_fts.rowid
+                    WHERE files_fts MATCH ?
+                    ORDER BY bm25(files_fts)
+                    LIMIT 50
+                    """, arguments: [ftsQuery])
+
+                return rows.map { row in
+                    SearchResult(
+                        file: Self.indexedFile(from: row),
+                        snippet: row["snippet"] ?? ""
+                    )
+                }
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func resolveWikiLink(name: String) -> IndexedFile? {
+        do {
+            return try dbPool.read { db in
+                // Case-insensitive match by filename, prefer shortest path for disambiguation
+                let row = try Row.fetchOne(db, sql: """
+                    SELECT * FROM files
+                    WHERE LOWER(filename) = LOWER(?)
+                    ORDER BY LENGTH(path) ASC
+                    LIMIT 1
+                    """, arguments: [name])
+                return row.map(Self.indexedFile(from:))
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: Read — Links
+
+    func linksTo(fileId: Int64) -> [LinkRecord] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT l.*, f.filename AS source_filename, f.path AS source_path
+                    FROM links l
+                    JOIN files f ON l.source_file_id = f.id
+                    WHERE l.target_file_id = ?
+                    ORDER BY f.filename
+                    """, arguments: [fileId])
+                    .map(Self.linkRecord(from:))
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func linksFrom(fileId: Int64) -> [LinkRecord] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT l.*, NULL AS source_filename, NULL AS source_path
+                    FROM links l
+                    WHERE l.source_file_id = ?
+                    ORDER BY l.target_name
+                    """, arguments: [fileId])
+                    .map(Self.linkRecord(from:))
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: Read — Tags
+
+    func allTags() -> [(tag: String, count: Int)] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT tag, COUNT(DISTINCT file_id) AS cnt
+                    FROM tags
+                    GROUP BY tag
+                    ORDER BY tag
+                    """)
+                    .map { (tag: $0["tag"] as String, count: Int($0["cnt"] as Int64)) }
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func filesForTag(tag: String) -> [IndexedFile] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT f.* FROM files f
+                    JOIN tags t ON t.file_id = f.id
+                    WHERE LOWER(t.tag) = LOWER(?)
+                    GROUP BY f.id
+                    ORDER BY f.filename
+                    """, arguments: [tag])
+                    .map(Self.indexedFile(from:))
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: Read — File by path
+
+    func file(forRelativePath path: String) -> IndexedFile? {
+        do {
+            return try dbPool.read { db in
+                let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE path = ?", arguments: [path])
+                return row.map(Self.indexedFile(from:))
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: Lifecycle
+
+    func close() {
+        // DatabasePool is released when the instance is deallocated.
+        // Explicit close not needed for GRDB v7, but we keep this for lifecycle clarity.
+    }
+
+    // MARK: Helpers
+
+    private static func indexDirectory() -> URL {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appName = Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
+        return dir.appendingPathComponent("\(appName)/indexes")
+    }
+
+    private static func pathHash(_ path: String) -> String {
+        let data = Data(path.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func contentHash(_ data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func fileModDate(_ url: URL) -> Date {
+        (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date) ?? Date()
+    }
+
+    static func relativePath(of fileURL: URL, from rootURL: URL) -> String {
+        let filePath = fileURL.standardizedFileURL.path
+        let rootPath = rootURL.standardizedFileURL.path
+        if filePath.hasPrefix(rootPath) {
+            var relative = String(filePath.dropFirst(rootPath.count))
+            if relative.hasPrefix("/") { relative = String(relative.dropFirst()) }
+            return relative
+        }
+        return filePath
+    }
+
+    private func collectMarkdownFiles(under rootURL: URL, showHiddenFiles: Bool) -> [URL] {
+        let fm = FileManager.default
+        let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
+        guard let enumerator = fm.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey], options: options) else {
+            return []
+        }
+
+        var files: [URL] = []
+        for case let url as URL in enumerator {
+            guard let isFile = try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isFile else { continue }
+            if FileNode.markdownExtensions.contains(url.pathExtension.lowercased()) {
+                files.append(url)
+            }
+        }
+        return files
+    }
+
+    private static func indexedFile(from row: Row) -> IndexedFile {
+        IndexedFile(
+            id: row["id"],
+            path: row["path"],
+            filename: row["filename"],
+            contentHash: row["content_hash"],
+            modifiedAt: Date(timeIntervalSince1970: row["modified_at"]),
+            indexedAt: Date(timeIntervalSince1970: row["indexed_at"])
+        )
+    }
+
+    private static func linkRecord(from row: Row) -> LinkRecord {
+        LinkRecord(
+            id: row["id"],
+            sourceFileId: row["source_file_id"],
+            targetName: row["target_name"],
+            targetFileId: row["target_file_id"],
+            lineNumber: row["line_number"],
+            displayText: row["display_text"],
+            context: row["context"],
+            sourceFilename: row["source_filename"],
+            sourcePath: row["source_path"]
+        )
+    }
+}

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -37,9 +37,12 @@ final class WorkspaceManager {
     // MARK: - Private
 
     private var fsStreams: [UUID: FSEventStreamRef] = [:]
+    @ObservationIgnored private var vaultIndexes: [UUID: VaultIndex] = [:]
     private var autoSaveWork: DispatchWorkItem?
     private var lastSavedText: String = ""
     private var accessedURLs: Set<URL> = []
+
+    var activeVaultIndexes: [VaultIndex] { Array(vaultIndexes.values) }
 
     // MARK: - UserDefaults Keys
 
@@ -83,6 +86,8 @@ final class WorkspaceManager {
 
     deinit {
         autoSaveWork?.cancel()
+        for index in vaultIndexes.values { index.close() }
+        vaultIndexes.removeAll()
         stopAllFSStreams()
         for url in accessedURLs {
             url.stopAccessingSecurityScopedResource()
@@ -102,6 +107,7 @@ final class WorkspaceManager {
         for index in locations.indices {
             locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
         }
+        reindexAllVaults()
     }
 
     // MARK: - Open Documents
@@ -419,12 +425,15 @@ final class WorkspaceManager {
         locations.append(location)
         persistLocations()
         startFSStream(for: location)
+        openVaultIndex(for: location)
 
         DiagnosticLog.log("Added location: \(url.lastPathComponent)")
     }
 
     func removeLocation(_ location: BookmarkedLocation) {
         stopFSStream(for: location.id)
+        vaultIndexes[location.id]?.close()
+        vaultIndexes.removeValue(forKey: location.id)
         if accessedURLs.contains(location.url) {
             location.url.stopAccessingSecurityScopedResource()
             accessedURLs.remove(location.url)
@@ -436,6 +445,9 @@ final class WorkspaceManager {
     func refreshTree(for locationID: UUID) {
         guard let index = locations.firstIndex(where: { $0.id == locationID }) else { return }
         locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
+
+        // Re-index on file system changes (hash check makes this efficient)
+        reindexVault(vaultIndexes[locationID])
     }
 
     // MARK: - Recents
@@ -504,6 +516,44 @@ final class WorkspaceManager {
             return newURL
         } catch {
             DiagnosticLog.log("Failed to rename: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func moveItem(at sourceURL: URL, into folderURL: URL) -> URL? {
+        let destURL = folderURL.appendingPathComponent(sourceURL.lastPathComponent)
+
+        guard !FileManager.default.fileExists(atPath: destURL.path) else {
+            DiagnosticLog.log("Move failed — \(sourceURL.lastPathComponent) already exists in \(folderURL.lastPathComponent)")
+            return nil
+        }
+
+        do {
+            try FileManager.default.moveItem(at: sourceURL, to: destURL)
+            // Update open document references if the moved item (or children) are open
+            for idx in openDocuments.indices {
+                if let fileURL = openDocuments[idx].fileURL {
+                    if fileURL == sourceURL {
+                        openDocuments[idx].fileURL = destURL
+                    } else if fileURL.path.hasPrefix(sourceURL.path + "/") {
+                        // Child of a moved folder
+                        let relative = String(fileURL.path.dropFirst(sourceURL.path.count))
+                        openDocuments[idx].fileURL = URL(fileURLWithPath: destURL.path + relative)
+                    }
+                }
+            }
+            if let current = currentFileURL {
+                if current == sourceURL {
+                    currentFileURL = destURL
+                } else if current.path.hasPrefix(sourceURL.path + "/") {
+                    let relative = String(current.path.dropFirst(sourceURL.path.count))
+                    currentFileURL = URL(fileURLWithPath: destURL.path + relative)
+                }
+            }
+            DiagnosticLog.log("Moved: \(sourceURL.lastPathComponent) → \(folderURL.lastPathComponent)/")
+            return destURL
+        } catch {
+            DiagnosticLog.log("Failed to move: \(error.localizedDescription)")
             return nil
         }
     }
@@ -637,6 +687,7 @@ final class WorkspaceManager {
             )
             locations.append(location)
             startFSStream(for: location)
+            openVaultIndex(for: location)
         }
 
         if !stored.isEmpty {
@@ -714,6 +765,30 @@ final class WorkspaceManager {
         // Only open if file still exists
         guard FileManager.default.fileExists(atPath: url.path) else { return }
         openFile(at: url)
+    }
+
+    // MARK: - Vault Index
+
+    private func openVaultIndex(for location: BookmarkedLocation) {
+        guard let index = try? VaultIndex(locationURL: location.url) else {
+            DiagnosticLog.log("Failed to create vault index for: \(location.url.lastPathComponent)")
+            return
+        }
+        vaultIndexes[location.id] = index
+        reindexVault(index)
+    }
+
+    private func reindexAllVaults() {
+        for index in vaultIndexes.values {
+            reindexVault(index)
+        }
+    }
+
+    private func reindexVault(_ index: VaultIndex?) {
+        let showHiddenFiles = self.showHiddenFiles
+        DispatchQueue.global(qos: .utility).async { [weak index] in
+            index?.indexAllFiles(showHiddenFiles: showHiddenFiles)
+        }
     }
 
     // MARK: - FSEventStream
@@ -829,6 +904,11 @@ final class WorkspaceManager {
         } else {
             DispatchQueue.main.sync(execute: flush)
         }
+    }
+
+    func liveCurrentFileText() -> String {
+        flushActiveEditorBuffer()
+        return currentFileText
     }
 
     /// Restore stored properties from the active document in openDocuments.

--- a/docs/expansion/IMPLEMENTATION.md
+++ b/docs/expansion/IMPLEMENTATION.md
@@ -1,0 +1,434 @@
+# Expansion Implementation Plan
+
+## Overview
+
+Add knowledge management (wiki-links, backlinks, global search, tags, quick switcher) and AI ecosystem integration (MCP server) to Clearly. Built on a SQLite cross-file index using GRDB.swift with FTS5 full-text search.
+
+The index is a derived cache — all data comes from the markdown files. Delete the database, it rebuilds from source. Files remain the source of truth.
+
+## Prerequisites
+
+- Xcode 16+ with Swift 5.9
+- XcodeGen installed (`xcodegen generate` after project.yml changes)
+- A folder with markdown files to test against
+
+## Phase Summary
+
+| Phase | Title | Delivers |
+|-------|-------|----------|
+| 1 | Cross-File Index + Quick Switcher | GRDB index of all vault files + Cmd+P fuzzy file finder |
+| 2 | Wiki-Links | `[[note]]` syntax highlighting, preview rendering, click navigation |
+| 3 | Wiki-Link Auto-Complete | `[[` trigger → popup with file suggestions |
+| 4 | Global Search | Cmd+Shift+F full-text search across all vault files |
+| 5 | Backlinks Panel | "What links here?" panel below editor |
+| 6 | Tags | `#tag` highlighting, indexing, sidebar tag browser |
+| 7 | MCP Server | Companion binary exposing vault to AI agents |
+
+---
+
+## Phase 1: Cross-File Index + Quick Switcher
+
+### Objective
+Build the complete SQLite index (files, links, tags, headings, FTS5) and the Quick Switcher (Cmd+P) as the first user-visible feature. The index populates everything upfront so later phases just add UI.
+
+### Rationale
+Every knowledge management feature depends on the index. Pairing it with the Quick Switcher means Phase 1 delivers something testable — not just plumbing.
+
+### Tasks
+
+- [ ] Add GRDB.swift package to `project.yml` (packages section + Clearly target dependency)
+- [ ] Run `xcodegen generate` to update Xcode project
+- [ ] Create `Clearly/VaultIndex.swift`:
+  - DatabasePool setup with WAL mode
+  - Full schema: `files`, `files_fts` (FTS5), `links`, `tags`, `headings` tables
+  - DatabaseMigrator for schema creation
+  - Index storage in `~/Library/Application Support/Clearly/indexes/` keyed by location path hash
+  - Query APIs: `searchFiles(query:)`, `allFiles()`, `resolveWikiLink(name:)`, `linksTo(fileId:)`, `linksFrom(fileId:)`, `allTags()`, `filesForTag(tag:)`
+- [ ] Create `Clearly/FileParser.swift`:
+  - Extract wiki-links: regex `\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]`
+  - Extract tags: regex `(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)`
+  - Extract headings: regex `^(#{1,6})\s+(.+)$`
+  - Extract frontmatter tags from YAML `tags:` field
+  - Strip fenced code blocks before extraction (avoid false positives)
+  - Pure function: `parse(content: String) -> ParseResult` (links, tags, headings)
+- [ ] Integrate indexer into `WorkspaceManager.swift`:
+  - Add `var vaultIndex: VaultIndex?` property
+  - On `addLocation()`: create/open VaultIndex, trigger full index
+  - On FSEventStream callback: call incremental re-index for changed files
+  - On `removeLocation()`: close index
+  - Background indexing on `DispatchQueue.global(qos: .utility)`
+- [ ] Create `Clearly/QuickSwitcherPanel.swift`:
+  - NSPanel (floating, non-activating): `styleMask: [.titled, .fullSizeContentView]`, hidden titlebar
+  - NSVisualEffectView with `.popover` material
+  - ~580px wide, centered on active window, upper third vertically
+  - NSTextField for search (~44px tall), NSTableView for results (~36px rows, max 8-10)
+  - Fuzzy matching: sequential character match with gap penalties, bonus for separator matches
+  - Return matched character ranges for highlighting in results
+  - Default state: show recently opened files when query is empty
+  - Create-on-miss: "Create [query].md" at bottom when no results
+  - Keyboard: Up/Down navigate, Enter opens, Escape dismisses
+- [ ] Add Cmd+P shortcut in `ClearlyApp.swift` (Cmd+O is taken by "Open…")
+- [ ] Wire quick switcher: result selection → `WorkspaceManager.openFile(at:)`
+
+### Success Criteria
+- Open a vault with 500+ markdown files. Index completes in <5 seconds.
+- Cmd+P opens quick switcher. Type characters → fuzzy-matched results appear instantly.
+- Select result → file opens in editor. Escape dismisses.
+- Modify a file externally → index updates within 1 second.
+- Delete index file → app recreates it on next launch.
+
+### Files Likely Affected
+- `project.yml` (GRDB dependency)
+- New: `Clearly/VaultIndex.swift`
+- New: `Clearly/FileParser.swift`
+- New: `Clearly/QuickSwitcherPanel.swift`
+- Modified: `Clearly/WorkspaceManager.swift` (index lifecycle, re-index triggers)
+- Modified: `Clearly/ClearlyApp.swift` (Cmd+P shortcut)
+
+---
+
+## Phase 2: Wiki-Links
+
+### Objective
+Support `[[note]]` syntax in editor (highlighting) and preview (rendering + click navigation). The foundational primitive for all cross-file linking.
+
+### Rationale
+Wiki-links are the core knowledge management feature. Every other cross-file feature (backlinks, auto-complete, graph) builds on this.
+
+### Tasks
+
+- [ ] Add wiki-link colors to `Clearly/Theme.swift`:
+  - `wikiLinkColor` (NSColor + SwiftUI wrapper) — distinct from regular link color
+  - `wikiLinkBrokenColor` — for unresolved links (dimmed/red)
+- [ ] Add wiki-link regex to `Clearly/MarkdownSyntaxHighlighter.swift`:
+  - Pattern: `\[\[([^\]\|#]+?)(?:#[^\]\|]+?)?(?:\|[^\]]+?)?\]\]`
+  - New `.wikiLink` case in `HighlightStyle` enum
+  - Insert after footnote markers (~line 83), before table rows
+  - Existing `cachedProtectedRanges` code-block exclusion handles protection automatically
+- [ ] Add `processWikiLinks()` to `Shared/MarkdownRenderer.swift`:
+  - Insert after `processEmoji()` (line 29), before `processCallouts()` (line 30)
+  - Follow `protectCodeRegions`/`restoreProtectedSegments` pattern
+  - Convert `[[note]]` → `<a href="clearly://wiki/note" class="wiki-link">note</a>`
+  - Convert `[[note|alias]]` → `<a href="clearly://wiki/note" class="wiki-link">alias</a>`
+  - Convert `[[note#heading]]` → `<a href="clearly://wiki/note#heading" class="wiki-link">note > heading</a>`
+  - Keep renderer pure — no VaultIndex dependency (QuickLook compatibility)
+- [ ] Add wiki-link CSS to `Shared/PreviewCSS.swift`:
+  - `.wiki-link` styling (distinct from regular links — e.g., dotted underline or different color)
+  - `.wiki-link-broken` styling (dimmed/strikethrough for unresolved)
+  - Cover light, dark, print, and export contexts
+- [ ] Add wiki-link click handler to `Clearly/PreviewView.swift`:
+  - JavaScript: intercept clicks on `a[href^="clearly://wiki/"]`, send target via `window.webkit.messageHandlers.wikiLinkClicked.postMessage(targetName)`
+  - Register `"wikiLinkClicked"` in `userContentController(_:didReceive:)` (follows `"linkClicked"` pattern at line 511)
+  - Resolve target name via `VaultIndex.resolveWikiLink(name:)`
+  - Open resolved file via `WorkspaceManager.openFile(at:)`
+  - Handle heading anchor: scroll to heading after file opens
+- [ ] Add JavaScript for link resolution in preview:
+  - Inject file list from VaultIndex into preview page
+  - Mark unresolved links with `.wiki-link-broken` class
+  - This runs client-side so MarkdownRenderer stays pure
+- [ ] Add Cmd+click wiki-link navigation in editor:
+  - Detect click on wiki-link range in `EditorView.swift`
+  - Resolve and navigate (same path as preview click)
+
+### Success Criteria
+- Type `[[My Note]]` in editor → highlighted with wiki-link color.
+- Switch to preview → link is rendered and clickable.
+- Click wiki-link in preview → target file opens in editor.
+- Cmd+click wiki-link in editor → same navigation.
+- `[[nonexistent]]` → styled as broken link (dimmed/red).
+- `[[note|display text]]` → shows "display text" in preview, navigates to "note".
+- Wiki-links inside code blocks are NOT processed.
+
+### Files Likely Affected
+- Modified: `Clearly/Theme.swift` (new colors)
+- Modified: `Clearly/MarkdownSyntaxHighlighter.swift` (wiki-link pattern + style)
+- Modified: `Shared/MarkdownRenderer.swift` (processWikiLinks)
+- Modified: `Shared/PreviewCSS.swift` (wiki-link styles)
+- Modified: `Clearly/PreviewView.swift` (click handler + JS injection)
+- Modified: `Clearly/EditorView.swift` (Cmd+click)
+
+---
+
+## Phase 3: Wiki-Link Auto-Complete
+
+### Objective
+When user types `[[` in the editor, show a popup with fuzzy-matched file suggestions from the vault index.
+
+### Rationale
+Wiki-links without auto-complete are tedious — you have to remember exact file names. This is the feature that makes wiki-linking feel effortless.
+
+### Tasks
+
+- [ ] Create `Clearly/WikiLinkCompletionWindow.swift`:
+  - Borderless `NSWindow` (child of editor window, `.above` ordering)
+  - Position below cursor via `NSTextView.firstRect(forCharacterRange:actualRange:)`
+  - ~300px wide, max 8 rows
+  - `NSTableView` with file name + folder path (dimmed)
+  - Fuzzy matching with highlighted match characters (reuse Phase 1 fuzzy matcher)
+- [ ] Add trigger detection in `Clearly/EditorView.swift`:
+  - In `textDidChange` delegate, detect `[[` was just typed
+  - Check character isn't inside a code block (use `cachedProtectedRanges`)
+  - Show completion window, seeded with all files (or recents for large vaults)
+- [ ] Wire completion lifecycle:
+  - As user types after `[[`, filter results via fuzzy match
+  - Up/Down: navigate results
+  - Enter/Tab: insert `selectedFileName]]` (completing the link)
+  - Escape: dismiss popup
+  - Backspace past `[[`: dismiss popup
+  - `]]` typed manually: dismiss popup
+  - Click outside: dismiss popup
+  - Pipe `|` typed: keep popup open (user is adding alias)
+- [ ] Handle edge cases:
+  - Vault with 10,000+ files: show top 50 fuzzy matches, not all files
+  - File names with special characters
+  - Cursor at end of document
+  - Multiple monitors / different window positions
+
+### Success Criteria
+- Type `[[` → popup appears below cursor with file suggestions.
+- Type characters → results filter in real-time with fuzzy matching.
+- Select file → `[[filename]]` inserted, popup dismissed.
+- Escape → popup dismissed, `[[` remains in editor.
+- Popup doesn't appear inside code blocks.
+- Works smoothly with 1,000+ files in vault.
+
+### Files Likely Affected
+- New: `Clearly/WikiLinkCompletionWindow.swift`
+- Modified: `Clearly/EditorView.swift` (trigger detection, popup management)
+
+---
+
+## Phase 4: Global Search
+
+### Objective
+Full-text search across all vault files with results in the sidebar. Cmd+Shift+F activates.
+
+### Rationale
+Search is the most immediately useful knowledge management feature for existing users. Even without wiki-links, people want to find things across their notes.
+
+### Tasks
+
+- [ ] Create search mode in sidebar:
+  - Add `isSearchMode` state to `SidebarViewController.swift`
+  - When active: show search field at top + results below, hide file tree
+  - When deactivated: return to file tree
+  - Cmd+Shift+F toggles search mode (add shortcut in `ClearlyApp.swift`)
+  - Escape in search field exits search mode
+- [ ] Create `Clearly/SearchResultsView.swift`:
+  - AppKit-based (consistent with `FileExplorerView`)
+  - Search field with 150ms debounce, starts after 2+ characters
+  - Results grouped by file: file name header with match count badge
+  - Under each file: indented match excerpts with 1 line context before/after
+  - Matched terms highlighted in results
+  - Two sections: file name matches first, then content matches
+- [ ] Wire search to VaultIndex:
+  - FTS5 `MATCH` query with `bm25()` ranking
+  - `snippet()` function for context extraction
+  - Also search `files.filename` for name matches (separate from content)
+- [ ] Wire result clicks:
+  - Click file header → open file via `WorkspaceManager.openFile(at:)`
+  - Click match excerpt → open file AND scroll to match line
+  - Scrolling to line: need to pass line number through to `EditorView`
+- [ ] Add Cmd+Shift+F shortcut in `ClearlyApp.swift`
+
+### Success Criteria
+- Cmd+Shift+F → sidebar switches to search mode with focused search field.
+- Type "keyword" → results appear grouped by file with highlighted matches.
+- Click a result → file opens and scrolls to the matching line.
+- Escape → returns to file tree.
+- Search across 1,000 files completes in <100ms.
+- Quoted phrases work: `"exact phrase"` matches only that phrase.
+
+### Files Likely Affected
+- Modified: `Clearly/SidebarViewController.swift` (search mode toggle)
+- New: `Clearly/SearchResultsView.swift`
+- Modified: `Clearly/ClearlyApp.swift` (Cmd+Shift+F shortcut)
+- Modified: `Clearly/VaultIndex.swift` (search query with snippets)
+- Modified: `Clearly/EditorView.swift` (scroll-to-line support)
+
+---
+
+## Phase 5: Backlinks Panel
+
+### Objective
+Show all files that link TO the current file in a collapsible panel below the editor.
+
+### Rationale
+Backlinks surface connections you didn't know existed. This is the feature that turns a collection of files into a knowledge graph.
+
+### Tasks
+
+- [ ] Create `Clearly/BacklinksState.swift`:
+  - `@Observable` class (follows `OutlineState` pattern)
+  - `isVisible: Bool`, `backlinks: [Backlink]`, `unlinkedMentions: [Backlink]`
+  - `struct Backlink`: source file name, path, context line, line number
+  - `update(for fileURL: URL, using index: VaultIndex)` method
+- [ ] Create `Clearly/BacklinksView.swift`:
+  - SwiftUI view (simpler than AppKit for a read-only panel)
+  - "Backlinks" header with count badge
+  - **Linked mentions** section: file name (clickable) + 1-2 lines of context with `[[link]]` highlighted
+  - **Unlinked mentions** section (collapsed by default): plain text matches of file name in other files. "Link" button to convert to `[[wiki-link]]`
+  - Empty state: "No other documents link to this file"
+- [ ] Integrate into `Clearly/ContentView.swift`:
+  - Add `@StateObject private var backlinksState = BacklinksState()`
+  - Add backlinks panel below `bottomBar()` in `mainContent` VStack (follows `FindBarView` pattern)
+  - Collapsible with divider line
+  - Height: ~200px default, or use draggable divider
+- [ ] Add toggle:
+  - Button in `bottomBar()` right-side button group (follows outline toggle pattern at lines 190-198)
+  - Cmd+Shift+B shortcut in `ClearlyApp.swift`
+- [ ] Update backlinks on active document change:
+  - Watch `WorkspaceManager.currentFileURL` changes
+  - Re-query VaultIndex for backlinks to current file
+- [ ] "Link" button for unlinked mentions:
+  - Convert plain text mention to `[[wiki-link]]` in source file
+  - Update the source file's content and save
+  - Re-index affected files
+
+### Success Criteria
+- Open a note that other notes link to → backlinks panel shows linking files with context.
+- Click a backlink → opens the linking file.
+- Switch to a different file → backlinks panel updates.
+- Cmd+Shift+B toggles panel visibility.
+- File with no backlinks → "No other documents link to this file".
+- Unlinked mentions section shows plain-text matches, collapsed by default.
+
+### Files Likely Affected
+- New: `Clearly/BacklinksState.swift`
+- New: `Clearly/BacklinksView.swift`
+- Modified: `Clearly/ContentView.swift` (panel integration + toggle)
+- Modified: `Clearly/ClearlyApp.swift` (Cmd+Shift+B shortcut)
+- Modified: `Clearly/VaultIndex.swift` (unlinked mentions query)
+
+---
+
+## Phase 6: Tags
+
+### Objective
+`#tag` syntax highlighting in editor, tag indexing, and a sidebar tag browser for filtering files by tag.
+
+### Rationale
+Tags complement wiki-links as an organizational tool. Wiki-links create specific connections; tags create categories.
+
+### Tasks
+
+- [ ] Add tag color to `Clearly/Theme.swift`:
+  - `tagColor` (NSColor + SwiftUI wrapper) — distinct from wiki-links and regular links
+- [ ] Add tag regex to `Clearly/MarkdownSyntaxHighlighter.swift`:
+  - Pattern: `(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)`
+  - New `.tag` case in `HighlightStyle` enum
+  - Must NOT match headings (`# ` with space) — regex handles this via no-space requirement
+  - Must NOT match inside code blocks (protected by `cachedProtectedRanges`)
+- [ ] Add `processTags()` to `Shared/MarkdownRenderer.swift`:
+  - Convert `#tag` → `<span class="tag" data-tag="tag">#tag</span>`
+  - Follow `protectCodeRegions`/`restoreProtectedSegments` pattern
+  - Add click handler in JavaScript: sends tag name via message handler
+- [ ] Add tag CSS to `Shared/PreviewCSS.swift`:
+  - `.tag` styling: subtle background, rounded, clickable appearance
+  - Light + dark mode variants
+- [ ] Add tag click handler in `Clearly/PreviewView.swift`:
+  - Register `"tagClicked"` message handler
+  - On click → activate sidebar search filtered to tag (or dedicated tag filter)
+- [ ] Create tag browser section in sidebar:
+  - New section in `FileExplorerView.swift` below Locations
+  - Collapsible tree for nested tags (`#project/clearly` → `project` > `clearly`)
+  - Each tag shows file count badge
+  - Click tag → filter file tree to files with that tag
+  - Query `VaultIndex.allTags()` for tag list with counts
+- [ ] Handle frontmatter tags:
+  - FileParser already extracts YAML `tags: [foo, bar]` (from Phase 1)
+  - Display alongside inline tags in tag browser (no distinction needed)
+
+### Success Criteria
+- Type `#project` in editor → highlighted with tag color.
+- Tags inside code blocks are NOT highlighted.
+- `#123` (all digits) is NOT treated as a tag.
+- `# Heading` (with space) is NOT treated as a tag.
+- Sidebar shows tag browser with all tags from vault.
+- Nested tags shown as tree: `#project/clearly` under `project`.
+- Click tag → file tree filters to matching files.
+- Frontmatter `tags:` field values appear in tag browser.
+
+### Files Likely Affected
+- Modified: `Clearly/Theme.swift` (tag color)
+- Modified: `Clearly/MarkdownSyntaxHighlighter.swift` (tag pattern + style)
+- Modified: `Shared/MarkdownRenderer.swift` (processTags)
+- Modified: `Shared/PreviewCSS.swift` (tag styles)
+- Modified: `Clearly/PreviewView.swift` (tag click handler)
+- Modified: `Clearly/FileExplorerView.swift` (tag browser section)
+
+---
+
+## Phase 7: MCP Server
+
+### Objective
+Ship a companion CLI binary that exposes the vault to AI agents via the Model Context Protocol. Direct download includes it automatically; App Store users install separately.
+
+### Rationale
+MCP makes Clearly visible to the AI ecosystem (Claude Desktop, ChatGPT, Cursor). Most note apps don't have native MCP support — this is a first-class differentiator. The binary is a thin wrapper over VaultIndex — marginal effort on top of existing infrastructure.
+
+### Tasks
+
+- [ ] Add MCP Swift SDK dependency to `project.yml`:
+  ```yaml
+  MCP:
+    url: https://github.com/modelcontextprotocol/swift-sdk.git
+    from: "0.11.0"
+  ```
+- [ ] Add `ClearlyMCP` target to `project.yml`:
+  - `type: commandLineTool`
+  - Sources: `ClearlyMCP/` + `Shared/` (for shared model types)
+  - Dependencies: GRDB, MCP SDK
+- [ ] Create `ClearlyMCP/` directory with:
+  - `main.swift` — entry point, parse `--vault` argument, open VaultIndex (read-only), start MCP server on stdio
+  - `MCPTools.swift` — implement tool handlers:
+    - `search_notes(query)` → FTS5 search, return file names + matching context
+    - `read_note(path)` → return full file content
+    - `list_notes(folder?)` → list all notes, optional folder filter
+  - `--test` flag: verify index is readable, print success/failure, exit
+- [ ] Companion binary distribution:
+  - **Direct download**: Bundle binary at `Contents/Helpers/ClearlyMCP` in app bundle. On first launch, copy to `~/Library/Application Support/Clearly/ClearlyMCP`. Update on app updates.
+  - **App Store**: One-click "Install MCP Helper" button in Settings downloads the binary from GitHub Releases via `URLSession`, writes to `~/Library/Application Support/Clearly/ClearlyMCP`, sets executable permission. No terminal needed.
+- [ ] Create MCP Settings panel in `Clearly/SettingsView.swift`:
+  - New "MCP" tab/section
+  - **Detection**: Check known paths for companion binary
+  - **Direct download state**: Green checkmark, version, vault path selector
+  - **App Store state**: One-click "Install MCP Helper" button (downloads + installs automatically)
+  - **"Copy Claude Desktop Config"** button: generates JSON with resolved binary path + vault path, copies to clipboard
+  - **"Test Connection"** button: runs binary with `--test`, shows result
+  - **Auto-detect Claude Desktop**: check if config file exists, offer to add config (with confirmation)
+- [ ] Run `xcodegen generate` after project.yml changes
+
+### Success Criteria
+- Direct download build: MCP binary auto-installed to App Support on first launch. No user action needed.
+- App Store build: Settings panel shows install instructions.
+- Configure in Claude Desktop config JSON.
+- In Claude Desktop: "What notes do I have?" → lists vault files.
+- "Search for notes about [topic]" → returns matching files with context.
+- "Read the note at [path]" → returns full content.
+- "Test Connection" button in Settings → shows success.
+
+### Files Likely Affected
+- `project.yml` (MCP SDK dependency + ClearlyMCP target)
+- New: `ClearlyMCP/main.swift`
+- New: `ClearlyMCP/MCPTools.swift`
+- Modified: `Clearly/SettingsView.swift` (MCP settings panel)
+- Modified: `Clearly/ClearlyApp.swift` (binary installation on launch for direct download)
+
+---
+
+## Post-Implementation
+
+- [ ] Update `Shared/Resources/demo.md` with wiki-link, tag, and backlink examples
+- [ ] Update `website/index.html` feature list with knowledge management + MCP
+- [ ] Update `CLAUDE.md` with new architecture (VaultIndex, FileParser, MCP)
+- [ ] Performance testing with 5,000+ file vault
+- [ ] Update `Clearly/Info.plist` if new URL schemes needed
+
+## Notes
+
+- **Index is a derived cache**: all data comes from markdown files. Delete it, it rebuilds. Stored in App Support, not inside the vault. No portability concern.
+- **Cmd+P for quick switcher** (not Cmd+O which is taken by "Open…"). Matches VS Code convention.
+- **MarkdownRenderer stays pure**: no VaultIndex dependency. Wiki-link resolution happens in JavaScript on the PreviewView side. This keeps QuickLook compatibility.
+- **FileParser extracts everything in Phase 1** (links, tags, headings) even though some UI doesn't ship until later phases. Avoids re-indexing and schema migrations.
+- **GRDB.swift v7.x**: provides DatabasePool (concurrent reads), FTS5 support, DatabaseMigrator, and raw sqlite3* handle for future sqlite-vec.

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,0 +1,157 @@
+# Expansion Progress
+
+## Status: Phase 1 - Completed
+
+## Quick Reference
+- Research: `docs/expansion/RESEARCH.md`
+- Implementation: `docs/expansion/IMPLEMENTATION.md`
+
+---
+
+## Phase Progress
+
+### Phase 1: Cross-File Index + Quick Switcher
+**Status:** Completed (2026-04-13)
+
+#### Tasks Completed
+- [x] Added GRDB.swift v7+ dependency to `project.yml` (Clearly target only, not QuickLook)
+- [x] Created `Clearly/FileParser.swift` — pure markdown parser extracting wiki-links, tags, headings with code-block skip ranges
+- [x] Created `Clearly/VaultIndex.swift` — SQLite index via GRDB DatabasePool, FTS5 full-text search, full schema (files, files_fts, links, tags, headings), content-hash-based incremental indexing, all read APIs
+- [x] Integrated VaultIndex into `Clearly/WorkspaceManager.swift` — index lifecycle wired to addLocation/removeLocation/refreshTree/restoreLocations/deinit, background indexing on utility queue
+- [x] Created `Clearly/QuickSwitcherPanel.swift` — borderless NSPanel with vibrancy, fuzzy matching with highlighted characters, keyboard navigation (Up/Down/Enter/Escape), recent files on empty query, create-on-miss, dynamic resizing to fit content
+- [x] Wired Cmd+P shortcut in `Clearly/ClearlyApp.swift` via local event monitor, moved Print to Cmd+Shift+P
+- [x] Added Debug-only dev bundle ID (`com.sabotage.clearly.dev`) and product name ("Clearly Dev") for safe side-by-side testing
+- [x] VaultIndex uses `Bundle.main.bundleIdentifier` for App Support path, keeping dev/prod indexes isolated
+
+#### Decisions Made
+- FTS5 uses standalone storage (not external content mode) — avoids column mismatch bug and supports `snippet()` for Phase 4 global search
+- Borderless NSPanel with `KeyablePanel` subclass (overrides `canBecomeKey`) for proper keyboard input without titlebar
+- `NSTableView.style = .plain` to eliminate hidden inset padding on macOS 11+
+- Panel resizes using `tableView.rect(ofRow:).maxY` for pixel-accurate height instead of manual math
+- `@ObservationIgnored` on `vaultIndexes` dictionary to prevent `@Observable` macro expansion issues with GRDB types
+- `indexAllFiles()` uses `self.rootURL` (no parameter) to prevent caller/instance URL divergence
+- Full schema (links, tags, headings) created in Phase 1 even though UI ships in later phases — avoids schema migrations
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 2: Wiki-Links
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 3: Wiki-Link Auto-Complete
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 4: Global Search
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 5: Backlinks Panel
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 6: Tags
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+### Phase 7: MCP Server
+**Status:** Not Started
+
+#### Tasks Completed
+- (none yet)
+
+#### Decisions Made
+- (none yet)
+
+#### Blockers
+- (none)
+
+---
+
+## Session Log
+
+### 2026-04-13 — Phase 1 Implementation
+- Built all 6 tasks: GRDB dep → FileParser → VaultIndex → WorkspaceManager integration → QuickSwitcherPanel → Cmd+P shortcut
+- Fixed FTS5 external content bug (content='files' referenced non-existent column) — switched to standalone FTS
+- Fixed borderless NSPanel keyboard input (canBecomeKey override)
+- Fixed NSTableView hidden inset padding (.style = .plain)
+- Fixed panel sizing to use rect(ofRow:).maxY instead of manual pixel math
+- Added dev bundle ID separation for safe testing alongside production
+- Verified: 11 files indexed, 73 headings extracted, Quick Switcher functional with fuzzy search
+
+---
+
+## Files Changed
+- `project.yml` — GRDB dependency, dev bundle IDs for Debug config
+- `Clearly/FileParser.swift` (new) — markdown parser for wiki-links, tags, headings
+- `Clearly/VaultIndex.swift` (new) — SQLite index with GRDB, FTS5, full schema
+- `Clearly/QuickSwitcherPanel.swift` (new) — NSPanel, fuzzy matching, keyboard nav
+- `Clearly/WorkspaceManager.swift` — VaultIndex lifecycle integration
+- `Clearly/ClearlyApp.swift` — Cmd+P shortcut, Print → Cmd+Shift+P
+
+## Architectural Decisions
+- **GRDB over raw SQLite or SwiftData**: DatabasePool gives concurrent WAL reads, DatabaseMigrator for schema versioning, raw sqlite3* handle available for future sqlite-vec embeddings
+- **FTS5 standalone (not external content)**: External content mode requires matching columns in the content table. Standalone stores its own copy but supports snippet() and is simpler to maintain
+- **Borderless NSPanel over .titled**: Eliminates the ~28pt invisible titlebar that was impossible to work around with fullSizeContentView. Requires KeyablePanel subclass for keyboard input
+- **Index stored in App Support by bundle ID**: `~/Library/Containers/{bundleID}/Data/Library/Application Support/{bundleID}/indexes/` — sandbox-safe, dev/prod isolated
+- **FileParser extracts everything upfront**: Links, tags, headings all parsed in Phase 1 even though wiki-link UI, tag browser, etc. ship in later phases. Avoids re-indexing and schema migrations
+
+## Lessons Learned
+- NSTableView.style defaults to .inset on macOS 11+, adding hidden vertical padding that breaks manual height calculations. Always set .plain for precise sizing
+- Borderless NSPanel can't become key by default — must subclass and override canBecomeKey
+- FTS5 external content mode (content='table') requires the referenced table to have columns matching the FTS column names — easy to miss
+- xcodegen must be re-run after adding new Swift files, not just after changing project.yml
+- @Observable macro expansion fails on properties whose types come from external packages — use @ObservationIgnored for non-observable state

--- a/docs/expansion/RESEARCH.md
+++ b/docs/expansion/RESEARCH.md
@@ -1,0 +1,512 @@
+# Expansion Research: Knowledge Management + AI Integration
+
+## Overview
+
+Transform Clearly from a polished markdown editor into a full knowledge management tool. This means adding cross-file intelligence (wiki-links, backlinks, global search, tags) and AI ecosystem integration (MCP server) — all on top of the existing native macOS foundation.
+
+Scope: Phases 0-3 only. Built-in AI (Phase 4) and monetization (Phase 5) are explicitly out of scope.
+
+## Problem Statement
+
+Clearly's rendering and preview side is strong (math, mermaid, callouts, code highlighting, PDF export). The knowledge management side is entirely missing — no cross-file awareness beyond the file tree. Every file is an island. Users can't link notes, search across their vault, track what references what, or expose their notes to AI agents.
+
+The gap isn't about polish — it's about architecture. Clearly has no persistent index of file contents, no cross-file link tracking, and no way to query across the vault. Everything depends on building that foundation first.
+
+## User Stories / Use Cases
+
+1. **Wiki-linking**: "I'm writing about a concept I've explored in another note. I type `[[` and get a popup suggesting matching files. I select one, and the link is inserted. In preview, clicking it opens that file."
+2. **Backlinks**: "I open a note and see a panel showing every other note that links to this one, with context. I discover connections I'd forgotten."
+3. **Global search**: "I press Cmd+Shift+F and search for a phrase. Results appear grouped by file with surrounding context. I click one and jump directly to that line."
+4. **Quick switcher**: "I press Cmd+O, type a few characters, and instantly find the file I want from hundreds of notes. It's faster than scrolling the sidebar."
+5. **Tags**: "I tag notes with `#project/clearly` and `#idea`. The sidebar shows all my tags in a tree. Clicking one filters to matching files."
+6. **MCP integration**: "I configure Clearly as an MCP server in Claude Desktop. I ask Claude 'what notes do I have about pricing?' and it searches my vault and answers."
+
+---
+
+## Technical Research
+
+### Phase 0: Cross-File Index (SQLite + FTS5)
+
+#### Approach: GRDB.swift
+
+**Recommendation: Use [GRDB.swift](https://github.com/groue/GRDB.swift) (v7.x).**
+
+Why GRDB over alternatives:
+- **vs raw `import SQLite3`**: GRDB gives you `DatabasePool` (concurrent reads via WAL mode), `DatabaseMigrator`, `Codable` record mapping, and `ValueObservation` for reactive SwiftUI — you'd rebuild half of this manually with raw C.
+- **vs SQLite.swift**: GRDB is 3-12x faster on fetches and supports concurrent reads. SQLite.swift uses a single serialized connection.
+- **vs SwiftData/CoreData**: Need direct FTS5 access and later sqlite-vec for embeddings. Apple's abstractions add overhead without benefit.
+
+GRDB exposes the raw `sqlite3*` handle for loading C extensions (sqlite-vec later).
+
+**FTS5 availability**: Enabled in macOS's bundled SQLite since macOS 10.13. Works out of the box on our deployment target (macOS 14.0). GRDB's Swift FTS5 wrappers require a custom build flag, but raw SQL `CREATE VIRTUAL TABLE ... USING fts5(...)` works immediately.
+
+**Threading**: `DatabasePool` handles everything. WAL mode is automatic — multiple threads read simultaneously, writes are serialized. One pool instance shared app-wide. Sub-10ms queries at 10,000+ documents.
+
+#### Schema Design
+
+```sql
+-- Core file metadata
+CREATE TABLE files (
+    id INTEGER PRIMARY KEY,
+    path TEXT UNIQUE NOT NULL,        -- relative to vault root
+    filename TEXT NOT NULL,            -- just the filename without extension
+    content_hash TEXT NOT NULL,        -- for incremental re-indexing
+    modified_at REAL NOT NULL,         -- file modification date
+    indexed_at REAL NOT NULL           -- when we last indexed this
+);
+
+-- Full-text search index
+CREATE VIRTUAL TABLE files_fts USING fts5(
+    filename,                          -- searchable filename
+    content,                           -- full file content for FTS
+    content=files,                     -- external content table
+    content_rowid=id,
+    tokenize='porter unicode61'        -- stemming + unicode support
+);
+
+-- Wiki-links between files
+CREATE TABLE links (
+    id INTEGER PRIMARY KEY,
+    source_file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    target_name TEXT NOT NULL,          -- raw link text (e.g., "My Note")
+    target_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL, -- resolved target (nullable if unresolved)
+    line_number INTEGER,               -- source line for context
+    display_text TEXT,                  -- alias text if [[note|alias]]
+    context TEXT                        -- surrounding text for backlinks display
+);
+
+-- Tags
+CREATE TABLE tags (
+    id INTEGER PRIMARY KEY,
+    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    tag TEXT NOT NULL,                  -- normalized: lowercase, no #
+    line_number INTEGER,
+    source TEXT NOT NULL DEFAULT 'inline'  -- 'inline' or 'frontmatter'
+);
+CREATE INDEX idx_tags_tag ON tags(tag);
+CREATE INDEX idx_tags_file ON tags(file_id);
+
+-- Headings (for [[note#heading]] resolution and outline)
+CREATE TABLE headings (
+    id INTEGER PRIMARY KEY,
+    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    text TEXT NOT NULL,
+    level INTEGER NOT NULL,            -- 1-6
+    line_number INTEGER NOT NULL
+);
+```
+
+#### Index Storage Location
+
+Store in `~/Library/Application Support/Clearly/indexes/` keyed by vault path hash. Not inside the vault (`.clearly/` pollutes user files, causes git noise). App Support is the standard macOS location for derived data.
+
+#### Indexing Pipeline
+
+1. **Initial index**: On location bookmark add, walk all markdown files, parse each, insert into SQLite. Use `DispatchQueue.global(qos: .utility)` with batch inserts (GRDB's `inTransaction` for performance).
+2. **Incremental updates**: FSEventStream (already exists in WorkspaceManager) fires on file changes. Compare `content_hash` — only re-parse changed files. Re-resolve links affected by renames/deletes.
+3. **File parsing**: For each file, extract:
+   - Content for FTS
+   - Wiki-links: regex `\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]`
+   - Tags: regex `(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)` (must contain at least one non-digit)
+   - Headings: regex `^(#{1,6})\s+(.+)$`
+   - Frontmatter tags from YAML `tags:` field
+4. **Code block exclusion**: Strip fenced code blocks before extracting links/tags (same pattern as MarkdownSyntaxHighlighter's cachedProtectedRanges).
+5. **Performance target**: Index 1,000 files in <5 seconds. Re-index single file in <50ms.
+
+#### Integration with WorkspaceManager
+
+```
+WorkspaceManager.swift changes:
+- Add `var vaultIndex: VaultIndex?` property
+- On addLocation(): create/open VaultIndex for that location, trigger initial index
+- On FSEventStream callback: call vaultIndex.reindexChangedFiles(paths:)
+- On removeLocation(): close and optionally delete index
+```
+
+New file: `Clearly/VaultIndex.swift` — wraps GRDB DatabasePool, provides query APIs:
+- `searchFiles(query:) -> [SearchResult]` (FTS5)
+- `allFiles() -> [FileRecord]`
+- `linksFrom(fileId:) -> [Link]`
+- `linksTo(fileId:) -> [Link]` (backlinks)
+- `tagsForFile(fileId:) -> [Tag]`
+- `filesForTag(tag:) -> [FileRecord]`
+- `allTags() -> [(tag: String, count: Int)]`
+- `resolveWikiLink(name:) -> FileRecord?`
+
+New file: `Clearly/FileParser.swift` — extracts links, tags, headings from markdown content. Pure function, no side effects. Testable.
+
+Dependency: Add GRDB.swift to `project.yml`:
+```yaml
+GRDB:
+  url: https://github.com/groue/GRDB.swift.git
+  from: "7.0.0"
+```
+
+---
+
+### Phase 1: Knowledge Primitives
+
+#### 1a. Wiki-Links
+
+**Editor Highlighting** (`MarkdownSyntaxHighlighter.swift`):
+
+Add to the `patterns` array (after footnote markers, before table rows — line ~83):
+```swift
+// Wiki-links: [[note]] or [[note|alias]] or [[note#heading]]
+add(#"\[\[([^\]\|#]+?)(?:#[^\]\|]+?)?(?:\|[^\]]+?)?\]\]"#, .wikiLink)
+```
+
+Add `.wikiLink` to the `HighlightStyle` enum. Style with `Theme.wikiLinkColor` — a distinct color (not the same as regular links). The `cachedProtectedRanges` mechanism already protects code blocks from highlighting.
+
+**Preview Rendering** (`MarkdownRenderer.swift`):
+
+Add `processWikiLinks()` in the post-processing pipeline after `processEmoji()` (line 29) and before `processCallouts()` (line 30). Follows the same `protectCodeRegions`/`restoreProtectedSegments` pattern:
+
+```swift
+html = processWikiLinks(html)
+```
+
+The transform converts `[[note]]` → `<a href="clearly://wiki/note" class="wiki-link">note</a>` and `[[note|alias]]` → `<a href="clearly://wiki/note" class="wiki-link">alias</a>`. Unresolved links get a `.wiki-link-broken` class (styled red/dimmed).
+
+**Link resolution** needs the VaultIndex. Two options:
+- Pass the index to `renderHTML()` (changes the API, affects QuickLook too)
+- Resolve links client-side in JavaScript after render (simpler, keeps renderer pure)
+
+Recommendation: **JavaScript resolution**. Keep `MarkdownRenderer` pure (shared with QuickLook where there's no index). In `PreviewView`, inject a script that resolves `clearly://wiki/` links against a file list passed from Swift. This matches the existing pattern of JS injection for interactivity.
+
+**Preview Click Handling** (`PreviewView.swift`):
+
+Add a `"wikiLinkClicked"` message handler (same pattern as `"linkClicked"` at line 511). When a wiki-link is clicked:
+1. JavaScript sends the link target name via `window.webkit.messageHandlers.wikiLinkClicked.postMessage(targetName)`
+2. Coordinator receives it, resolves via VaultIndex
+3. Calls `WorkspaceManager.openFile(at: resolvedURL)`
+
+**Editor Click Handling**:
+
+Cmd+click on a `[[wiki-link]]` in the editor should navigate too. Detect via `NSTextView.clicked(onLink:in:at:characterIndex:)` or a gesture recognizer that checks if the click is within a wiki-link range.
+
+#### 1b. Quick Switcher (Cmd+O)
+
+**UI Pattern: NSPanel** (floating, non-activating)
+
+- `styleMask: [.titled, .fullSizeContentView]`, hidden titlebar
+- `NSVisualEffectView` with `.popover` material for vibrancy
+- ~580px wide, centered horizontally on active window, upper third vertically
+- Search field: ~44px tall, placeholder "Search notes..."
+- Results: `NSTableView` with ~36px rows, max 8-10 visible
+- Keyboard: Up/Down navigate results, Enter opens, Escape dismisses
+- Dismiss on: Escape, click outside, focus loss
+
+**Fuzzy matching**: Sequential character matching with gap penalties. Bonus for matches after separators (`/`, `.`, `_`, space) and consecutive matches. Return matched ranges for highlighting. This is <16ms for 70K files.
+
+**Default state**: When query is empty, show recently opened files. Immediately useful.
+
+**Results display**: File name (primary, bold matched characters), folder path (dimmed secondary text).
+
+**Create-on-miss**: If no results, show "Create [query].md" option at bottom. Enter creates the file and opens it.
+
+**File**: New `Clearly/QuickSwitcherPanel.swift`
+
+**Shortcut**: Cmd+P (consistent with VS Code's quick file finder). Register in `ClearlyApp.swift` menu commands.
+
+#### 1c. Global Search (Cmd+Shift+F)
+
+**UI Pattern: Sidebar search panel**
+
+When activated, a search field appears at top of sidebar. Results replace the file tree below.
+
+**Results layout**: Grouped by file — file name header with match count badge, then indented match excerpts below. Each match shows the matching line with matched term highlighted. 1 line of context before/after. File groups are collapsible.
+
+**Two-section results**: File name matches first (from `files.filename` column), content matches second (from FTS5). This distinguishes "I know the name" from "I remember what it said."
+
+**Search behavior**: Real-time with 150ms debounce. Start after 2+ characters. Keyboard: Down arrow moves to results, Enter opens file at match line.
+
+**FTS5 query**: Use `MATCH` with `bm25()` ranking. Support quoted phrases and boolean operators naturally (FTS5 handles this).
+
+**Integration**: New `Clearly/SearchView.swift` (AppKit, like FileExplorerView). Toggle between file tree and search results in the sidebar. Modified `FileExplorerView.swift` to add search activation.
+
+**Shortcut**: Cmd+Shift+F. Register in `ClearlyApp.swift`.
+
+---
+
+### Phase 2: Knowledge Graph
+
+#### 2a. Backlinks Panel
+
+**UI Pattern: Bottom panel, collapsible**
+
+Horizontal divider below editor content area. "Backlinks" header with count badge. Toggle via menu/shortcut.
+
+**Two subsections**:
+- **Linked mentions**: Files with explicit `[[this-file]]` wiki-links. Show: source file name (clickable → opens file), 1-2 lines of context with the `[[link]]` highlighted.
+- **Unlinked mentions**: Files containing this file's title as plain text (not inside a `[[]]`). Show same format + subtle "Link" button to convert to `[[wiki-link]]`. Collapsed by default.
+
+**Query**: `SELECT l.*, f.path, f.filename FROM links l JOIN files f ON l.source_file_id = f.id WHERE l.target_file_id = ?`
+
+**Updates**: Refresh when active document changes. Use GRDB's `ValueObservation` to reactively watch for link changes.
+
+**Layout integration**: Add below the editor in `ContentView.swift`. Similar to how the outline panel works — a collapsible section. Use `NSSplitView` or a simple VStack with a draggable divider.
+
+**File**: New `Clearly/BacklinksView.swift`
+
+**Shortcut**: Cmd+Shift+B (toggle backlinks panel).
+
+#### 2b. Tags
+
+**Parsing rules** (important edge cases):
+- `#tag` is a tag. `# heading` (hash-space) is a heading.
+- Tags must contain at least one non-digit: `#2024` is NOT a tag, `#year-2024` IS.
+- Nested tags: `#parent/child` indexes both `parent` and `parent/child`.
+- Don't parse inside code blocks, inline code, URLs, or HTML.
+- Frontmatter `tags: [foo, bar]` are also indexed (no `#` prefix in YAML).
+- Store normalized (lowercase, no `#` prefix).
+
+**Tag regex**: `(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)`
+
+**Editor highlighting** (`MarkdownSyntaxHighlighter.swift`):
+Add `.tag` style to patterns array. Color: distinct from wiki-links and regular links.
+
+**Preview rendering** (`MarkdownRenderer.swift`):
+`processWikiLinks` can also transform `#tag` → `<span class="tag" data-tag="tag">#tag</span>` with click handler.
+
+**Sidebar tag browser** (`FileExplorerView.swift`):
+New section below Locations. Collapsible tree for nested tags. Each tag shows file count badge. Click → filter file tree to files with that tag.
+
+**Query**: `SELECT DISTINCT tag, COUNT(*) FROM tags GROUP BY tag ORDER BY tag`
+
+#### 2c. Link Auto-Complete
+
+**DO NOT use `NSTextView.complete(_:)`.** It's word-boundary based and wrong for `[[` triggers.
+
+**Custom popup**:
+- Borderless `NSWindow` child of editor window, positioned below cursor via `firstRect(forCharacterRange:actualRange:)`
+- ~300px wide, max 8 rows, `NSTableView` with file names
+- Keyboard: Up/Down navigate, Enter/Tab inserts `filename]]`, Escape dismisses
+
+**Trigger lifecycle**:
+1. In `textDidChange` (EditorView.swift), detect `[[` was just typed
+2. Show popup with all files (or recents if vault is large)
+3. As user types after `[[`, filter results via fuzzy match
+4. On select: insert `filename]]` (completing the link)
+5. Dismiss on: Escape, `]]` typed manually, backspace past `[[`, click outside
+6. Don't trigger inside code blocks (check `cachedProtectedRanges`)
+
+**File**: New `Clearly/WikiLinkCompletionWindow.swift`
+
+---
+
+### Phase 3: MCP Server
+
+#### Architecture: Standalone Companion Binary
+
+Clearly is sandboxed. The MCP protocol uses stdio (client spawns server as subprocess). A sandboxed app can't be spawned this way. Solution: **ship a standalone CLI binary** that lives outside the app bundle.
+
+The companion binary (`clearly-mcp`) is a tiny CLI (~2MB) that reads the same SQLite index via WAL mode (concurrent reads are safe). It does NOT need sandbox entitlements.
+
+**Distribution:**
+- **Direct download (DMG)**: Binary bundled inside the app bundle at `Contents/Helpers/ClearlyMCP`. On first launch (or on update), the app copies it to `~/Library/Application Support/Clearly/ClearlyMCP`. Zero user interaction — MCP just works.
+- **App Store**: One-click "Install MCP Helper" button in Settings. Downloads the binary from GitHub Releases via `URLSession`, writes to `~/Library/Application Support/Clearly/ClearlyMCP`, sets executable permission. No terminal needed.
+
+#### Settings → MCP Setup Panel (All Builds)
+
+A dedicated MCP section in Settings, present in **both** direct and App Store builds:
+
+**Direct download build:**
+- MCP binary is already installed. Show green checkmark + version.
+- Vault path selector (defaults to active bookmarked location).
+- **"Copy Claude Desktop Config"** button — generates correct JSON with resolved binary path and vault path, copies to clipboard.
+- **"Test Connection"** button — runs the binary with `--test` flag, confirms it can read the index.
+- **Auto-detect Claude Desktop** — if `~/Library/Application Support/Claude/claude_desktop_config.json` exists, offer to add the config automatically (with confirmation).
+
+**App Store build:**
+- Same panel, but detection shows "Not installed" initially.
+- One-click "Install MCP Helper" button (downloads + installs automatically).
+- Once installed, same setup flow as direct download (config copy, test, auto-detect).
+
+Direct download users never think about MCP installation. It's just there. App Store users click one button. One install path, no terminal.
+
+#### MCP Swift SDK
+
+Official SDK exists: [modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk) (v0.11.0+). Requires Swift 6.0 / Xcode 16+.
+
+```swift
+import MCP
+
+let server = Server(
+    name: "clearly",
+    version: "1.0.0"
+)
+
+server.withMethodHandler(ListTools.self) { _ in
+    return .init(tools: [
+        Tool(name: "search_notes", description: "Full-text search across all notes",
+             inputSchema: .object(properties: ["query": .string(description: "Search query")])),
+        Tool(name: "read_note", description: "Read a note's content",
+             inputSchema: .object(properties: ["path": .string(description: "Note path")])),
+        Tool(name: "list_notes", description: "List all notes in the vault",
+             inputSchema: .object(properties: [:])),
+    ])
+}
+```
+
+#### Tools to Expose (Priority Order)
+
+**P0 (ship with MCP):**
+- `search_notes` — FTS5 search, returns matching files + context
+- `read_note` — get full content of a note by path
+- `list_notes` — list all notes with optional folder filter
+
+**P1 (add after backlinks/tags):**
+- `get_backlinks` — backlinks for a note
+- `get_tags` — all tags or files for a tag
+- `create_note` — create a new note
+- `update_note` — update note content
+
+**P2 (future):**
+- `get_metadata` — frontmatter for a note
+- `search_by_tag` — notes with specific tag
+- `get_outgoing_links` — wiki-links from a note
+
+#### Claude Desktop Configuration
+
+The Settings panel generates and copies this config for the user:
+```json
+{
+  "mcpServers": {
+    "clearly": {
+      "command": "~/Library/Application Support/Clearly/ClearlyMCP",
+      "args": ["--vault", "/path/to/vault"]
+    }
+  }
+}
+```
+The vault path is auto-populated from the active bookmarked location.
+
+#### Files
+
+- New target in `project.yml`: `ClearlyMCP` (command-line tool)
+- New: `ClearlyMCP/main.swift` — MCP server entry point
+- Shared: `Clearly/VaultIndex.swift` (read-only access to the index)
+- Dependency: Add MCP Swift SDK to `project.yml`
+
+---
+
+## UI/UX Considerations
+
+### Quick Switcher
+- Appears instantly (no animation). Fast animations feel slow.
+- Match characters highlighted in accent color (the #1 delight detail).
+- Recently opened files shown when query is empty.
+- Path truncated from middle: `~/Docs/.../nested/file.md`
+- "No results — press Enter to create [query].md" empty state.
+
+### Global Search
+- Real-time, no enter-to-search. 150ms debounce.
+- File name matches separated from content matches.
+- Keyboard-navigable: arrow keys move between results, Enter opens.
+- Match term highlighted in results.
+
+### Backlinks Panel
+- Collapsed by default for notes with no backlinks.
+- "No other documents link to this file" empty state (brief, not educational).
+- Unlinked mentions collapsed by default (can be noisy).
+- Clickable file names open the linking note.
+
+### Wiki-Link Auto-Complete
+- Appears below cursor, no arrow chrome.
+- Fuzzy matching with highlighted match characters.
+- Keyboard-first: Tab/Enter to select, Escape to dismiss.
+- Shows file icon + name + folder path.
+
+### Tags Browser
+- Collapsible tree for nested tags.
+- Count badge per tag.
+- Click → filter file tree (simpler than triggering search).
+- "Use #tag in your documents to organize them" empty state.
+
+### General
+- Every feature fully keyboard-operable.
+- Smart recency: recently opened files first everywhere.
+- No slow animations — panels appear/disappear immediately.
+
+---
+
+## Integration Points
+
+### MarkdownRenderer.swift (Shared/)
+- **Wiki-link processing**: New `processWikiLinks()` method, inserted after `processEmoji()` (line 29), before `processCallouts()` (line 30). Uses existing `protectCodeRegions`/`restoreProtectedSegments` pattern.
+- Renderer stays pure — no VaultIndex dependency. Link resolution happens in JavaScript on the PreviewView side.
+
+### MarkdownSyntaxHighlighter.swift (Clearly/)
+- **Wiki-link pattern**: Add to `patterns` array after footnote markers (~line 83). New `.wikiLink` style.
+- **Tag pattern**: Add to `patterns` array. New `.tag` style.
+- Both are protected by existing `cachedProtectedRanges` code-block exclusion.
+
+### PreviewView.swift (Clearly/)
+- **Wiki-link click handler**: New `"wikiLinkClicked"` message handler in `userContentController(_:didReceive:)` (~line 504). Follows `"linkClicked"` pattern at line 511.
+- **JavaScript injection**: Script to resolve `clearly://wiki/` links and handle tag clicks.
+
+### WorkspaceManager.swift (Clearly/)
+- **VaultIndex integration**: New `var vaultIndex: VaultIndex?` property.
+- **Index lifecycle**: Create on `addLocation()`, update on FSEventStream changes, close on `removeLocation()`.
+- **Navigation**: `openFile(at:)` at line 235 is the API for all "open this file" actions.
+
+### EditorView.swift (Clearly/)
+- **Auto-complete trigger**: In `textDidChange` delegate, detect `[[` and show completion popup.
+- **Cmd+click navigation**: Detect click on wiki-link range, resolve, navigate.
+
+### FileExplorerView.swift (Clearly/)
+- **Search section**: New mode that replaces file tree with search results.
+- **Tags section**: New sidebar section below Locations showing tag tree.
+
+### ContentView.swift (Clearly/)
+- **Backlinks panel**: New collapsible bottom panel below editor.
+- **Shortcut wiring**: Cmd+O (quick switcher), Cmd+Shift+F (search), Cmd+Shift+B (backlinks).
+
+### Theme.swift (Clearly/)
+- New colors: `wikiLinkColor`, `wikiLinkBrokenColor`, `tagColor`.
+
+### project.yml
+- New dependency: GRDB.swift
+- New dependency: MCP Swift SDK (for ClearlyMCP target)
+- New target: ClearlyMCP (command-line tool)
+
+---
+
+## Risks and Challenges
+
+1. **Index corruption/staleness**: SQLite can become out of sync if files are modified outside the app while it's not running. Mitigation: compare `content_hash` on launch, re-index stale files. Provide manual "Rebuild Index" command.
+
+2. **Large vault performance**: 10,000+ files need efficient batch indexing. GRDB's `inTransaction` + batch inserts help. FTS5 queries are fast (sub-10ms). The bottleneck is initial file parsing, not search.
+
+3. **Link resolution ambiguity**: Multiple files with the same name in different folders. Resolve by shortest path (most intuitive) and show disambiguation in auto-complete when ambiguous.
+
+4. **Sandboxing vs MCP**: Companion binary can't be sandboxed. Direct distribution only. App Store build won't have MCP — acceptable tradeoff (same as Sparkle).
+
+5. **GRDB dependency size**: GRDB is a substantial dependency (~50 Swift files). Acceptable given it replaces building our own connection pool, migrations, FTS5 wrappers, and threading.
+
+6. **Renderer purity**: Adding VaultIndex awareness to MarkdownRenderer would break QuickLook (which has no index). Keeping resolution in JavaScript is the right call but adds complexity.
+
+7. **Tag false positives**: CSS colors (`#fff`), heading markers (`# `), and issue references (`#123`) can be confused with tags. The regex requires at least one non-digit character, but edge cases will exist.
+
+## Open Questions
+
+1. **Index storage**: App Support (recommended) vs inside vault (`.clearly/`). App Support is cleaner but means index is per-machine — if you open the same vault on another Mac, it re-indexes. This is acceptable.
+
+2. **Unlinked mentions**: Should the backlinks panel show unlinked mentions (plain text matching the file name)? Useful for discovering implicit connections but can be noisy. Recommendation: yes, but collapsed by default.
+
+3. **Tag click behavior**: Filter file tree vs show search results? Filter is simpler for v1. Search results offer more context. Start with filter, revisit if users want more.
+
+4. **MCP config auto-write**: The Settings panel can detect Claude Desktop and offer to write the config automatically (with confirmation). Low risk since it's additive (adds a key, doesn't overwrite). Fall back to clipboard copy if user declines.
+
+5. **`[[note#heading]]` support**: Should wiki-links resolve to specific headings? Medium effort — requires heading index (which we have) and scroll-to-heading after navigation. Include in Phase 2 or defer?
+
+## References
+
+- **GRDB.swift**: https://github.com/groue/GRDB.swift — SQLite toolkit for Swift
+- **MCP Swift SDK**: https://github.com/modelcontextprotocol/swift-sdk — Official Model Context Protocol SDK
+- **MCP Specification**: https://modelcontextprotocol.io/specification — Protocol spec
+- **SQLite FTS5**: https://www.sqlite.org/fts5.html — Full-text search documentation
+- **Wiki-link syntax reference**: https://help.obsidian.md/Linking+notes+and+files/Internal+links — Common `[[link]]` format spec
+- **Tag syntax reference**: https://help.obsidian.md/Editing+and+formatting/Tags — Common `#tag` syntax rules
+- **Backlinks UX reference**: https://help.obsidian.md/Plugins/Backlinks — Backlinks panel patterns

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,9 @@ packages:
   KeyboardShortcuts:
     url: https://github.com/sindresorhus/KeyboardShortcuts
     from: "2.1.0"
+  GRDB:
+    url: https://github.com/groue/GRDB.swift.git
+    from: "7.0.0"
 
 targets:
   Clearly:
@@ -47,6 +50,7 @@ targets:
         product: cmark
       - package: Sparkle
       - package: KeyboardShortcuts
+      - package: GRDB
       - target: ClearlyQuickLook
         embed: true
     settings:
@@ -62,6 +66,9 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev
+          PRODUCT_NAME: "Clearly Dev"
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
@@ -100,6 +107,8 @@ targets:
         CODE_SIGN_ENTITLEMENTS: ClearlyQuickLook/ClearlyQuickLook.entitlements
         INFOPLIST_FILE: ClearlyQuickLook/Info.plist
       configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.quicklook
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"


### PR DESCRIPTION
## Summary

Phase 1 of the expansion plan — adds the foundational cross-file index and Quick Switcher that all future knowledge management features (wiki-links, backlinks, search, tags, MCP) will build on.

- **VaultIndex** (new): GRDB-backed SQLite index with FTS5 full-text search. Indexes all markdown files with content-hash-based incremental updates on a background queue. Full schema for files, links, tags, and headings.
- **FileParser** (new): Pure markdown parser extracting wiki-links (`[[note]]`), tags (`#tag`), and headings from content, with fenced code block protection.
- **QuickSwitcherPanel** (new): Borderless floating NSPanel triggered by Cmd+P. Fuzzy matching with highlighted characters, keyboard navigation (Up/Down/Enter/Escape), recent files on empty query, create-on-miss for new files.
- **WorkspaceManager**: VaultIndex lifecycle wired to location add/remove/restore and FSEventStream changes. Sidebar drag-and-drop for moving files between folders.
- **ClearlyApp**: Cmd+P shortcut via local event monitor, Print moved to Cmd+Shift+P, "Quick Open…" menu item in View menu.
- **project.yml**: GRDB.swift v7+ dependency, Debug-only dev bundle ID (`com.sabotage.clearly.dev`) for safe side-by-side testing.
- **Fix**: Duplicate Format menu merged into single `CommandGroup(replacing: .textFormatting)`.

## Test plan

- [ ] Cmd+P opens Quick Switcher, typing filters with fuzzy matching, Enter opens file, Escape dismisses
- [ ] Empty query shows recent files; no-match query shows "Create X.md" option
- [ ] Index auto-creates on location add (check `~/Library/Containers/.../indexes/*.sqlite`)
- [ ] External file changes detected within ~1s via FSEventStream
- [ ] Cmd+Shift+P opens Print (not Cmd+P)
- [ ] View menu shows "Quick Open… ⌘P"
- [ ] Single Format menu with all formatting items
- [ ] Drag-and-drop files between folders in sidebar
- [ ] Dev build runs side-by-side with production without sharing data