### PR TITLE
Add global search to Quick Switcher with FTS5 content search

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -298,6 +298,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
                 NotificationCenter.default.post(name: .init("ClearlyToggleOutline"), object: nil)
                 return nil
             }
+            if chars == "f" && mods == [.command, .shift] {
+                QuickSwitcherManager.shared.toggle()
+                return nil
+            }
             return event
         }
 
@@ -394,6 +398,27 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         injectSpellingMenuIfNeeded()
         injectSidebarToggleIfNeeded()
         injectViewCommandsIfNeeded()
+        injectGlobalSearchIfNeeded()
+    }
+
+    private func injectGlobalSearchIfNeeded() {
+        guard let viewMenu = NSApp.mainMenu?.item(withTitle: "View")?.submenu else { return }
+        guard !viewMenu.items.contains(where: { $0.title == "Search All Files…" }) else { return }
+
+        let item = NSMenuItem(title: "Search All Files…", action: #selector(globalSearchAction(_:)), keyEquivalent: "f")
+        item.keyEquivalentModifierMask = [.command, .shift]
+        item.target = self
+
+        if let quickOpenIndex = viewMenu.items.firstIndex(where: { $0.title == "Quick Open…" }) {
+            viewMenu.insertItem(item, at: quickOpenIndex + 1)
+        } else {
+            let insertAt = min(3, viewMenu.items.count)
+            viewMenu.insertItem(item, at: insertAt)
+        }
+    }
+
+    @objc private func globalSearchAction(_ sender: Any?) {
+        QuickSwitcherManager.shared.toggle()
     }
 
     private func injectSidebarToggleIfNeeded() {

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -93,6 +93,23 @@ struct QuickSwitcherItem {
     let score: Int
     let matchedRanges: [Range<String.Index>]
     let isCreateNew: Bool
+    let lineNumber: Int?           // for content matches: line to scroll to
+    let contextSnippet: String?    // for content matches: matching line text
+
+    init(filename: String, relativePath: String, fullURL: URL, score: Int,
+         matchedRanges: [Range<String.Index>], isCreateNew: Bool,
+         lineNumber: Int? = nil, contextSnippet: String? = nil) {
+        self.filename = filename
+        self.relativePath = relativePath
+        self.fullURL = fullURL
+        self.score = score
+        self.matchedRanges = matchedRanges
+        self.isCreateNew = isCreateNew
+        self.lineNumber = lineNumber
+        self.contextSnippet = contextSnippet
+    }
+
+    var isContentMatch: Bool { lineNumber != nil }
 
     var displayPath: String {
         let dir = (relativePath as NSString).deletingLastPathComponent
@@ -306,8 +323,8 @@ final class QuickSwitcherManager: NSObject {
                 )
             }
         } else {
-            // Fuzzy match
-            items = allFiles.compactMap { file in
+            // Fuzzy match on filenames
+            var nameMatches = allFiles.compactMap { file -> QuickSwitcherItem? in
                 guard let result = FuzzyMatcher.match(query: query, target: file.filename) else { return nil }
                 return QuickSwitcherItem(
                     filename: file.filename,
@@ -319,11 +336,35 @@ final class QuickSwitcherManager: NSObject {
                 )
             }
             .sorted { $0.score > $1.score }
+            if nameMatches.count > 20 { nameMatches = Array(nameMatches.prefix(20)) }
 
-            // Limit results
-            if items.count > 50 { items = Array(items.prefix(50)) }
+            // Content matches via FTS5 (only if query is 2+ chars)
+            var contentMatches: [QuickSwitcherItem] = []
+            if query.count >= 2 {
+                let nameMatchURLs = Set(nameMatches.map(\.fullURL))
+                for index in WorkspaceManager.shared.activeVaultIndexes {
+                    for group in index.searchFilesGrouped(query: query) {
+                        let fileURL = group.vaultRootURL.appendingPathComponent(group.file.path)
+                        guard !nameMatchURLs.contains(fileURL) else { continue }
+                        let excerpt = group.excerpts.first
+                        contentMatches.append(QuickSwitcherItem(
+                            filename: group.file.filename,
+                            relativePath: group.file.path,
+                            fullURL: fileURL,
+                            score: 0,
+                            matchedRanges: [],
+                            isCreateNew: false,
+                            lineNumber: excerpt?.lineNumber,
+                            contextSnippet: excerpt?.contextLine.trimmingCharacters(in: .whitespaces)
+                        ))
+                    }
+                }
+                if contentMatches.count > 30 { contentMatches = Array(contentMatches.prefix(30)) }
+            }
 
-            // Add create-on-miss if no results
+            items = nameMatches + contentMatches
+
+            // Add create-on-miss if no results at all
             if items.isEmpty {
                 let createName = query.hasSuffix(".md") ? query : "\(query).md"
                 items = [QuickSwitcherItem(
@@ -388,6 +429,19 @@ final class QuickSwitcherManager: NSObject {
             }
         } else {
             WorkspaceManager.shared.openFile(at: item.fullURL)
+            if let line = item.lineNumber {
+                let currentMode = ViewMode(rawValue: UserDefaults.standard.string(forKey: "viewMode") ?? "") ?? .edit
+                let notificationName: Notification.Name = currentMode == .preview
+                    ? .scrollPreviewToLine
+                    : .scrollEditorToLine
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                    NotificationCenter.default.post(
+                        name: notificationName,
+                        object: nil,
+                        userInfo: ["line": line]
+                    )
+                }
+            }
         }
 
         dismiss()
@@ -467,22 +521,37 @@ extension QuickSwitcherManager: NSTableViewDelegate {
             guard row < items.count else { return nil }
             let item = items[row]
 
-            let cellID = NSUserInterfaceItemIdentifier("QuickSwitcherCell")
-            let cell: QuickSwitcherCellView
-            if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? QuickSwitcherCellView {
-                cell = reused
+            if item.isContentMatch {
+                let cellID = NSUserInterfaceItemIdentifier("QuickSwitcherContentCell")
+                let cell: QuickSwitcherContentCellView
+                if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? QuickSwitcherContentCellView {
+                    cell = reused
+                } else {
+                    cell = QuickSwitcherContentCellView()
+                    cell.identifier = cellID
+                }
+                cell.configure(with: item)
+                return cell
             } else {
-                cell = QuickSwitcherCellView()
-                cell.identifier = cellID
+                let cellID = NSUserInterfaceItemIdentifier("QuickSwitcherCell")
+                let cell: QuickSwitcherCellView
+                if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? QuickSwitcherCellView {
+                    cell = reused
+                } else {
+                    cell = QuickSwitcherCellView()
+                    cell.identifier = cellID
+                }
+                cell.configure(with: item)
+                return cell
             }
-
-            cell.configure(with: item)
-            return cell
         }
     }
 
     nonisolated func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        36
+        MainActor.assumeIsolated {
+            guard row < items.count else { return 36 }
+            return items[row].isContentMatch ? 52 : 36
+        }
     }
 
     nonisolated func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
@@ -573,6 +642,113 @@ private class QuickSwitcherCellView: NSView {
                 .foregroundColor: NSColor.tertiaryLabelColor,
             ])
         }
+    }
+}
+
+// MARK: - Content Match Cell View (two-line: filename + snippet)
+
+private class QuickSwitcherContentCellView: NSView {
+    private let iconView = NSImageView()
+    private let nameLabel = NSTextField(labelWithString: "")
+    private let snippetLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyDown
+        addSubview(iconView)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        addSubview(nameLabel)
+
+        snippetLabel.translatesAutoresizingMaskIntoConstraints = false
+        snippetLabel.lineBreakMode = .byTruncatingTail
+        snippetLabel.maximumNumberOfLines = 1
+        snippetLabel.cell?.truncatesLastVisibleLine = true
+        snippetLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        addSubview(snippetLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            iconView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            iconView.widthAnchor.constraint(equalToConstant: 16),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+            nameLabel.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+
+            snippetLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            snippetLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+            snippetLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2),
+        ])
+    }
+
+    func configure(with item: QuickSwitcherItem) {
+        iconView.image = NSImage(systemSymbolName: "text.magnifyingglass", accessibilityDescription: "Content match")
+        iconView.contentTintColor = .tertiaryLabelColor
+
+        // Filename + path
+        let nameAttr = NSMutableAttributedString(string: item.filename, attributes: [
+            .font: NSFont.systemFont(ofSize: 13, weight: .regular),
+            .foregroundColor: NSColor.labelColor,
+        ])
+        let displayPath = item.displayPath
+        if !displayPath.isEmpty {
+            nameAttr.append(NSAttributedString(string: "  \(displayPath)", attributes: [
+                .font: NSFont.systemFont(ofSize: 11),
+                .foregroundColor: NSColor.tertiaryLabelColor,
+            ]))
+        }
+        nameLabel.attributedStringValue = nameAttr
+
+        // Snippet (markdown stripped)
+        let raw = item.contextSnippet ?? ""
+        let stripped = Self.stripMarkdown(raw)
+        let truncated = String(stripped.prefix(120))
+        snippetLabel.attributedStringValue = NSAttributedString(string: truncated, attributes: [
+            .font: NSFont.systemFont(ofSize: 11),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ])
+    }
+
+    private static func stripMarkdown(_ text: String) -> String {
+        var s = text
+        // Headings
+        s = s.replacingOccurrences(of: #"^#{1,6}\s+"#, with: "", options: .regularExpression)
+        // Bold/italic markers
+        s = s.replacingOccurrences(of: #"\*{1,3}|_{1,3}"#, with: "", options: .regularExpression)
+        // Strikethrough
+        s = s.replacingOccurrences(of: "~~", with: "")
+        // Inline code
+        s = s.replacingOccurrences(of: "`", with: "")
+        // Links: [text](url) → text
+        s = s.replacingOccurrences(of: #"\[([^\]]*)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
+        // Images: ![alt](url) → alt
+        s = s.replacingOccurrences(of: #"!\[([^\]]*)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
+        // Wiki-links: [[target|alias]] → alias, [[target]] → target
+        s = s.replacingOccurrences(of: #"\[\[(?:[^\]|]*\|)?([^\]]*)\]\]"#, with: "$1", options: .regularExpression)
+        // HTML tags
+        s = s.replacingOccurrences(of: #"<[^>]+>"#, with: "", options: .regularExpression)
+        // Blockquote markers
+        s = s.replacingOccurrences(of: #"^>\s?"#, with: "", options: .regularExpression)
+        // List markers
+        s = s.replacingOccurrences(of: #"^[\-\*\+]\s"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"^\d+\.\s"#, with: "", options: .regularExpression)
+        // Task checkboxes
+        s = s.replacingOccurrences(of: #"\[[ x]\]\s?"#, with: "", options: .regularExpression)
+        return s.trimmingCharacters(in: .whitespaces)
     }
 }
 

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -18,6 +18,18 @@ struct SearchResult {
     let snippet: String
 }
 
+struct MatchExcerpt {
+    let lineNumber: Int        // 1-based
+    let contextLine: String    // the line containing the match
+}
+
+struct SearchFileGroup {
+    let file: IndexedFile
+    let vaultRootURL: URL
+    let matchesFilename: Bool
+    let excerpts: [MatchExcerpt]
+}
+
 struct LinkRecord {
     let id: Int64
     let sourceFileId: Int64
@@ -284,6 +296,125 @@ final class VaultIndex {
                         file: Self.indexedFile(from: row),
                         snippet: row["snippet"] ?? ""
                     )
+                }
+            }
+        } catch {
+            return []
+        }
+    }
+
+    func searchFilesGrouped(query: String) -> [SearchFileGroup] {
+        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
+
+        // Parse quoted phrases and bare terms
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        var ftsTerms: [String] = []
+        var searchTerms: [String] = [] // plain terms for line matching
+
+        let quoteRegex = try! NSRegularExpression(pattern: #""([^"]+)""#)
+        let matches = quoteRegex.matches(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed))
+        var coveredRanges = Set<Range<String.Index>>()
+
+        for match in matches {
+            if let range = Range(match.range(at: 1), in: trimmed) {
+                let phrase = String(trimmed[range])
+                ftsTerms.append("\"\(phrase.replacingOccurrences(of: "\"", with: "\"\""))\"")
+                searchTerms.append(phrase.lowercased())
+                coveredRanges.insert(Range(match.range, in: trimmed)!)
+            }
+        }
+
+        // Bare (unquoted) terms
+        var remaining = trimmed
+        for range in coveredRanges.sorted(by: { $0.lowerBound > $1.lowerBound }) {
+            remaining.removeSubrange(range)
+        }
+        for word in remaining.components(separatedBy: .whitespaces) where !word.isEmpty {
+            let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
+            ftsTerms.append("\"\(escaped)\"*")
+            searchTerms.append(word.lowercased())
+        }
+
+        guard !ftsTerms.isEmpty else { return [] }
+        let ftsQuery = ftsTerms.joined(separator: " ")
+
+        do {
+            return try dbPool.read { db in
+                // FTS5 content search
+                let contentRows = try Row.fetchAll(db, sql: """
+                    SELECT f.*, highlight(files_fts, 1, '<<', '>>') AS highlighted_content
+                    FROM files_fts
+                    JOIN files f ON f.id = files_fts.rowid
+                    WHERE files_fts MATCH ?
+                    ORDER BY bm25(files_fts)
+                    LIMIT 50
+                    """, arguments: [ftsQuery])
+
+                var resultsByFileId: [Int64: SearchFileGroup] = [:]
+                var orderedIds: [Int64] = []
+
+                for row in contentRows {
+                    let file = Self.indexedFile(from: row)
+                    let highlightedContent: String = row["highlighted_content"] ?? ""
+                    let filenameMatches = searchTerms.contains { file.filename.lowercased().contains($0) }
+
+                    // Find matching lines from FTS-highlighted content so stemmed/tokenized
+                    // matches still produce excerpts and scroll targets.
+                    let lines = highlightedContent.components(separatedBy: "\n")
+                    var excerpts: [MatchExcerpt] = []
+                    for (i, line) in lines.enumerated() {
+                        if line.contains("<<") {
+                            excerpts.append(MatchExcerpt(
+                                lineNumber: i + 1,
+                                contextLine: String(
+                                    line
+                                        .replacingOccurrences(of: "<<", with: "")
+                                        .replacingOccurrences(of: ">>", with: "")
+                                        .prefix(200)
+                                )
+                            ))
+                            if excerpts.count >= 5 { break }
+                        }
+                    }
+
+                    resultsByFileId[file.id] = SearchFileGroup(
+                        file: file,
+                        vaultRootURL: rootURL,
+                        matchesFilename: filenameMatches,
+                        excerpts: excerpts
+                    )
+                    orderedIds.append(file.id)
+                }
+
+                // Filename-only matches (not already in content results)
+                let existingIds = Set(orderedIds)
+                for term in searchTerms {
+                    let likePattern = "%\(term)%"
+                    let nameRows = try Row.fetchAll(db, sql: """
+                        SELECT * FROM files
+                        WHERE LOWER(filename) LIKE LOWER(?)
+                        LIMIT 20
+                        """, arguments: [likePattern])
+                    for row in nameRows {
+                        let file = Self.indexedFile(from: row)
+                        guard !existingIds.contains(file.id) else { continue }
+                        if resultsByFileId[file.id] == nil {
+                            resultsByFileId[file.id] = SearchFileGroup(
+                                file: file,
+                                vaultRootURL: self.rootURL,
+                                matchesFilename: true,
+                                excerpts: []
+                            )
+                            orderedIds.append(file.id)
+                        }
+                    }
+                }
+
+                // Sort: filename matches first, then content-only, preserving bm25 order within
+                let groups = orderedIds.compactMap { resultsByFileId[$0] }
+                return groups.sorted { a, b in
+                    if a.matchesFilename != b.matchesFilename { return a.matchesFilename }
+                    return false // preserve bm25 order
                 }
             }
         } catch {

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -247,11 +247,11 @@ enum MarkdownRenderer {
     // MARK: - Wiki-Links [[note]]
 
     private static func processWikiLinks(_ html: String) -> String {
-        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        let (protectedHTML, segments) = protectWikiLinkRegions(in: html)
         guard let regex = try? NSRegularExpression(
             pattern: #"\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]"#
         ) else {
-            return restoreProtectedSegments(in: protectedHTML, segments: segments)
+            return restoreWikiLinkRegions(in: protectedHTML, segments: segments)
         }
         let ns = protectedHTML as NSString
         var result = ""
@@ -289,7 +289,41 @@ enum MarkdownRenderer {
             lastEnd = match.range.location + match.range.length
         }
         result += ns.substring(from: lastEnd)
-        return restoreProtectedSegments(in: result, segments: segments)
+        return restoreWikiLinkRegions(in: result, segments: segments)
+    }
+
+    private static func protectWikiLinkRegions(in html: String) -> (html: String, segments: [String]) {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<(pre|code|a|script|style)\b[^>]*>[\s\S]*?<\/\1>"#,
+            options: [.caseInsensitive]
+        ) else {
+            return (html, [])
+        }
+
+        var protectedHTML = html
+        var segments: [String] = []
+        let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html)).reversed()
+
+        for match in matches {
+            guard let range = Range(match.range, in: protectedHTML) else { continue }
+            let segment = String(protectedHTML[range])
+            let token = "__CLEARLY_PROTECTED_WIKILINK_\(segments.count)__"
+            segments.append(segment)
+            protectedHTML.replaceSubrange(range, with: token)
+        }
+
+        return (protectedHTML, segments)
+    }
+
+    private static func restoreWikiLinkRegions(in html: String, segments: [String]) -> String {
+        var restored = html
+        for (index, segment) in segments.enumerated() {
+            restored = restored.replacingOccurrences(
+                of: "__CLEARLY_PROTECTED_WIKILINK_\(index)__",
+                with: segment
+            )
+        }
+        return restored
     }
 
     // MARK: - Highlight/Mark ==text==

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 3 - Completed
+## Status: Phase 4 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -107,13 +107,30 @@
 ---
 
 ### Phase 4: Global Search
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `MatchExcerpt` and `SearchFileGroup` types to `VaultIndex.swift`
+- [x] Added `searchFilesGrouped(query:)` to `VaultIndex.swift` — FTS5 MATCH with bm25 ranking, filename LIKE matching, line-level excerpt extraction (capped at 5 per file), quoted phrase support
+- [x] Enhanced `QuickSwitcherPanel.swift` with FTS5 content search below fuzzy filename matches
+  - Content matches shown with `text.magnifyingglass` icon + context snippet
+  - Filename matches (fuzzy) shown first, content matches (FTS5) appended after
+  - Deduplication: files already matched by name are skipped in content results
+  - Content results capped at 30, filename results capped at 20
+  - Selecting a content match opens file + scrolls to matching line via `.scrollEditorToLine`
+- [x] Added Cmd+Shift+F shortcut in `Clearly/ClearlyApp.swift` — opens Quick Switcher (same as Cmd+P)
+- [x] Added "Search All Files…" menu item in View menu via `injectGlobalSearchIfNeeded()`
+- [x] Scroll-to-line reuses existing `.scrollEditorToLine` notification (no EditorView changes needed)
+- [x] Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
 
 #### Decisions Made
-- (none yet)
+- Integrated into existing Quick Switcher (Cmd+P) instead of separate sidebar search — simpler, unified search surface
+- Cmd+Shift+F opens the same Quick Switcher as Cmd+P (common "search in project" shortcut)
+- Content search requires 2+ character query (FTS5 is pointless for single chars)
+- Line numbers extracted by scanning file content from FTS `content` column — avoids disk I/O, stays in SQLite read
+- Quoted phrases preserved as FTS5 phrase queries, bare terms get prefix matching (`"term"*`)
+- Scroll-to-line uses 0.15s delay after `openFile` to let document load — matches wiki-link navigation pattern
+- Content match items use `text.magnifyingglass` icon to distinguish from filename matches
 
 #### Blockers
 - (none)
@@ -164,6 +181,13 @@
 
 ## Session Log
 
+### 2026-04-13 — Phase 4 Implementation
+- Added `MatchExcerpt`, `SearchFileGroup` types and `searchFilesGrouped(query:)` to VaultIndex.swift (~100 lines)
+- Enhanced QuickSwitcherPanel.swift: content matches via FTS5 appended below fuzzy filename matches, scroll-to-line on selection
+- Added Cmd+Shift+F shortcut (opens Quick Switcher) and "Search All Files…" View menu item in ClearlyApp.swift
+- Initially built sidebar-based search, then pivoted to Quick Switcher integration (simpler, unified UX)
+- Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
+
 ### 2026-04-13 — Phase 3 Implementation
 - Created WikiLinkCompletionWindow.swift (~280 lines): manager, panel, table, cell views, positioning, completion insertion
 - Added isInsideProtectedRange(at:) to MarkdownSyntaxHighlighter for code-block detection
@@ -194,6 +218,9 @@
 ---
 
 ## Files Changed
+- `Clearly/VaultIndex.swift` — `MatchExcerpt`, `SearchFileGroup` types, `searchFilesGrouped(query:)` method
+- `Clearly/QuickSwitcherPanel.swift` — content match support (FTS5 results, scroll-to-line, snippet display)
+- `Clearly/ClearlyApp.swift` — Cmd+Shift+F shortcut, `injectGlobalSearchIfNeeded()` View menu item
 - `Clearly/WikiLinkCompletionWindow.swift` (new) — WikiLinkCompletionManager, panel, table, cell views
 - `Clearly/MarkdownSyntaxHighlighter.swift` — `isInsideProtectedRange(at:)` public method
 - `Clearly/ClearlyTextView.swift` — `keyDown` override, mouseDown dismiss


### PR DESCRIPTION
## Summary
- Adds full-text content search (FTS5) to the existing Cmd+P Quick Switcher — fuzzy filename matches appear first, content matches below with a two-line layout showing the markdown-stripped matching snippet
- Adds `searchFilesGrouped()` to VaultIndex with quoted phrase support, bm25 ranking, and line-number extraction from the FTS content column
- Selecting a content match opens the file and scrolls to the matching line (editor or preview mode)
- Cmd+Shift+F added as an alias shortcut, plus "Search All Files…" in the View menu

## Test plan
- [ ] Press Cmd+P or Cmd+Shift+F — Quick Switcher opens
- [ ] Type 2+ characters — filename matches show first, content matches below with magnifying glass icon and snippet
- [ ] Select a content match — file opens and scrolls to the matching line
- [ ] Try quoted phrase search like `"exact phrase"` — only matches that exact phrase
- [ ] Verify markdown syntax is stripped from snippet text
- [ ] Escape dismisses as before