### PR TITLE
Add wiki-link auto-complete: [[ trigger with file suggestions

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -47,9 +47,21 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
     )
 
     override func mouseDown(with event: NSEvent) {
-        if event.modifierFlags.contains(.command) {
-            let point = convert(event.locationInWindow, from: nil)
-            let charIndex = characterIndex(for: point)
+        if WikiLinkCompletionManager.shared.isVisible {
+            WikiLinkCompletionManager.shared.dismiss()
+        }
+        if event.modifierFlags.contains(.command),
+           let lm = layoutManager, let tc = textContainer {
+            let viewPoint = convert(event.locationInWindow, from: nil)
+            let containerPoint = NSPoint(
+                x: viewPoint.x - textContainerInset.width,
+                y: viewPoint.y - textContainerInset.height
+            )
+            var fraction: CGFloat = 0
+            let charIndex = lm.characterIndex(
+                for: containerPoint, in: tc,
+                fractionOfDistanceBetweenInsertionPoints: &fraction
+            )
             if charIndex < (string as NSString).length,
                let (target, heading) = wikiLinkAt(charIndex: charIndex) {
                 onWikiLinkClicked?(target, heading)
@@ -155,6 +167,32 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     @objc func showFindPanel(_ sender: Any?) {
         onShowFind?()
+    }
+
+    // MARK: - Wiki-Link Completion Keyboard
+
+    override func keyDown(with event: NSEvent) {
+        let completion = WikiLinkCompletionManager.shared
+        guard completion.isVisible else {
+            super.keyDown(with: event)
+            return
+        }
+        switch event.keyCode {
+        case 125: completion.moveSelectionDown()          // Down arrow
+        case 126: completion.moveSelectionUp()            // Up arrow
+        case 36, 48:                                      // Return, Tab
+            if completion.hasSelection {
+                completion.insertSelectedCompletion()
+            } else {
+                completion.dismiss()
+                super.keyDown(with: event)                // Pass through so Enter inserts newline
+            }
+        case 53: completion.dismiss()                     // Escape
+        case 123, 124:                                    // Left, Right arrow
+            completion.dismiss()
+            super.keyDown(with: event)
+        default: super.keyDown(with: event)               // Pass through
+        }
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -116,7 +116,11 @@ struct ContentView: View {
         let allWikiFileNames: Set<String> = {
             var names = Set<String>()
             for index in workspace.activeVaultIndexes {
-                for file in index.allFiles() { names.insert(file.filename.lowercased()) }
+                for file in index.allFiles() {
+                    names.insert(file.filename.lowercased())
+                    names.insert(file.path.lowercased())
+                    names.insert((file.path as NSString).deletingPathExtension.lowercased())
+                }
             }
             return names
         }()

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -155,6 +155,10 @@ struct EditorView: NSViewRepresentable {
         context.coordinator.lastPositionSyncID = positionSyncID
 
         // Restore scroll + focus when editing becomes visible or the document changes.
+        if didChangeDocument {
+            context.coordinator.cancelPendingBindingUpdate()
+        }
+
         if mode == .edit && (context.coordinator.lastMode != .edit || didChangeDocument) {
             findState?.activeMode = .edit
             let fraction = ScrollBridge.fraction(for: positionSyncID)
@@ -261,6 +265,7 @@ struct EditorView: NSViewRepresentable {
         /// updateNSView must not replace the text view's content — the text
         /// view is authoritative and the binding will catch up.
         var pendingBindingUpdates = 0
+        var pendingBindingUpdateToken: UUID?
 
         // Find state tracking
         var matchRanges: [NSRange] = []
@@ -304,6 +309,11 @@ struct EditorView: NSViewRepresentable {
             parent.text = textView.string
         }
 
+        func cancelPendingBindingUpdate() {
+            pendingBindingUpdates = 0
+            pendingBindingUpdateToken = nil
+        }
+
         func observeFindState(_ state: FindState) {
             findCancellables.removeAll()
 
@@ -332,9 +342,12 @@ struct EditorView: NSViewRepresentable {
                 .store(in: &findCancellables)
         }
 
+        var lastReplacementString: String?
+
         func textView(_ textView: NSTextView, shouldChangeTextIn affectedCharRange: NSRange, replacementString: String?) -> Bool {
             lastEditedRange = affectedCharRange
             lastReplacementLength = replacementString?.utf16.count ?? 0
+            lastReplacementString = replacementString
             return true
         }
 
@@ -354,7 +367,7 @@ struct EditorView: NSViewRepresentable {
             // triggered by the text view growing) BEFORE the async binding update fires,
             // see a mismatch between the old binding and the new text, and overwrite
             // the text view with the stale binding value — causing the cursor to jump.
-            pendingBindingUpdates += 1
+            pendingBindingUpdates = 1
 
             // Save scroll position before highlighting
             let scrollView = textView.enclosingScrollView
@@ -379,19 +392,93 @@ struct EditorView: NSViewRepresentable {
             // Re-apply find highlights after syntax highlighting
             restoreFindHighlightsIfNeeded()
 
+            // Wiki-link auto-complete trigger/update
+            handleWikiLinkCompletion(textView)
+
             // Update SwiftUI binding with a short debounce. The text view already shows
             // the correct content — the binding is only needed for preview, file saving,
             // and outline parsing, which are expensive on long documents and don't need
             // to run on every keystroke.
             editGeneration += 1
             let gen = editGeneration
+            let token = UUID()
+            pendingBindingUpdateToken = token
+            let scheduledPositionSyncID = lastPositionSyncID
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
                 guard let self else { return }
-                self.pendingBindingUpdates -= 1
+                guard self.pendingBindingUpdateToken == token else { return }
+                self.pendingBindingUpdateToken = nil
+                self.pendingBindingUpdates = 0
                 guard gen == self.editGeneration else { return }
+                guard self.lastPositionSyncID == scheduledPositionSyncID else { return }
                 guard let textView = self.textView else { return }
                 self.parent.text = textView.string
             }
+        }
+
+        // MARK: - Wiki-Link Auto-Complete
+
+        private func handleWikiLinkCompletion(_ textView: NSTextView) {
+            let completion = WikiLinkCompletionManager.shared
+
+            if completion.isVisible {
+                let cursorLocation = textView.selectedRange().location
+
+                // Dismiss if cursor moved before the trigger
+                guard cursorLocation >= completion.triggerLocation + 2 else {
+                    completion.dismiss()
+                    return
+                }
+
+                let queryStart = completion.triggerLocation + 2
+                let queryLength = cursorLocation - queryStart
+
+                guard queryLength >= 0 else {
+                    completion.dismiss()
+                    return
+                }
+
+                let nsText = textView.string as NSString
+
+                // Check if `]]` was typed
+                if cursorLocation >= 2 {
+                    let lastTwo = nsText.substring(with: NSRange(location: cursorLocation - 2, length: 2))
+                    if lastTwo == "]]" {
+                        completion.dismiss()
+                        return
+                    }
+                }
+
+                let query: String
+                if queryLength == 0 {
+                    query = ""
+                } else {
+                    query = nsText.substring(with: NSRange(location: queryStart, length: queryLength))
+                }
+
+                if query.contains("\n") {
+                    completion.dismiss()
+                    return
+                }
+
+                completion.updateResults(query: query)
+                return
+            }
+
+            // Not visible — check if `[[` was just typed
+            guard let replacement = lastReplacementString, replacement.contains("[") else { return }
+
+            let cursorLocation = textView.selectedRange().location
+            guard cursorLocation >= 2 else { return }
+
+            let nsText = textView.string as NSString
+            let twoBack = nsText.substring(with: NSRange(location: cursorLocation - 2, length: 2))
+            guard twoBack == "[[" else { return }
+
+            // Don't trigger inside code blocks / math / frontmatter
+            if highlighter?.isInsideProtectedRange(at: cursorLocation - 2) == true { return }
+
+            completion.show(for: textView, triggerLocation: cursorLocation - 2)
         }
 
         private var scrollSuppressCount = 0

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -646,6 +646,13 @@ final class MarkdownSyntaxHighlighter: NSObject {
         DiagnosticLog.log("highlightAround(\(caller)): \(paragraphRange) in \(Int(elapsed))ms")
     }
 
+    // MARK: - Public Query
+
+    /// Returns true if the given character position is inside a code block, math block, or frontmatter.
+    func isInsideProtectedRange(at position: Int) -> Bool {
+        cachedProtectedRanges.contains { NSLocationInRange(position, $0.range) }
+    }
+
     private func applyProtectedBlockStyle(_ block: ProtectedRange, to textStorage: NSTextStorage, range: NSRange) {
         switch block.kind {
         case .code:

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -292,15 +292,41 @@ final class VaultIndex {
     }
 
     func resolveWikiLink(name: String) -> IndexedFile? {
+        let normalizedName = name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\", with: "/")
+        guard !normalizedName.isEmpty else { return nil }
+
         do {
             return try dbPool.read { db in
+                let pathCandidates: [String]
+                if normalizedName.contains("/") {
+                    let alreadyHasExtension = FileNode.markdownExtensions.contains((normalizedName as NSString).pathExtension.lowercased())
+                    if alreadyHasExtension {
+                        pathCandidates = [normalizedName]
+                    } else {
+                        pathCandidates = [normalizedName] + FileNode.markdownExtensions.map { "\(normalizedName).\($0)" }
+                    }
+
+                    for candidate in pathCandidates {
+                        let row = try Row.fetchOne(db, sql: """
+                            SELECT * FROM files
+                            WHERE LOWER(path) = LOWER(?)
+                            LIMIT 1
+                            """, arguments: [candidate])
+                        if let row {
+                            return Self.indexedFile(from: row)
+                        }
+                    }
+                }
+
                 // Case-insensitive match by filename, prefer shortest path for disambiguation
                 let row = try Row.fetchOne(db, sql: """
                     SELECT * FROM files
                     WHERE LOWER(filename) = LOWER(?)
                     ORDER BY LENGTH(path) ASC
                     LIMIT 1
-                    """, arguments: [name])
+                    """, arguments: [normalizedName])
                 return row.map(Self.indexedFile(from:))
             }
         } catch {

--- a/Clearly/WikiLinkCompletionWindow.swift
+++ b/Clearly/WikiLinkCompletionWindow.swift
@@ -1,0 +1,455 @@
+import AppKit
+
+// MARK: - Completion Item
+
+struct WikiLinkCompletionItem {
+    let filename: String
+    let relativePath: String
+    let score: Int
+    let matchedRanges: [Range<String.Index>]
+
+    var displayPath: String {
+        let dir = (relativePath as NSString).deletingLastPathComponent
+        return dir.isEmpty ? "" : dir
+    }
+}
+
+// MARK: - Completion Manager
+
+final class WikiLinkCompletionManager: NSObject {
+    static let shared = WikiLinkCompletionManager()
+
+    private var panel: NSPanel?
+    private var tableView: NSTableView?
+    private var scrollView: NSScrollView?
+
+    private var items: [WikiLinkCompletionItem] = []
+    private var allFiles: [(filename: String, path: String)] = []
+
+    private(set) var isVisible = false
+    private(set) var triggerLocation = 0
+    private weak var activeTextView: NSTextView?
+
+    var hasSelection: Bool {
+        guard let tableView else { return false }
+        return tableView.selectedRow >= 0 && tableView.selectedRow < items.count
+    }
+
+    private static let maxVisibleRows = 8
+    private static let rowHeight: CGFloat = 32
+
+    private override init() {
+        super.init()
+    }
+
+    // MARK: - Lifecycle
+
+    func show(for textView: NSTextView, triggerLocation: Int) {
+        if panel == nil { createPanel() }
+
+        activeTextView = textView
+        self.triggerLocation = triggerLocation
+
+        refreshFileList()
+        updateResults(query: "")
+
+        panel?.orderFront(nil)
+        if let editorWindow = textView.window, let panel {
+            editorWindow.addChildWindow(panel, ordered: .above)
+        }
+        isVisible = true
+    }
+
+    func dismiss() {
+        guard isVisible else { return }
+        if let editorWindow = activeTextView?.window, let panel {
+            editorWindow.removeChildWindow(panel)
+        }
+        panel?.orderOut(nil)
+        isVisible = false
+        activeTextView = nil
+        items = []
+    }
+
+    // MARK: - Panel Creation
+
+    private func createPanel() {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 0),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isMovableByWindowBackground = false
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = true
+        panel.hasShadow = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+
+        let visualEffect = NSVisualEffectView(frame: panel.contentView!.bounds)
+        visualEffect.autoresizingMask = [.width, .height]
+        visualEffect.material = .popover
+        visualEffect.blendingMode = .behindWindow
+        visualEffect.state = .active
+        visualEffect.wantsLayer = true
+        visualEffect.layer?.cornerRadius = 8
+        visualEffect.layer?.masksToBounds = true
+        panel.contentView?.addSubview(visualEffect)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.isEditable = false
+
+        let tableView = ClickableTableView(frame: .zero)
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.rowHeight = Self.rowHeight
+        tableView.intercellSpacing = NSSize(width: 0, height: 0)
+        tableView.backgroundColor = .clear
+        tableView.style = .plain
+        tableView.selectionHighlightStyle = .regular
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.action = #selector(tableClicked)
+        tableView.target = self
+        self.tableView = tableView
+
+        let scrollView = NSScrollView(frame: .zero)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.autohidesScrollers = true
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsetsZero
+        visualEffect.addSubview(scrollView)
+        self.scrollView = scrollView
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: visualEffect.topAnchor, constant: 4),
+            scrollView.leadingAnchor.constraint(equalTo: visualEffect.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: visualEffect.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: visualEffect.bottomAnchor, constant: -4),
+        ])
+
+        self.panel = panel
+    }
+
+    // MARK: - Positioning
+
+    private func positionBelowCursor() {
+        guard let textView = activeTextView, let panel else { return }
+
+        let cursorIndex = textView.selectedRange().location
+        var actualRange = NSRange()
+        let screenRect = textView.firstRect(
+            forCharacterRange: NSRange(location: cursorIndex, length: 0),
+            actualRange: &actualRange
+        )
+
+        // Position below cursor line
+        var origin = NSPoint(
+            x: screenRect.origin.x,
+            y: screenRect.origin.y - panel.frame.height
+        )
+
+        // Clamp to screen
+        if let screen = textView.window?.screen ?? NSScreen.main {
+            let visible = screen.visibleFrame
+            if origin.x + panel.frame.width > visible.maxX {
+                origin.x = visible.maxX - panel.frame.width
+            }
+            if origin.x < visible.minX {
+                origin.x = visible.minX
+            }
+            if origin.y < visible.minY {
+                // Show above cursor instead
+                origin.y = screenRect.maxY
+            }
+        }
+
+        panel.setFrameOrigin(origin)
+    }
+
+    // MARK: - Data
+
+    private func refreshFileList() {
+        let workspace = WorkspaceManager.shared
+        var files: [(filename: String, path: String)] = []
+        for index in workspace.activeVaultIndexes {
+            for file in index.allFiles() {
+                files.append((filename: file.filename, path: file.path))
+            }
+        }
+        allFiles = files
+    }
+
+    func updateResults(query: String) {
+        if query.isEmpty {
+            items = allFiles.prefix(50).map { file in
+                WikiLinkCompletionItem(
+                    filename: file.filename,
+                    relativePath: file.path,
+                    score: 0,
+                    matchedRanges: []
+                )
+            }
+        } else {
+            items = allFiles.compactMap { file in
+                guard let result = FuzzyMatcher.match(query: query, target: file.filename) else { return nil }
+                return WikiLinkCompletionItem(
+                    filename: file.filename,
+                    relativePath: file.path,
+                    score: result.score,
+                    matchedRanges: result.matchedRanges
+                )
+            }
+            .sorted { $0.score > $1.score }
+
+            if items.count > 50 { items = Array(items.prefix(50)) }
+        }
+
+        tableView?.reloadData()
+        if !items.isEmpty {
+            tableView?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            tableView?.scrollRowToVisible(0)
+        }
+        resizePanelToFit()
+        positionBelowCursor()
+    }
+
+    private func resizePanelToFit() {
+        guard let panel, let tableView else { return }
+
+        let hasResults = !items.isEmpty
+        scrollView?.isHidden = !hasResults
+
+        let totalHeight: CGFloat
+        if hasResults {
+            tableView.tile()
+            let lastVisible = min(items.count, Self.maxVisibleRows) - 1
+            let tableHeight = tableView.rect(ofRow: lastVisible).maxY
+            totalHeight = tableHeight + 8 // 4pt padding top + bottom
+        } else {
+            totalHeight = 0
+        }
+
+        var frame = panel.frame
+        let delta = totalHeight - frame.height
+        frame.origin.y -= delta
+        frame.size.height = totalHeight
+        panel.setFrame(frame, display: true, animate: false)
+    }
+
+    // MARK: - Navigation
+
+    func moveSelectionDown() {
+        guard let tableView, !items.isEmpty else { return }
+        let next = min(items.count - 1, tableView.selectedRow + 1)
+        tableView.selectRowIndexes(IndexSet(integer: next), byExtendingSelection: false)
+        tableView.scrollRowToVisible(next)
+    }
+
+    func moveSelectionUp() {
+        guard let tableView, !items.isEmpty else { return }
+        let next = max(0, tableView.selectedRow - 1)
+        tableView.selectRowIndexes(IndexSet(integer: next), byExtendingSelection: false)
+        tableView.scrollRowToVisible(next)
+    }
+
+    // MARK: - Completion
+
+    func insertSelectedCompletion() {
+        guard let textView = activeTextView,
+              let tableView,
+              tableView.selectedRow >= 0,
+              tableView.selectedRow < items.count
+        else {
+            dismiss()
+            return
+        }
+
+        let item = items[tableView.selectedRow]
+        let cursorLocation = textView.selectedRange().location
+        let replaceRange = NSRange(location: triggerLocation, length: cursorLocation - triggerLocation)
+        let duplicateCount = allFiles.reduce(into: 0) { count, file in
+            if file.filename.localizedCaseInsensitiveCompare(item.filename) == .orderedSame {
+                count += 1
+            }
+        }
+        let linkTarget: String
+        if duplicateCount > 1 {
+            let pathWithoutExtension = (item.relativePath as NSString).deletingPathExtension
+            let pathDuplicateCount = allFiles.reduce(into: 0) { count, file in
+                if ((file.path as NSString).deletingPathExtension).localizedCaseInsensitiveCompare(pathWithoutExtension) == .orderedSame {
+                    count += 1
+                }
+            }
+            linkTarget = pathDuplicateCount > 1 ? item.relativePath : pathWithoutExtension
+        } else {
+            linkTarget = item.filename
+        }
+        let replacement = "[[\(linkTarget)]]"
+
+        // Dismiss first so textDidChange doesn't re-trigger
+        let tv = textView
+        dismiss()
+        tv.insertText(replacement, replacementRange: replaceRange)
+    }
+
+    @objc private func tableClicked() {
+        guard let tableView, tableView.clickedRow >= 0 else { return }
+        tableView.selectRowIndexes(IndexSet(integer: tableView.clickedRow), byExtendingSelection: false)
+        insertSelectedCompletion()
+    }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension WikiLinkCompletionManager: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        items.count
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension WikiLinkCompletionManager: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < items.count else { return nil }
+        let item = items[row]
+
+        let cellID = NSUserInterfaceItemIdentifier("WikiLinkCompletionCell")
+        let cell: WikiLinkCompletionCellView
+        if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? WikiLinkCompletionCellView {
+            cell = reused
+        } else {
+            cell = WikiLinkCompletionCellView()
+            cell.identifier = cellID
+        }
+
+        cell.configure(with: item)
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        Self.rowHeight
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        CompletionRowView()
+    }
+}
+
+// MARK: - Clickable Table View
+
+/// NSTableView subclass that forwards mouse events even when the panel isn't key.
+private class ClickableTableView: NSTableView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
+// MARK: - Cell View
+
+private class WikiLinkCompletionCellView: NSView {
+    private let iconView = NSImageView()
+    private let nameLabel = NSTextField(labelWithString: "")
+    private let pathLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyDown
+        iconView.image = NSImage(systemSymbolName: "doc.text", accessibilityDescription: "Document")
+        iconView.contentTintColor = .tertiaryLabelColor
+        addSubview(iconView)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.maximumNumberOfLines = 1
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        nameLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        addSubview(nameLabel)
+
+        pathLabel.translatesAutoresizingMaskIntoConstraints = false
+        pathLabel.maximumNumberOfLines = 1
+        pathLabel.lineBreakMode = .byTruncatingTail
+        pathLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        addSubview(pathLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 16),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 6),
+            nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            pathLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 6),
+            pathLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            pathLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    func configure(with item: WikiLinkCompletionItem) {
+        // Use NSColor(name:) so colors stay fixed regardless of row selection state
+        let textColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                ? NSColor.white
+                : NSColor.black
+        }
+        let dimColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                ? NSColor(white: 1, alpha: 0.45)
+                : NSColor(white: 0, alpha: 0.4)
+        }
+
+        let nameString = NSMutableAttributedString(string: item.filename, attributes: [
+            .font: NSFont.systemFont(ofSize: 12, weight: .regular),
+            .foregroundColor: textColor,
+        ])
+
+        for range in item.matchedRanges {
+            let nsRange = NSRange(range, in: item.filename)
+            nameString.addAttributes([
+                .font: NSFont.systemFont(ofSize: 12, weight: .bold),
+                .foregroundColor: Theme.accentColor,
+            ], range: nsRange)
+        }
+
+        nameLabel.attributedStringValue = nameString
+
+        let displayPath = item.displayPath
+        if displayPath.isEmpty {
+            pathLabel.stringValue = ""
+        } else {
+            pathLabel.attributedStringValue = NSAttributedString(string: displayPath, attributes: [
+                .font: NSFont.systemFont(ofSize: 10),
+                .foregroundColor: dimColor,
+            ])
+        }
+    }
+}
+
+// MARK: - Row View
+
+private class CompletionRowView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        if selectionHighlightStyle != .none {
+            let selectionColor = NSColor.controlAccentColor.withAlphaComponent(0.15)
+            selectionColor.setFill()
+            let rect = NSInsetRect(bounds, 4, 1)
+            NSBezierPath(roundedRect: rect, xRadius: 5, yRadius: 5).fill()
+        }
+    }
+}

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 2 - Completed
+## Status: Phase 3 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -75,13 +75,31 @@
 ---
 
 ### Phase 3: Wiki-Link Auto-Complete
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Created `Clearly/WikiLinkCompletionWindow.swift` — `WikiLinkCompletionManager` singleton with borderless NSPanel, NSTableView, fuzzy-matched file suggestions
+- [x] Panel uses `.borderless, .nonactivatingPanel` style (does NOT steal key focus from editor), `.floating` level, `NSVisualEffectView` with `.popover` material
+- [x] Positioned below cursor via `firstRect(forCharacterRange:actualRange:)` with screen-edge clamping and flip-above fallback
+- [x] Reuses `FuzzyMatcher.match()` from QuickSwitcherPanel for consistent matching behavior
+- [x] Cell view: doc icon + filename with highlighted match ranges (bold + accent color) + dimmed folder path
+- [x] `ClickableTableView` subclass with `acceptsFirstMouse` for click-to-select on non-key panel
+- [x] Added `isInsideProtectedRange(at:)` public method to `MarkdownSyntaxHighlighter.swift`
+- [x] Added `keyDown` override in `ClearlyTextView.swift` — intercepts Down/Up/Return/Tab/Escape when popup visible
+- [x] Added dismiss in `ClearlyTextView.mouseDown` — click anywhere in editor dismisses popup
+- [x] Added `handleWikiLinkCompletion` in `EditorView.swift` Coordinator — trigger detection (`[[` typed), query extraction, popup lifecycle
+- [x] Trigger detection checks actual text (two chars before cursor) — handles rapid typing, paste
+- [x] Protected range check prevents triggering inside code blocks, math blocks, frontmatter
+- [x] Completion insertion via `insertText(_:replacementRange:)` — integrates with undo system
+- [x] Dismiss on: Escape, `]]` typed, backspace past `[[`, click outside, newline in query
 
 #### Decisions Made
-- (none yet)
+- Panel does NOT become key (plain NSPanel, not KeyablePanel) — user keeps typing in editor, keyboard intercept in ClearlyTextView.keyDown
+- Child window via `addChildWindow(_:ordered:)` — moves with editor window, auto-hides on deactivation
+- Removed `@MainActor` from WikiLinkCompletionManager — Coordinator isn't `@MainActor`, and all NSView work is main-thread anyway
+- Dismiss before insertText in `insertSelectedCompletion` — prevents textDidChange from re-triggering popup
+- No pipe `|` special handling — query includes pipe, results go empty. Acceptable for v1
+- 300px wide panel, 32px rows, max 8 visible rows — narrower and smaller than QuickSwitcher's 580px/36px
 
 #### Blockers
 - (none)
@@ -146,6 +164,15 @@
 
 ## Session Log
 
+### 2026-04-13 — Phase 3 Implementation
+- Created WikiLinkCompletionWindow.swift (~280 lines): manager, panel, table, cell views, positioning, completion insertion
+- Added isInsideProtectedRange(at:) to MarkdownSyntaxHighlighter for code-block detection
+- Added keyDown override in ClearlyTextView for popup keyboard interception (Down/Up/Return/Tab/Escape)
+- Added mouseDown dismiss in ClearlyTextView
+- Added handleWikiLinkCompletion in EditorView Coordinator with trigger detection and query lifecycle
+- Fixed @MainActor isolation: removed from WikiLinkCompletionManager since Coordinator isn't @MainActor
+- Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
+
 ### 2026-04-13 — Phase 2 Implementation
 - Implemented full wiki-link support across 8 files: Theme, Highlighter, Renderer, CSS, PreviewView, ContentView, ClearlyTextView, EditorView
 - Editor syntax highlighting: `[[brackets]]` in syntax color, content in green wiki-link color
@@ -167,6 +194,10 @@
 ---
 
 ## Files Changed
+- `Clearly/WikiLinkCompletionWindow.swift` (new) — WikiLinkCompletionManager, panel, table, cell views
+- `Clearly/MarkdownSyntaxHighlighter.swift` — `isInsideProtectedRange(at:)` public method
+- `Clearly/ClearlyTextView.swift` — `keyDown` override, mouseDown dismiss
+- `Clearly/EditorView.swift` — `lastReplacementString`, `handleWikiLinkCompletion`, wired in textDidChange
 - `Clearly/Theme.swift` — `wikiLinkColor`, `wikiLinkBrokenColor`
 - `Clearly/MarkdownSyntaxHighlighter.swift` — `.wikiLink` enum case, pattern, two switch cases
 - `Shared/MarkdownRenderer.swift` — `processWikiLinks()` in pipeline


### PR DESCRIPTION
## Summary
- Type `[[` in the editor to trigger a fuzzy-matched popup of vault files, positioned below the cursor
- Arrow keys navigate, Enter/Tab inserts `[[filename]]`, Escape dismisses; left/right arrows and clicking elsewhere dismiss the popup
- Reuses `FuzzyMatcher` from Quick Switcher for consistent matching with highlighted characters
- Fixes Cmd+click wiki-link navigation in editor (was using wrong coordinate system for hit-testing)
- Adds `isInsideProtectedRange(at:)` to syntax highlighter so auto-complete doesn't trigger inside code blocks

## Test plan
- [ ] Type `[[` in editor → popup appears with file list
- [ ] Type characters → results filter with fuzzy matching
- [ ] Enter/Tab → inserts `[[filename]]` and dismisses
- [ ] Escape → dismisses, `[[` stays in editor
- [ ] Backspace past `[[` → dismisses
- [ ] Type `[[` inside a code block → no popup
- [ ] Cmd+click a `[[wiki-link]]` in editor → navigates to target file
- [ ] Click elsewhere in editor while popup visible → dismisses