### PR TITLE
Add wiki-link support with cross-file navigation

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -38,6 +38,46 @@ class PersistentTextCheckingTextView: NSTextView {
 final class ClearlyTextView: PersistentTextCheckingTextView {
     var documentURL: URL?
     var onShowFind: (() -> Void)?
+    var onWikiLinkClicked: ((String, String?) -> Void)?
+
+    // MARK: - Wiki-Link Cmd+Click
+
+    private static let wikiLinkRegex = try! NSRegularExpression(
+        pattern: #"\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|[^\]]+?)?\]\]"#
+    )
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            let point = convert(event.locationInWindow, from: nil)
+            let charIndex = characterIndex(for: point)
+            if charIndex < (string as NSString).length,
+               let (target, heading) = wikiLinkAt(charIndex: charIndex) {
+                onWikiLinkClicked?(target, heading)
+                return
+            }
+        }
+        super.mouseDown(with: event)
+    }
+
+    private func wikiLinkAt(charIndex: Int) -> (target: String, heading: String?)? {
+        let text = string as NSString
+        let searchStart = max(0, charIndex - 200)
+        let searchEnd = min(text.length, charIndex + 200)
+        let searchRange = NSRange(location: searchStart, length: searchEnd - searchStart)
+
+        for match in Self.wikiLinkRegex.matches(in: string, range: searchRange) {
+            guard NSLocationInRange(charIndex, match.range) else { continue }
+            let target = text.substring(with: match.range(at: 1))
+                .trimmingCharacters(in: .whitespaces)
+            var heading: String? = nil
+            if match.range(at: 2).location != NSNotFound {
+                heading = text.substring(with: match.range(at: 2))
+                    .trimmingCharacters(in: .whitespaces)
+            }
+            return (target, heading)
+        }
+        return nil
+    }
 
     // MARK: - Cursor
 

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 extension Notification.Name {
     static let scrollEditorToLine = Notification.Name("scrollEditorToLine")
+    static let scrollPreviewToLine = Notification.Name("scrollPreviewToLine")
     static let flushEditorBuffer = Notification.Name("flushEditorBuffer")
+    static let navigateWikiLink = Notification.Name("navigateWikiLink")
 }
 
 enum ViewMode: String, CaseIterable {
@@ -80,9 +82,16 @@ struct HiddenToolbarBackground: ViewModifier {
 }
 
 struct ContentView: View {
+    private struct PendingWikiNavigation {
+        let fileURL: URL
+        let lineNumber: Int
+        let destinationMode: ViewMode
+    }
+
     @Bindable var workspace: WorkspaceManager
     @State private var mode: ViewMode
     @State private var positionSyncID = UUID().uuidString
+    @State private var pendingWikiNavigation: PendingWikiNavigation?
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
@@ -103,6 +112,14 @@ struct ContentView: View {
     private var previewPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
+        let _ = workspace.vaultIndexRevision
+        let allWikiFileNames: Set<String> = {
+            var names = Set<String>()
+            for index in workspace.activeVaultIndexes {
+                for file in index.allFiles() { names.insert(file.filename.lowercased()) }
+            }
+            return names
+        }()
         return PreviewView(
             markdown: workspace.currentFileText,
             fontSize: editorFontSize,
@@ -133,9 +150,12 @@ struct ContentView: View {
             },
             onClickToSource: { line in
                 mode = .edit
-                // Post a notification that EditorView can observe to scroll to line
                 NotificationCenter.default.post(name: .scrollEditorToLine, object: nil, userInfo: ["line": line])
-            }
+            },
+            onWikiLinkClicked: { target, heading in
+                navigateToWikiLink(target: target, heading: heading, destinationMode: .preview)
+            },
+            wikiFileNames: allWikiFileNames
         )
     }
 
@@ -263,6 +283,7 @@ struct ContentView: View {
                 findState.isVisible = false
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
+                applyPendingWikiNavigationIfNeeded()
                 // New untitled docs always open in edit mode
                 if let newID, let doc = workspace.openDocuments.first(where: { $0.id == newID }), doc.isUntitled {
                     mode = .edit
@@ -286,6 +307,11 @@ struct ContentView: View {
                     outlineState.toggle()
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .navigateWikiLink)) { notification in
+                guard let target = notification.userInfo?["target"] as? String else { return }
+                let heading = notification.userInfo?["heading"] as? String
+                navigateToWikiLink(target: target, heading: heading, destinationMode: .edit)
+            }
     }
 
     private func setupFileWatcher() {
@@ -300,5 +326,54 @@ struct ContentView: View {
             workspace.externalFileDidChange(newText)
         }
         fileWatcher.watch(url, currentText: workspace.currentFileText)
+    }
+
+    private func navigateToWikiLink(target: String, heading: String?, destinationMode: ViewMode) {
+        for vaultIndex in workspace.activeVaultIndexes {
+            guard let file = vaultIndex.resolveWikiLink(name: target) else { continue }
+
+            let fileURL = vaultIndex.rootURL.appendingPathComponent(file.path)
+            let headingLine = heading.flatMap { vaultIndex.lineNumberForHeading(in: file.id, heading: $0) }
+
+            guard workspace.openFile(at: fileURL) else { return }
+
+            if let headingLine {
+                if workspace.currentFileURL == fileURL {
+                    scheduleWikiNavigation(lineNumber: headingLine, destinationMode: destinationMode)
+                } else {
+                    pendingWikiNavigation = PendingWikiNavigation(
+                        fileURL: fileURL,
+                        lineNumber: headingLine,
+                        destinationMode: destinationMode
+                    )
+                }
+            } else {
+                mode = destinationMode
+                pendingWikiNavigation = nil
+            }
+            return
+        }
+    }
+
+    private func applyPendingWikiNavigationIfNeeded() {
+        guard let pendingWikiNavigation,
+              workspace.currentFileURL == pendingWikiNavigation.fileURL else { return }
+        scheduleWikiNavigation(
+            lineNumber: pendingWikiNavigation.lineNumber,
+            destinationMode: pendingWikiNavigation.destinationMode
+        )
+        self.pendingWikiNavigation = nil
+    }
+
+    private func scheduleWikiNavigation(lineNumber: Int, destinationMode: ViewMode) {
+        mode = destinationMode
+        let notificationName: Notification.Name = destinationMode == .preview ? .scrollPreviewToLine : .scrollEditorToLine
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: notificationName,
+                object: nil,
+                userInfo: ["line": lineNumber]
+            )
+        }
     }
 }

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -76,6 +76,12 @@ struct EditorView: NSViewRepresentable {
         context.coordinator.highlighter = highlighter
         textView.string = text
         textView.delegate = context.coordinator
+        textView.onWikiLinkClicked = { target, heading in
+            NotificationCenter.default.post(
+                name: .navigateWikiLink, object: nil,
+                userInfo: ["target": target, "heading": heading as Any]
+            )
+        }
 
         scrollView.documentView = textView
         context.coordinator.textView = textView

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -82,6 +82,9 @@ final class MarkdownSyntaxHighlighter: NSObject {
         // Footnote markers: [^ref]
         add("(\\[\\^)([^\\]\n]+)(\\])", .footnote)
 
+        // Wiki-links: [[note]] or [[note|alias]] or [[note#heading]]
+        add(#"(\[\[)([^\]\n]+?)(\]\])"#, .wikiLink)
+
         // Table rows: lines with pipes
         add("^(\\|.+\\|)\\s*$", .syntax, options: .anchorsMatchLines)
 
@@ -113,6 +116,7 @@ final class MarkdownSyntaxHighlighter: NSObject {
         case frontmatter
         case highlight
         case footnote
+        case wikiLink
         case htmlTag
     }
 
@@ -323,6 +327,13 @@ final class MarkdownSyntaxHighlighter: NSObject {
 
                 case .footnote:
                     textStorage.addAttribute(.foregroundColor, value: Theme.footnoteColor, range: match.range)
+
+                case .wikiLink:
+                    if match.numberOfRanges >= 4 {
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 1))
+                        textStorage.addAttribute(.foregroundColor, value: Theme.wikiLinkColor, range: match.range(at: 2))
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 3))
+                    }
 
                 case .htmlTag:
                     textStorage.addAttribute(.foregroundColor, value: Theme.htmlTagColor, range: match.range)
@@ -611,6 +622,13 @@ final class MarkdownSyntaxHighlighter: NSObject {
 
                 case .footnote:
                     textStorage.addAttribute(.foregroundColor, value: Theme.footnoteColor, range: match.range)
+
+                case .wikiLink:
+                    if match.numberOfRanges >= 4 {
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 1))
+                        textStorage.addAttribute(.foregroundColor, value: Theme.wikiLinkColor, range: match.range(at: 2))
+                        textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 3))
+                    }
 
                 case .htmlTag:
                     textStorage.addAttribute(.foregroundColor, value: Theme.htmlTagColor, range: match.range)

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -12,10 +12,16 @@ struct PreviewView: NSViewRepresentable {
     var outlineState: OutlineState?
     var onTaskToggle: ((Int, Bool) -> Void)?
     var onClickToSource: ((Int) -> Void)?
+    var onWikiLinkClicked: ((String, String?) -> Void)?
+    var wikiFileNames: Set<String>?
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))"
+        "\(markdown)__\(fontSize)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)"
+    }
+
+    private var wikiFilesKey: String {
+        (wikiFileNames ?? []).sorted().joined(separator: "\n")
     }
 
     func makeCoordinator() -> Coordinator {
@@ -41,6 +47,7 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.outlineState = outlineState
         context.coordinator.onTaskToggle = onTaskToggle
         context.coordinator.onClickToSource = onClickToSource
+        context.coordinator.onWikiLinkClicked = onWikiLinkClicked
         let coordinator = context.coordinator
         findState?.previewNavigateToNext = { [weak coordinator] in
             coordinator?.navigateToNextMatch()
@@ -54,6 +61,12 @@ struct PreviewView: NSViewRepresentable {
         outlineState?.scrollToPreviewAnchor = { [weak coordinator = context.coordinator] anchor in
             coordinator?.scrollToHeading(anchor: anchor)
         }
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleScrollToLine(_:)),
+            name: .scrollPreviewToLine,
+            object: nil
+        )
 
         loadHTML(in: webView, context: context)
         return webView
@@ -95,6 +108,7 @@ struct PreviewView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        NotificationCenter.default.removeObserver(coordinator)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
@@ -104,8 +118,17 @@ struct PreviewView: NSViewRepresentable {
 
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
+        context.coordinator.isLoadingContent = true
         let rawBody = MarkdownRenderer.renderHTML(markdown)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
+        let wikiFilesJSON: String = {
+            guard let names = wikiFileNames, !names.isEmpty else { return "[]" }
+            guard let data = try? JSONSerialization.data(withJSONObject: Array(names)),
+                  var json = String(data: data, encoding: .utf8) else { return "[]" }
+            // Prevent </script> injection in HTML context
+            json = json.replacingOccurrences(of: "</", with: "<\\/")
+            return json
+        }()
         let scrollJS = """
         // Track scroll fraction for position sync between editor and preview.
         var _scrollTicking = false;
@@ -269,6 +292,18 @@ struct PreviewView: NSViewRepresentable {
                 if (popover) { popover.remove(); popover = null; }
             });
         });
+        // Wiki-link broken detection
+        (function() {
+            var knownFiles = new Set(\(wikiFilesJSON));
+            document.querySelectorAll('a.wiki-link').forEach(function(a) {
+                var href = a.getAttribute('href') || '';
+                if (!href.startsWith('clearly://wiki/')) return;
+                var target = decodeURIComponent(href.replace('clearly://wiki/', '').split('#')[0]);
+                if (knownFiles.size > 0 && !knownFiles.has(target.toLowerCase())) {
+                    a.classList.add('wiki-link-broken');
+                }
+            });
+        })();
         </script>
         \(MathSupport.scriptHTML(for: htmlBody))
         \(TableSupport.scriptHTML(for: htmlBody))
@@ -290,7 +325,10 @@ struct PreviewView: NSViewRepresentable {
         var outlineState: OutlineState?
         var onTaskToggle: ((Int, Bool) -> Void)?
         var onClickToSource: ((Int) -> Void)?
+        var onWikiLinkClicked: ((String, String?) -> Void)?
         var skipNextReload = false
+        var isLoadingContent = false
+        var pendingScrollLine: Int?
         weak var webView: WKWebView?
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
@@ -345,6 +383,48 @@ struct PreviewView: NSViewRepresentable {
             })();
             """
             webView?.evaluateJavaScript(js)
+        }
+
+        @objc func handleScrollToLine(_ notification: Notification) {
+            guard let line = notification.userInfo?["line"] as? Int, line > 0 else { return }
+            pendingScrollLine = line
+            guard !isLoadingContent else { return }
+            scrollToPendingLine()
+        }
+
+        private func scrollToPendingLine() {
+            guard let line = pendingScrollLine else { return }
+            let js = """
+            (function() {
+                var targetLine = \(line);
+                var candidates = Array.from(document.querySelectorAll('[data-sourcepos]'));
+                var best = null;
+                for (var i = 0; i < candidates.length; i++) {
+                    var sp = candidates[i].getAttribute('data-sourcepos');
+                    if (!sp) continue;
+                    var match = /^(\\d+):/.exec(sp);
+                    if (!match) continue;
+                    var startLine = parseInt(match[1], 10);
+                    if (startLine === targetLine) {
+                        best = candidates[i];
+                        break;
+                    }
+                    if (startLine < targetLine) {
+                        best = candidates[i];
+                    } else if (best === null) {
+                        best = candidates[i];
+                        break;
+                    } else {
+                        break;
+                    }
+                }
+                if (best) {
+                    best.scrollIntoView({behavior:'smooth', block:'start'});
+                }
+            })();
+            """
+            webView?.evaluateJavaScript(js)
+            pendingScrollLine = nil
         }
 
         func performFind(query: String) {
@@ -464,6 +544,7 @@ struct PreviewView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isLoadingContent = false
             if !didInitialLoad {
                 didInitialLoad = true
             }
@@ -480,6 +561,7 @@ struct PreviewView: NSViewRepresentable {
                !query.isEmpty {
                 performFind(query: query)
             }
+            scrollToPendingLine()
         }
 
         private func resolvedLinkURL(for href: String) -> URL? {
@@ -497,6 +579,16 @@ struct PreviewView: NSViewRepresentable {
         }
 
         private func handleLinkClick(_ href: String) {
+            if href.hasPrefix("clearly://wiki/") {
+                let remainder = String(href.dropFirst("clearly://wiki/".count))
+                let parts = remainder.components(separatedBy: "#")
+                let target = parts[0].removingPercentEncoding ?? parts[0]
+                let heading = parts.count > 1 ? (parts[1].removingPercentEncoding ?? parts[1]) : nil
+                DispatchQueue.main.async { [weak self] in
+                    self?.onWikiLinkClicked?(target, heading)
+                }
+                return
+            }
             guard let targetURL = resolvedLinkURL(for: href) else { return }
             NSWorkspace.shared.open(targetURL)
         }

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -117,6 +117,18 @@ enum Theme {
             : NSColor(red: 0.3, green: 0.4, blue: 0.7, alpha: 1)
     }
 
+    static let wikiLinkColor = NSColor(name: "themeWikiLink") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.35, green: 0.75, blue: 0.50, alpha: 1)
+            : NSColor(red: 0.2, green: 0.55, blue: 0.35, alpha: 1)
+    }
+
+    static let wikiLinkBrokenColor = NSColor(name: "themeWikiLinkBroken") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.85, green: 0.45, blue: 0.35, alpha: 1)
+            : NSColor(red: 0.7, green: 0.35, blue: 0.25, alpha: 1)
+    }
+
     static let htmlTagColor = NSColor(name: "themeHTMLTag") { appearance in
         appearance.isDark
             ? NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -308,6 +308,25 @@ final class VaultIndex {
         }
     }
 
+    func lineNumberForHeading(in fileId: Int64, heading: String) -> Int? {
+        let normalized = heading.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+
+        do {
+            return try dbPool.read { db in
+                let row = try Row.fetchOne(db, sql: """
+                    SELECT line_number FROM headings
+                    WHERE file_id = ? AND LOWER(text) = LOWER(?)
+                    ORDER BY line_number
+                    LIMIT 1
+                    """, arguments: [fileId, normalized])
+                return row?["line_number"]
+            }
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: Read — Links
 
     func linksTo(fileId: Int64) -> [LinkRecord] {

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -43,6 +43,7 @@ final class WorkspaceManager {
     private var accessedURLs: Set<URL> = []
 
     var activeVaultIndexes: [VaultIndex] { Array(vaultIndexes.values) }
+    private(set) var vaultIndexRevision: Int = 0
 
     // MARK: - UserDefaults Keys
 
@@ -434,6 +435,7 @@ final class WorkspaceManager {
         stopFSStream(for: location.id)
         vaultIndexes[location.id]?.close()
         vaultIndexes.removeValue(forKey: location.id)
+        vaultIndexRevision += 1
         if accessedURLs.contains(location.url) {
             location.url.stopAccessingSecurityScopedResource()
             accessedURLs.remove(location.url)
@@ -549,6 +551,24 @@ final class WorkspaceManager {
                     let relative = String(current.path.dropFirst(sourceURL.path.count))
                     currentFileURL = URL(fileURLWithPath: destURL.path + relative)
                 }
+            }
+            var recentsChanged = false
+            for idx in recentFiles.indices {
+                let recentURL = recentFiles[idx]
+                if recentURL == sourceURL {
+                    recentFiles[idx] = destURL
+                    recentsChanged = true
+                } else if recentURL.path.hasPrefix(sourceURL.path + "/") {
+                    let relative = String(recentURL.path.dropFirst(sourceURL.path.count))
+                    recentFiles[idx] = URL(fileURLWithPath: destURL.path + relative)
+                    recentsChanged = true
+                }
+            }
+            if recentsChanged {
+                persistRecents()
+            }
+            if let currentFileURL {
+                persistLastOpenFile(currentFileURL)
             }
             DiagnosticLog.log("Moved: \(sourceURL.lastPathComponent) → \(folderURL.lastPathComponent)/")
             return destURL
@@ -775,6 +795,7 @@ final class WorkspaceManager {
             return
         }
         vaultIndexes[location.id] = index
+        vaultIndexRevision += 1
         reindexVault(index)
     }
 
@@ -786,8 +807,11 @@ final class WorkspaceManager {
 
     private func reindexVault(_ index: VaultIndex?) {
         let showHiddenFiles = self.showHiddenFiles
-        DispatchQueue.global(qos: .utility).async { [weak index] in
+        DispatchQueue.global(qos: .utility).async { [weak self, weak index] in
             index?.indexAllFiles(showHiddenFiles: showHiddenFiles)
+            DispatchQueue.main.async {
+                self?.vaultIndexRevision += 1
+            }
         }
     }
 

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -27,6 +27,7 @@ enum MarkdownRenderer {
         html = processHighlightMarks(html)
         html = processSuperSub(html)
         html = processEmoji(html)
+        html = processWikiLinks(html)
         html = processCallouts(html)
         html = processTOC(html)
         html = processCaptions(html)
@@ -241,6 +242,54 @@ enum MarkdownRenderer {
         }
         result += ns.substring(from: lastEnd)
         return result
+    }
+
+    // MARK: - Wiki-Links [[note]]
+
+    private static func processWikiLinks(_ html: String) -> String {
+        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        guard let regex = try? NSRegularExpression(
+            pattern: #"\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]"#
+        ) else {
+            return restoreProtectedSegments(in: protectedHTML, segments: segments)
+        }
+        let ns = protectedHTML as NSString
+        var result = ""
+        var lastEnd = 0
+        for match in regex.matches(in: protectedHTML, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+
+            let target = ns.substring(with: match.range(at: 1))
+                .trimmingCharacters(in: .whitespaces)
+
+            var heading: String? = nil
+            if match.range(at: 2).location != NSNotFound {
+                heading = ns.substring(with: match.range(at: 2))
+                    .trimmingCharacters(in: .whitespaces)
+            }
+
+            let displayText: String
+            if match.range(at: 3).location != NSNotFound {
+                displayText = ns.substring(with: match.range(at: 3))
+                    .trimmingCharacters(in: .whitespaces)
+            } else if let heading {
+                displayText = "\(target) > \(heading)"
+            } else {
+                displayText = target
+            }
+
+            let encodedTarget = target.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? target
+            var href = "clearly://wiki/\(encodedTarget)"
+            if let heading {
+                let encodedHeading = heading.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? heading
+                href += "#\(encodedHeading)"
+            }
+
+            result += "<a href=\"\(href)\" class=\"wiki-link\">\(escapeHTML(displayText))</a>"
+            lastEnd = match.range.location + match.range.length
+        }
+        result += ns.substring(from: lastEnd)
+        return restoreProtectedSegments(in: result, segments: segments)
     }
 
     // MARK: - Highlight/Mark ==text==

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -3,6 +3,8 @@ import Foundation
 enum PreviewCSS {
     static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
     let exportOverrides = forExport ? """
+    a.wiki-link { color: #34855A !important; border-bottom: none !important; }
+    a.wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
     .code-copy-btn { display: none !important; }
     .table-copy-btn { display: none !important; }
     .sort-indicator { display: none !important; }
@@ -197,6 +199,23 @@ enum PreviewCSS {
     }
     a:hover {
         text-decoration: underline;
+    }
+    a.wiki-link {
+        color: #34855A;
+        text-decoration: none;
+        border-bottom: 1px solid rgba(52, 133, 90, 0.3);
+    }
+    a.wiki-link:hover {
+        text-decoration: none;
+        border-bottom-color: #34855A;
+    }
+    a.wiki-link-broken {
+        color: #B35C3A;
+        border-bottom: 1px dashed rgba(179, 92, 58, 0.4);
+    }
+    a.wiki-link-broken:hover {
+        text-decoration: none;
+        border-bottom-color: #B35C3A;
     }
 
     code {
@@ -682,6 +701,10 @@ enum PreviewCSS {
             background-color: #323236;
         }
         a { color: #0A84FF; }
+        a.wiki-link { color: #5ABF80; border-bottom-color: rgba(90, 191, 128, 0.3); }
+        a.wiki-link:hover { border-bottom-color: #5ABF80; }
+        a.wiki-link-broken { color: #D97A57; border-bottom-color: rgba(217, 122, 87, 0.4); }
+        a.wiki-link-broken:hover { border-bottom-color: #D97A57; }
         h6 { color: rgba(245, 245, 247, 0.55); }
         code {
             background-color: rgba(255, 255, 255, 0.06);
@@ -804,6 +827,8 @@ enum PreviewCSS {
     }
 
     @media print {
+        a.wiki-link { color: #34855A !important; border-bottom: none !important; }
+        a.wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
         .code-filename {
             background: #EDEDF0 !important;
             color: #86868B !important;

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 1 - Completed
+## Status: Phase 2 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -38,13 +38,36 @@
 ---
 
 ### Phase 2: Wiki-Links
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `wikiLinkColor` (warm green) and `wikiLinkBrokenColor` (orange-red) to `Theme.swift`
+- [x] Added `.wikiLink` case to `HighlightStyle` enum in `MarkdownSyntaxHighlighter.swift`
+- [x] Added wiki-link regex pattern `(\[\[)([^\]\n]+?)(\]\])` to patterns array (after footnotes, before tables)
+- [x] Added `.wikiLink` switch cases to both `highlightAll` and `highlightAround` methods
+- [x] Added `processWikiLinks()` to `MarkdownRenderer.swift` pipeline (after processEmoji, before processCallouts)
+  - Handles `[[note]]`, `[[note|alias]]`, `[[note#heading]]`, `[[note#heading|alias]]`
+  - Uses `clearly://wiki/` custom URL scheme, `escapeHTML` for display text
+  - Renderer stays pure — no VaultIndex dependency
+- [x] Added `.wiki-link` and `.wiki-link-broken` CSS to `PreviewCSS.swift` in all 4 contexts (light, dark, print, export)
+  - Resolved: green with solid bottom border; Broken: orange-red with dashed border
+- [x] Added `onWikiLinkClicked` callback and `wikiFileNames` property to `PreviewView.swift`
+- [x] Modified `handleLinkClick` to detect `clearly://wiki/` scheme and call callback
+- [x] Injected broken-link detection JS: compares wiki-link targets against known file names, adds `.wiki-link-broken` class
+- [x] Wired `onWikiLinkClicked` and `wikiFileNames` in `ContentView.swift` previewPane
+- [x] Added Cmd+click wiki-link navigation to `ClearlyTextView.swift` (mouseDown override + regex detection)
+- [x] Added `.navigateWikiLink` notification for editor-to-ContentView communication
+- [x] Wired `onWikiLinkClicked` from ClearlyTextView via NotificationCenter in `EditorView.swift`
 
 #### Decisions Made
-- (none yet)
+- Wiki-link color is warm green (distinct from blue standard links) — visually signals "internal/connected"
+- Broken-link color is orange-red — signals "needs attention" without being alarm-red
+- Editor highlighting uses single color for all wiki-link content (no sub-parsing of heading/alias) — simpler, consistent
+- No broken-link coloring in editor (would require VaultIndex in hot path) — preview handles it via JS
+- Reuse existing `linkClicked` JS handler rather than adding new message handler — `clearly://wiki/` scheme detection in `handleLinkClick` is simpler
+- Editor Cmd+click uses regex scan on 400-char window around click point — avoids complex attribute/range tracking
+- File name comparison is case-insensitive (lowercased set) matching VaultIndex.resolveWikiLink behavior
+- Wiki-link JS broken detection skips marking when knownFiles set is empty (no vault index yet)
 
 #### Blockers
 - (none)
@@ -123,6 +146,15 @@
 
 ## Session Log
 
+### 2026-04-13 — Phase 2 Implementation
+- Implemented full wiki-link support across 8 files: Theme, Highlighter, Renderer, CSS, PreviewView, ContentView, ClearlyTextView, EditorView
+- Editor syntax highlighting: `[[brackets]]` in syntax color, content in green wiki-link color
+- Preview rendering: `[[note]]` → `<a href="clearly://wiki/note" class="wiki-link">note</a>` with code-block protection
+- Preview click handling: `clearly://wiki/` scheme detected in handleLinkClick, resolved via VaultIndex, opens via workspace.openFile
+- Broken-link detection: JS injected with known file names set, marks unresolved links with `.wiki-link-broken` class
+- Editor Cmd+click: mouseDown override on ClearlyTextView with regex-based wiki-link detection at click point
+- Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
+
 ### 2026-04-13 — Phase 1 Implementation
 - Built all 6 tasks: GRDB dep → FileParser → VaultIndex → WorkspaceManager integration → QuickSwitcherPanel → Cmd+P shortcut
 - Fixed FTS5 external content bug (content='files' referenced non-existent column) — switched to standalone FTS
@@ -135,6 +167,14 @@
 ---
 
 ## Files Changed
+- `Clearly/Theme.swift` — `wikiLinkColor`, `wikiLinkBrokenColor`
+- `Clearly/MarkdownSyntaxHighlighter.swift` — `.wikiLink` enum case, pattern, two switch cases
+- `Shared/MarkdownRenderer.swift` — `processWikiLinks()` in pipeline
+- `Shared/PreviewCSS.swift` — `.wiki-link`, `.wiki-link-broken` CSS in 4 contexts
+- `Clearly/PreviewView.swift` — `onWikiLinkClicked` callback, `wikiFileNames`, broken-link JS, scheme handling
+- `Clearly/ContentView.swift` — wiki file names computation, callbacks, `.navigateWikiLink` notification handler
+- `Clearly/ClearlyTextView.swift` — `onWikiLinkClicked`, mouseDown override, regex detection
+- `Clearly/EditorView.swift` — wire onWikiLinkClicked via notification
 - `project.yml` — GRDB dependency, dev bundle IDs for Debug config
 - `Clearly/FileParser.swift` (new) — markdown parser for wiki-links, tags, headings
 - `Clearly/VaultIndex.swift` (new) — SQLite index with GRDB, FTS5, full schema


### PR DESCRIPTION
## Summary
- Adds `[[note]]` wiki-link syntax support across editor and preview — including `[[note|alias]]` for display aliases and `[[note#heading]]` for heading anchors
- Editor highlights wiki-links in a distinct green color (brackets dimmed as syntax); preview renders them as clickable links with broken-link detection (unresolved links styled orange-red with dashed underline)
- Click a wiki-link in preview or Cmd+click in editor to navigate to the target file, with optional scroll-to-heading via `VaultIndex.lineNumberForHeading()`
- Adds `vaultIndexRevision` tracking on WorkspaceManager so preview reactively updates broken-link markers when the index changes

## Test plan
- [ ] Type `[[existing note]]` in editor — verify green highlighting, clickable in preview, navigates on click
- [ ] Type `[[nonexistent]]` — verify orange-red dashed underline in preview
- [ ] Test `[[note|alias]]` shows alias text in preview, navigates to note
- [ ] Test `[[note#heading]]` navigates and scrolls to heading
- [ ] Cmd+click a wiki-link in editor — verify navigation
- [ ] Verify `[[link]]` inside fenced code blocks is NOT processed
- [ ] Build succeeds for both Clearly and ClearlyQuickLook targets