### PR TITLE
Add backlinks panel: linked mentions, unlinked mentions with Link button (#136)

### DIFF
--- a/Clearly/BacklinksState.swift
+++ b/Clearly/BacklinksState.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+struct Backlink: Identifiable {
+    let id = UUID()
+    let sourceFilename: String
+    let sourcePath: String
+    let contextLine: String
+    let lineNumber: Int
+    let vaultRootURL: URL
+}
+
+final class BacklinksState: ObservableObject {
+    @Published var isVisible: Bool {
+        didSet { UserDefaults.standard.set(isVisible, forKey: "backlinksVisible") }
+    }
+    @Published var backlinks: [Backlink] = []
+    @Published var unlinkedMentions: [Backlink] = []
+    private(set) var currentFilename: String = ""
+    private(set) var currentLinkTarget: String = ""
+
+    private var updateWork: DispatchWorkItem?
+
+    init() {
+        self.isVisible = UserDefaults.standard.bool(forKey: "backlinksVisible")
+    }
+
+    func toggle() {
+        isVisible.toggle()
+    }
+
+    func update(for fileURL: URL?, using indexes: [VaultIndex]) {
+        updateWork?.cancel()
+
+        guard let fileURL else {
+            DispatchQueue.main.async {
+                self.backlinks = []
+                self.unlinkedMentions = []
+                self.currentFilename = ""
+                self.currentLinkTarget = ""
+            }
+            return
+        }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.performUpdate(for: fileURL, using: indexes)
+        }
+        updateWork = work
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+
+    func removeUnlinkedMention(_ backlink: Backlink) {
+        unlinkedMentions.removeAll { $0.id == backlink.id }
+    }
+
+    private func performUpdate(for fileURL: URL, using indexes: [VaultIndex]) {
+        var linkedResults: [Backlink] = []
+        var unlinkedResults: [Backlink] = []
+        var filename = ""
+        var linkTarget = ""
+
+        for index in indexes {
+            guard let file = index.file(forURL: fileURL) else { continue }
+            filename = file.filename
+            linkTarget = Self.linkTarget(for: file, using: indexes)
+
+            // Linked mentions
+            let links = index.linksTo(fileId: file.id)
+            for link in links {
+                guard let sourcePath = link.sourcePath else { continue }
+                let sourceURL = index.rootURL.appendingPathComponent(sourcePath)
+                let contextLine = readContextLine(from: sourceURL, at: link.lineNumber)
+
+                linkedResults.append(Backlink(
+                    sourceFilename: link.sourceFilename ?? sourcePath,
+                    sourcePath: sourcePath,
+                    contextLine: contextLine,
+                    lineNumber: link.lineNumber ?? 1,
+                    vaultRootURL: index.rootURL
+                ))
+            }
+
+            // Unlinked mentions
+            let mentions = index.unlinkedMentions(for: file.filename, excludingFileId: file.id)
+            for mention in mentions {
+                // Skip if this file already appears in linked results
+                if linkedResults.contains(where: { $0.sourcePath == mention.file.path }) { continue }
+
+                unlinkedResults.append(Backlink(
+                    sourceFilename: mention.file.filename,
+                    sourcePath: mention.file.path,
+                    contextLine: mention.contextLine,
+                    lineNumber: mention.lineNumber,
+                    vaultRootURL: index.rootURL
+                ))
+            }
+        }
+
+        DispatchQueue.main.async {
+            self.currentFilename = filename
+            self.currentLinkTarget = linkTarget
+            self.backlinks = linkedResults
+            self.unlinkedMentions = unlinkedResults
+        }
+    }
+
+    private func readContextLine(from fileURL: URL, at lineNumber: Int?) -> String {
+        guard let lineNumber, lineNumber > 0,
+              let data = try? Data(contentsOf: fileURL),
+              let content = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        let lines = content.components(separatedBy: "\n")
+        guard lineNumber <= lines.count else { return "" }
+        return lines[lineNumber - 1].trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func linkTarget(for file: IndexedFile, using indexes: [VaultIndex]) -> String {
+        var allFiles: [(filename: String, path: String)] = []
+        for index in indexes {
+            for indexedFile in index.allFiles() {
+                allFiles.append((filename: indexedFile.filename, path: indexedFile.path))
+            }
+        }
+
+        let duplicateCount = allFiles.reduce(into: 0) { count, indexedFile in
+            if indexedFile.filename.localizedCaseInsensitiveCompare(file.filename) == .orderedSame {
+                count += 1
+            }
+        }
+
+        if duplicateCount > 1 {
+            let pathWithoutExtension = (file.path as NSString).deletingPathExtension
+            let pathDuplicateCount = allFiles.reduce(into: 0) { count, indexedFile in
+                if ((indexedFile.path as NSString).deletingPathExtension).localizedCaseInsensitiveCompare(pathWithoutExtension) == .orderedSame {
+                    count += 1
+                }
+            }
+            return pathDuplicateCount > 1 ? file.path : pathWithoutExtension
+        }
+
+        return file.filename
+    }
+}

--- a/Clearly/BacklinksView.swift
+++ b/Clearly/BacklinksView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct BacklinksView: View {
+    @ObservedObject var backlinksState: BacklinksState
+    var onNavigate: (Backlink) -> Void
+    var onLink: (Backlink) -> Void
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var totalCount: Int {
+        backlinksState.backlinks.count + backlinksState.unlinkedMentions.count
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(spacing: 6) {
+                Text("BACKLINKS")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(1.5)
+                if totalCount > 0 {
+                    Text("\(totalCount)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(Color.primary.opacity(0.08)))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+
+            Rectangle()
+                .fill(Color.primary.opacity(colorScheme == .dark ? Theme.separatorOpacityDark : Theme.separatorOpacity))
+                .frame(height: 1)
+                .padding(.horizontal, 12)
+
+            if backlinksState.backlinks.isEmpty && backlinksState.unlinkedMentions.isEmpty {
+                Text("No other documents link to this file")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Linked mentions
+                        if !backlinksState.backlinks.isEmpty {
+                            ForEach(backlinksState.backlinks) { backlink in
+                                BacklinkRow(backlink: backlink) {
+                                    onNavigate(backlink)
+                                }
+                            }
+                        }
+
+                        // Unlinked mentions
+                        if !backlinksState.unlinkedMentions.isEmpty {
+                            DisclosureGroup {
+                                ForEach(backlinksState.unlinkedMentions) { backlink in
+                                    BacklinkRow(backlink: backlink, showLinkButton: true, onTap: {
+                                        onNavigate(backlink)
+                                    }, onLink: {
+                                        onLink(backlink)
+                                    })
+                                }
+                            } label: {
+                                Text("Unlinked (\(backlinksState.unlinkedMentions.count))")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.top, 8)
+                        }
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Theme.backgroundColorSwiftUI)
+    }
+}
+
+private struct BacklinkRow: View {
+    let backlink: Backlink
+    var showLinkButton: Bool = false
+    let onTap: () -> Void
+    var onLink: (() -> Void)? = nil
+    @State private var isHovered = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: onTap) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(backlink.sourceFilename)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if !backlink.contextLine.isEmpty {
+                        Text(backlink.contextLine)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+
+            if showLinkButton, let onLink {
+                Button(action: onLink) {
+                    Text("Link")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.primary.opacity(0.06))
+                        )
+                }
+                .buttonStyle(.plain)
+                .opacity(isHovered ? 1 : 0)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered
+                    ? Color.primary.opacity(colorScheme == .dark ? Theme.hoverOpacityDark - 0.03 : 0.05)
+                    : Color.clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { hovering in
+            withAnimation(Theme.Motion.hover) {
+                isHovered = hovering
+            }
+        }
+    }
+}

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -298,6 +298,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
                 NotificationCenter.default.post(name: .init("ClearlyToggleOutline"), object: nil)
                 return nil
             }
+            if chars == "b" && mods == [.command, .shift] {
+                NotificationCenter.default.post(name: .init("ClearlyToggleBacklinks"), object: nil)
+                return nil
+            }
             if chars == "f" && mods == [.command, .shift] {
                 QuickSwitcherManager.shared.toggle()
                 return nil
@@ -467,6 +471,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         outlineItem.keyEquivalentModifierMask = [.command, .shift]
         outlineItem.target = self
 
+        let backlinksItem = NSMenuItem(title: "Toggle Backlinks", action: #selector(toggleBacklinksAction(_:)), keyEquivalent: "b")
+        backlinksItem.keyEquivalentModifierMask = [.command, .shift]
+        backlinksItem.target = self
+
         let editorItem = NSMenuItem(title: "Editor", action: #selector(switchToEditorAction(_:)), keyEquivalent: "1")
         editorItem.keyEquivalentModifierMask = [.command]
         editorItem.target = self
@@ -478,6 +486,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         // Insert right after Toggle Sidebar (index 0)
         var insertIndex = 1
         viewMenu.insertItem(outlineItem, at: insertIndex); insertIndex += 1
+        viewMenu.insertItem(backlinksItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
         viewMenu.insertItem(editorItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(previewItem, at: insertIndex)
@@ -493,6 +502,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func toggleOutlineAction(_ sender: Any?) {
         NotificationCenter.default.post(name: .init("ClearlyToggleOutline"), object: nil)
+    }
+
+    @objc private func toggleBacklinksAction(_ sender: Any?) {
+        NotificationCenter.default.post(name: .init("ClearlyToggleBacklinks"), object: nil)
     }
 
     private func injectSpellingMenuIfNeeded() {

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -32,6 +32,10 @@ struct OutlineStateKey: FocusedValueKey {
     typealias Value = OutlineState
 }
 
+struct BacklinksStateKey: FocusedValueKey {
+    typealias Value = BacklinksState
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -53,6 +57,10 @@ extension FocusedValues {
         get { self[OutlineStateKey.self] }
         set { self[OutlineStateKey.self] = newValue }
     }
+    var backlinksState: BacklinksState? {
+        get { self[BacklinksStateKey.self] }
+        set { self[BacklinksStateKey.self] = newValue }
+    }
 }
 
 struct FocusedValuesModifier: ViewModifier {
@@ -60,6 +68,7 @@ struct FocusedValuesModifier: ViewModifier {
     @Binding var mode: ViewMode
     var findState: FindState
     var outlineState: OutlineState
+    var backlinksState: BacklinksState
 
     func body(content: Content) -> some View {
         content
@@ -68,6 +77,7 @@ struct FocusedValuesModifier: ViewModifier {
             .focusedSceneValue(\.documentFileURL, workspace.currentFileURL)
             .focusedSceneValue(\.findState, findState)
             .focusedSceneValue(\.outlineState, outlineState)
+            .focusedSceneValue(\.backlinksState, backlinksState)
     }
 }
 
@@ -96,6 +106,7 @@ struct ContentView: View {
     @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
     @StateObject private var outlineState = OutlineState()
+    @StateObject private var backlinksState = BacklinksState()
 
     init(workspace: WorkspaceManager) {
         self.workspace = workspace
@@ -213,6 +224,16 @@ struct ContentView: View {
 
                 Button {
                     withAnimation(Theme.Motion.smooth) {
+                        backlinksState.toggle()
+                    }
+                } label: {
+                    Image(systemName: "link")
+                }
+                .buttonStyle(ClearlyToolbarButtonStyle(isActive: backlinksState.isVisible))
+                .help("Backlinks (Shift+Cmd+B)")
+
+                Button {
+                    withAnimation(Theme.Motion.smooth) {
                         outlineState.toggle()
                     }
                 } label: {
@@ -260,6 +281,30 @@ struct ContentView: View {
                     .opacity(mode == .preview ? 1 : 0)
                     .allowsHitTesting(mode == .preview)
             }
+            .layoutPriority(1)
+
+            if backlinksState.isVisible {
+                Rectangle()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(height: 1)
+                BacklinksView(backlinksState: backlinksState) { backlink in
+                    let fileURL = backlink.vaultRootURL.appendingPathComponent(backlink.sourcePath)
+                    if workspace.openFile(at: fileURL) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                            NotificationCenter.default.post(
+                                name: .scrollEditorToLine,
+                                object: nil,
+                                userInfo: ["line": backlink.lineNumber]
+                            )
+                        }
+                    }
+                } onLink: { backlink in
+                    linkBacklink(backlink)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxHeight: 200)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
 
             bottomBar(words: words, chars: chars)
         }
@@ -277,16 +322,18 @@ struct ContentView: View {
                 UserDefaults.standard.set(newMode.rawValue, forKey: "viewMode")
             }
             .animation(Theme.Motion.smooth, value: mode)
-            .modifier(FocusedValuesModifier(workspace: workspace, mode: $mode, findState: findState, outlineState: outlineState))
+            .modifier(FocusedValuesModifier(workspace: workspace, mode: $mode, findState: findState, outlineState: outlineState, backlinksState: backlinksState))
             .onAppear {
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
+                backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
             }
             .onChange(of: workspace.activeDocumentID) { _, newID in
                 positionSyncID = UUID().uuidString
                 findState.isVisible = false
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
+                backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
                 applyPendingWikiNavigationIfNeeded()
                 // New untitled docs always open in edit mode
                 if let newID, let doc = workspace.openDocuments.first(where: { $0.id == newID }), doc.isUntitled {
@@ -311,6 +358,14 @@ struct ContentView: View {
                     outlineState.toggle()
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleBacklinks"))) { _ in
+                withAnimation(Theme.Motion.smooth) {
+                    backlinksState.toggle()
+                }
+            }
+            .onChange(of: workspace.vaultIndexRevision) { _, _ in
+                backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .navigateWikiLink)) { notification in
                 guard let target = notification.userInfo?["target"] as? String else { return }
                 let heading = notification.userInfo?["heading"] as? String
@@ -330,6 +385,18 @@ struct ContentView: View {
             workspace.externalFileDidChange(newText)
         }
         fileWatcher.watch(url, currentText: workspace.currentFileText)
+    }
+
+    private func linkBacklink(_ backlink: Backlink) {
+        let fileURL = backlink.vaultRootURL.appendingPathComponent(backlink.sourcePath)
+        guard workspace.insertWikiLink(
+            in: fileURL,
+            matching: backlinksState.currentFilename,
+            linkTarget: backlinksState.currentLinkTarget,
+            atLine: backlink.lineNumber
+        ) else { return }
+
+        backlinksState.removeUnlinkedMention(backlink)
     }
 
     private func navigateToWikiLink(target: String, heading: String?, destinationMode: ViewMode) {

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -519,6 +519,66 @@ final class VaultIndex {
         }
     }
 
+    // MARK: Read — Unlinked Mentions
+
+    func unlinkedMentions(for filename: String, excludingFileId: Int64) -> [(file: IndexedFile, lineNumber: Int, contextLine: String)] {
+        guard filename.count >= 3 else { return [] }
+
+        do {
+            return try dbPool.read { db in
+                // FTS5 phrase search for the filename
+                let ftsQuery = "\"\(filename.replacingOccurrences(of: "\"", with: "\"\""))\""
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT f.*, files_fts.content AS raw_content
+                    FROM files_fts
+                    JOIN files f ON f.id = files_fts.rowid
+                    WHERE files_fts MATCH ? AND f.id != ?
+                    LIMIT 30
+                    """, arguments: [ftsQuery, excludingFileId])
+
+                let wikiLinkPattern = try NSRegularExpression(pattern: "\\[\\[[^\\]]*\\]\\]")
+                let lowerFilename = filename.lowercased()
+                var results: [(file: IndexedFile, lineNumber: Int, contextLine: String)] = []
+
+                for row in rows {
+                    let file = Self.indexedFile(from: row)
+                    guard let content = row["raw_content"] as? String else { continue }
+
+                    let lines = content.components(separatedBy: "\n")
+                    for (index, line) in lines.enumerated() {
+                        guard line.lowercased().contains(lowerFilename) else { continue }
+
+                        // Check if ALL occurrences of filename on this line are inside [[...]]
+                        let nsLine = line as NSString
+                        let wikiRanges = wikiLinkPattern.matches(in: line, range: NSRange(location: 0, length: nsLine.length)).map(\.range)
+
+                        // Find all occurrences of filename in the line
+                        var searchStart = line.startIndex
+                        var hasUnlinkedOccurrence = false
+                        while let range = line.range(of: filename, options: .caseInsensitive, range: searchStart..<line.endIndex) {
+                            let charRange = NSRange(range, in: line)
+                            let isInsideWikiLink = wikiRanges.contains { $0.location <= charRange.location && NSMaxRange($0) >= NSMaxRange(charRange) }
+                            if !isInsideWikiLink {
+                                hasUnlinkedOccurrence = true
+                                break
+                            }
+                            searchStart = range.upperBound
+                        }
+
+                        if hasUnlinkedOccurrence {
+                            results.append((file: file, lineNumber: index + 1, contextLine: line.trimmingCharacters(in: .whitespaces)))
+                            if results.count >= 20 { return results }
+                            break // One mention per file is enough
+                        }
+                    }
+                }
+                return results
+            }
+        } catch {
+            return []
+        }
+    }
+
     // MARK: Read — Tags
 
     func allTags() -> [(tag: String, count: Int)] {
@@ -552,6 +612,13 @@ final class VaultIndex {
         } catch {
             return []
         }
+    }
+
+    // MARK: Read — File by URL
+
+    func file(forURL url: URL) -> IndexedFile? {
+        let relativePath = Self.relativePath(of: url, from: rootURL)
+        return file(forRelativePath: relativePath)
     }
 
     // MARK: Read — File by path

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -55,6 +55,7 @@ final class WorkspaceManager {
     private static let folderIconsKey = "folderIcons"
     private static let folderColorsKey = "folderColors"
     private static let showHiddenFilesKey = "showHiddenFiles"
+    private static let wikiLinkPattern = try! NSRegularExpression(pattern: "\\[\\[[^\\]]*\\]\\]")
 
     /// Custom folder icons keyed by folder path (URL.path → SF Symbol name).
     var folderIcons: [String: String] = [:]
@@ -302,6 +303,60 @@ final class WorkspaceManager {
         }
     }
 
+    @discardableResult
+    func insertWikiLink(in fileURL: URL, matching searchTerm: String, linkTarget: String, atLine lineNumber: Int) -> Bool {
+        guard !searchTerm.isEmpty, !linkTarget.isEmpty, lineNumber > 0 else { return false }
+
+        let openDocumentIndex = openDocuments.firstIndex(where: { $0.fileURL == fileURL })
+        let content: String
+
+        if let openDocumentIndex {
+            if activeDocumentIndex == openDocumentIndex {
+                snapshotActiveDocument()
+                content = currentFileText
+            } else {
+                content = openDocuments[openDocumentIndex].text
+            }
+        } else {
+            guard let data = try? Data(contentsOf: fileURL),
+                  let diskContent = String(data: data, encoding: .utf8) else {
+                DiagnosticLog.log("Failed to read backlink source: \(fileURL.lastPathComponent)")
+                return false
+            }
+            content = diskContent
+        }
+
+        guard let updatedContent = Self.replacingFirstUnlinkedMention(
+            in: content,
+            matching: searchTerm,
+            linkTarget: linkTarget,
+            atLine: lineNumber
+        ) else {
+            return false
+        }
+
+        do {
+            try updatedContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+            if let openDocumentIndex {
+                openDocuments[openDocumentIndex].text = updatedContent
+                openDocuments[openDocumentIndex].lastSavedText = updatedContent
+
+                if activeDocumentIndex == openDocumentIndex {
+                    currentFileURL = fileURL
+                    currentFileText = updatedContent
+                    lastSavedText = updatedContent
+                    isDirty = false
+                }
+            }
+
+            return true
+        } catch {
+            DiagnosticLog.log("Failed to write backlink source: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     // MARK: - Save
 
     @discardableResult
@@ -396,6 +451,42 @@ final class WorkspaceManager {
         }
         autoSaveWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
+    }
+
+    private static func replacingFirstUnlinkedMention(
+        in content: String,
+        matching searchTerm: String,
+        linkTarget: String,
+        atLine lineNumber: Int
+    ) -> String? {
+        var lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let lineIndex = lineNumber - 1
+        guard lines.indices.contains(lineIndex) else { return nil }
+        guard let range = firstUnlinkedOccurrence(in: lines[lineIndex], matching: searchTerm) else { return nil }
+
+        lines[lineIndex].replaceSubrange(range, with: "[[\(linkTarget)]]")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func firstUnlinkedOccurrence(in line: String, matching term: String) -> Range<String.Index>? {
+        let nsLine = line as NSString
+        let wikiRanges = wikiLinkPattern.matches(in: line, range: NSRange(location: 0, length: nsLine.length)).map(\.range)
+
+        var searchStart = line.startIndex
+        while let range = line.range(of: term, options: .caseInsensitive, range: searchStart..<line.endIndex) {
+            let charRange = NSRange(range, in: line)
+            let isInsideWikiLink = wikiRanges.contains {
+                $0.location <= charRange.location && NSMaxRange($0) >= NSMaxRange(charRange)
+            }
+
+            if !isInsideWikiLink {
+                return range
+            }
+
+            searchStart = range.upperBound
+        }
+
+        return nil
     }
 
     // MARK: - Locations

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 4 - Completed
+## Status: Phase 5 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -138,13 +138,32 @@
 ---
 
 ### Phase 5: Backlinks Panel
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Created `Clearly/BacklinksState.swift` — `ObservableObject` with `@Published` isVisible/backlinks/unlinkedMentions, debounced update on utility queue, reads source files for context lines
+- [x] Created `Clearly/BacklinksView.swift` — SwiftUI view with "BACKLINKS" header + count badge, linked mentions list, collapsible unlinked mentions DisclosureGroup, empty state, hover-highlight rows (matches OutlineView patterns)
+- [x] Added `file(forURL:)` helper to `VaultIndex.swift` — resolves file URL to IndexedFile via relative path
+- [x] Added `unlinkedMentions(for:excludingFileId:)` to `VaultIndex.swift` — FTS5 phrase search → line scan → wiki-link bracket filtering, capped at 20 results, skips filenames < 3 chars
+- [x] Integrated BacklinksView into `ContentView.swift` — panel between editor ZStack and bottomBar, max 200px height, separator line, animated toggle
+- [x] Added toggle button in `bottomBar()` using `link` SF Symbol with `ClearlyToolbarButtonStyle(isActive:)` pattern
+- [x] Added `BacklinksStateKey` FocusedValueKey + extended FocusedValues + updated FocusedValuesModifier
+- [x] Backlinks update on: `.onAppear`, `activeDocumentID` change, `vaultIndexRevision` change
+- [x] Added Cmd+Shift+B shortcut in `ClearlyApp.swift` NSEvent monitor
+- [x] Added "Toggle Backlinks" menu item in View menu via `injectViewCommandsIfNeeded()`
+- [x] Added `toggleBacklinksAction` objc method for menu item
+- [x] Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
 
 #### Decisions Made
-- (none yet)
+- Panel sits below editor, above bottom bar (not an inspector) — it's document-contextual, not a navigation tool
+- Fixed maxHeight 200px with ScrollView — no draggable divider (simpler, adequate for typical 0-10 backlinks)
+- SwiftUI for BacklinksView (read-only list, no AppKit bridging needed)
+- Context lines read from disk at stored lineNumber (the `context` column in links table is unpopulated)
+- Unlinked mentions deduplicated: files already in linked results are skipped
+- One unlinked mention per file (first match) — prevents noisy results
+- "Link" button for unlinked mentions deferred — it's a write operation that deserves focused work
+- Visibility persisted to UserDefaults ("backlinksVisible") matching OutlineState pattern
+- Debounce 0.3s on utility queue (matches OutlineState's 0.4s debounce pattern)
 
 #### Blockers
 - (none)
@@ -180,6 +199,14 @@
 ---
 
 ## Session Log
+
+### 2026-04-13 — Phase 5 Implementation
+- Created BacklinksState.swift (~100 lines): ObservableObject with debounced update, linked + unlinked mention resolution, disk-based context line reading
+- Created BacklinksView.swift (~115 lines): SwiftUI panel with header, linked/unlinked sections, hover-highlighted clickable rows, DisclosureGroup for unlinked
+- Added `file(forURL:)` and `unlinkedMentions(for:excludingFileId:)` to VaultIndex.swift — FTS5 phrase search + wiki-link bracket filtering
+- Integrated into ContentView.swift: state object, layout between editor and bottomBar, toggle button, FocusedValueKey, notification listeners, vaultIndexRevision watcher
+- Added Cmd+Shift+B shortcut and "Toggle Backlinks" View menu item in ClearlyApp.swift
+- Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
 
 ### 2026-04-13 — Phase 4 Implementation
 - Added `MatchExcerpt`, `SearchFileGroup` types and `searchFilesGrouped(query:)` to VaultIndex.swift (~100 lines)
@@ -218,6 +245,11 @@
 ---
 
 ## Files Changed
+- `Clearly/BacklinksState.swift` (new) — ObservableObject with debounced update, linked/unlinked mention queries
+- `Clearly/BacklinksView.swift` (new) — SwiftUI panel with linked/unlinked sections, hover rows, empty state
+- `Clearly/VaultIndex.swift` — `file(forURL:)`, `unlinkedMentions(for:excludingFileId:)` methods
+- `Clearly/ContentView.swift` — BacklinksStateKey, FocusedValues, BacklinksView layout, toggle button, notification listeners
+- `Clearly/ClearlyApp.swift` — Cmd+Shift+B shortcut, "Toggle Backlinks" menu item, toggleBacklinksAction
 - `Clearly/VaultIndex.swift` — `MatchExcerpt`, `SearchFileGroup` types, `searchFilesGrouped(query:)` method
 - `Clearly/QuickSwitcherPanel.swift` — content match support (FTS5 results, scroll-to-line, snippet display)
 - `Clearly/ClearlyApp.swift` — Cmd+Shift+F shortcut, `injectGlobalSearchIfNeeded()` View menu item


### PR DESCRIPTION
## Summary
- Adds a collapsible backlinks panel below the editor showing all files that reference the current document via `[[wiki-links]]` (linked mentions) and plain-text filename matches (unlinked mentions)
- Toggle via Cmd+Shift+B or the link icon in the bottom bar; clicking a backlink navigates to the source file and scrolls to the matching line
- Unlinked mentions show a hover "Link" button that converts the plain-text mention to a `[[wiki-link]]` in the source file, with disambiguation for duplicate filenames
- New VaultIndex APIs: `file(forURL:)` and `unlinkedMentions(for:excludingFileId:)` using FTS5 phrase search with wiki-link bracket filtering

## Test plan
- [ ] Open a file that other files link to via `[[wiki-links]]` — backlinks panel shows linking files with context
- [ ] Click a backlink — source file opens and scrolls to the matching line
- [ ] Toggle panel with Cmd+Shift+B and bottom bar link icon
- [ ] Hover an unlinked mention — "Link" button appears; click it to convert to `[[wiki-link]]`
- [ ] File with no backlinks shows "No other documents link to this file"
- [ ] Panel visibility persists across app restarts