### PR TITLE
Add #tag support: editor highlighting, preview rendering, sidebar browser (#136)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -186,6 +186,14 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
                 self?.updateWindowAppearance()
             }
         }
+
+        // Listen for tag filter requests (from sidebar tag clicks and preview tag links)
+        NotificationCenter.default.addObserver(
+            forName: .init("ClearlyFilterByTag"), object: nil, queue: .main
+        ) { notification in
+            guard let tag = notification.userInfo?["tag"] as? String else { return }
+            QuickSwitcherManager.shared.show(tagFilter: tag)
+        }
     }
 
     private func updateWindowAppearance() {

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -170,6 +170,13 @@ struct ContentView: View {
             onWikiLinkClicked: { target, heading in
                 navigateToWikiLink(target: target, heading: heading, destinationMode: .preview)
             },
+            onTagClicked: { tagName in
+                NotificationCenter.default.post(
+                    name: .init("ClearlyFilterByTag"),
+                    object: nil,
+                    userInfo: ["tag": tagName]
+                )
+            },
             wikiFileNames: allWikiFileNames
         )
     }

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -283,6 +283,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
     /// Root-level sections
     enum Section: String, CaseIterable {
         case locations = "LOCATIONS"
+        case tags = "TAGS"
         case recents = "RECENTS"
     }
 
@@ -294,6 +295,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             case fileNode(FileNode)
             case recentFile(URL)
             case openDocument(OpenDocument)
+            case tagEntry(tag: String, count: Int)
         }
         var kind: Kind
 
@@ -308,6 +310,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             case .fileNode(let node): return node.url
             case .recentFile(let url): return url
             case .openDocument(let doc): return doc.fileURL
+            case .tagEntry: return nil
             }
         }
 
@@ -315,7 +318,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             switch kind {
             case .fileNode(let node): return node.isDirectory
             case .location: return true
-            case .section, .recentFile, .openDocument: return false
+            case .section, .recentFile, .openDocument, .tagEntry: return false
             }
         }
     }
@@ -332,6 +335,10 @@ struct FileExplorerOutlineView: NSViewRepresentable {
         private var nodeItems: [URL: OutlineItem] = [:]
         private var recentItems: [URL: OutlineItem] = [:]
         private var openDocItems: [UUID: OutlineItem] = [:]
+        private var tagItems: [String: OutlineItem] = [:]
+        private var cachedTags: [(tag: String, count: Int)] = []
+        private var lastVaultRevision: Int = 0
+        private var hadTagsBefore = false
 
         // Track state to avoid redundant reloads (updateNSView fires on every SwiftUI render)
         private var lastLocationCount = 0
@@ -396,6 +403,16 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             return item
         }
 
+        func item(forTag tag: String, count: Int) -> OutlineItem {
+            if let existing = tagItems[tag] {
+                existing.kind = .tagEntry(tag: tag, count: count)
+                return existing
+            }
+            let item = OutlineItem(.tagEntry(tag: tag, count: count))
+            tagItems[tag] = item
+            return item
+        }
+
         // MARK: - Folder Color Lookup
 
         /// Finds the folder color for a URL by checking the URL and its parent folders
@@ -427,20 +444,38 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             let openCount = workspace.openDocuments.count
             let treeHash = workspace.locations.reduce(0) { $0 ^ $1.fileTree.hashValue }
             let activeID = workspace.activeDocumentID
+            let vaultRev = workspace.vaultIndexRevision
 
             let changed = locCount != lastLocationCount
                 || recCount != lastRecentCount
                 || openCount != lastOpenDocCount
                 || treeHash != lastLocationTreeHash
                 || activeID != lastActiveDocumentID
+                || vaultRev != lastVaultRevision
+
+            if vaultRev != lastVaultRevision {
+                refreshCachedTags()
+            }
 
             lastLocationCount = locCount
             lastRecentCount = recCount
             lastOpenDocCount = openCount
             lastLocationTreeHash = treeHash
             lastActiveDocumentID = activeID
+            lastVaultRevision = vaultRev
 
             return changed
+        }
+
+        private func refreshCachedTags() {
+            var merged: [String: Int] = [:]
+            for index in workspace.activeVaultIndexes {
+                for entry in index.allTags() {
+                    merged[entry.tag, default: 0] += entry.count
+                }
+            }
+            cachedTags = merged.map { (tag: $0.key, count: $0.value) }
+                .sorted { $0.tag < $1.tag }
         }
 
         // MARK: - Reload
@@ -458,14 +493,20 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 }
             }
             selectCurrentFile()
+            hadTagsBefore = !cachedTags.isEmpty
             _ = dataDidChange()
         }
 
         func reloadIfNeeded() {
             guard dataDidChange() else { return }
             guard let outlineView else { return }
+            let tagsJustAppeared = !hadTagsBefore && !cachedTags.isEmpty
+            hadTagsBefore = !cachedTags.isEmpty
             outlineView.reloadData()
             // autosaveExpandedItems handles restoration automatically
+            if tagsJustAppeared {
+                outlineView.expandItem(item(for: .tags))
+            }
             selectCurrentFile()
             clearRecentsButton?.isHidden = workspace.recentFiles.isEmpty
         }
@@ -506,6 +547,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             case .fileNode(let node): return "node:\(node.url.path)"
             case .recentFile(let url): return "recent:\(url.path)"
             case .openDocument(let doc): return "openDoc:\(doc.id.uuidString)"
+            case .tagEntry(let tag, _): return "tag:\(tag)"
             }
         }
 
@@ -533,6 +575,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 }
                 for loc in workspace.locations {
                     if let node = findNode(in: loc.fileTree) { return item(for: node) }
+                }
+            } else if key.hasPrefix("tag:") {
+                let tag = String(key.dropFirst("tag:".count))
+                if let entry = cachedTags.first(where: { $0.tag == tag }) {
+                    return item(forTag: entry.tag, count: entry.count)
                 }
             }
             return nil
@@ -605,6 +652,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
 
         // MARK: - Data Source
 
+        /// Sections to display — hides TAGS when no tags exist.
+        private var visibleSections: [Section] {
+            Section.allCases.filter { $0 != .tags || !cachedTags.isEmpty }
+        }
+
         /// Open documents shown at the top of RECENTS.
         private var recentSectionOpenDocs: [OpenDocument] {
             workspace.openDocuments
@@ -618,29 +670,34 @@ struct FileExplorerOutlineView: NSViewRepresentable {
 
         func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
             guard let item = item as? OutlineItem else {
-                return Section.allCases.count
+                return visibleSections.count
             }
             switch item.kind {
             case .section(.locations):
                 return workspace.locations.count
+            case .section(.tags):
+                return cachedTags.count
             case .section(.recents):
                 return recentSectionOpenDocs.count + recentHistoryFiles.count
             case .location(let loc):
                 return loc.fileTree.count
             case .fileNode(let node):
                 return node.children?.count ?? 0
-            case .recentFile, .openDocument:
+            case .recentFile, .openDocument, .tagEntry:
                 return 0
             }
         }
 
         func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
             guard let item = item as? OutlineItem else {
-                return self.item(for: Section.allCases[index])
+                return self.item(for: visibleSections[index])
             }
             switch item.kind {
             case .section(.locations):
                 return self.item(for: workspace.locations[index])
+            case .section(.tags):
+                let entry = cachedTags[index]
+                return self.item(forTag: entry.tag, count: entry.count)
             case .section(.recents):
                 let openDocs = recentSectionOpenDocs
                 if index < openDocs.count {
@@ -651,7 +708,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 return self.item(for: loc.fileTree[index])
             case .fileNode(let node):
                 return self.item(for: node.children![index])
-            case .recentFile, .openDocument:
+            case .recentFile, .openDocument, .tagEntry:
                 fatalError("Leaf items have no children")
             }
         }
@@ -660,10 +717,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             guard let item = item as? OutlineItem else { return false }
             switch item.kind {
             case .section(.locations): return true
+            case .section(.tags): return true
             case .section(.recents): return true
             case .location: return true
             case .fileNode(let node): return node.isDirectory
-            case .recentFile, .openDocument: return false
+            case .recentFile, .openDocument, .tagEntry: return false
             }
         }
 
@@ -689,6 +747,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             case .fileNode(let node): return !node.isDirectory
             case .recentFile: return true
             case .openDocument: return true
+            case .tagEntry: return true
             }
         }
 
@@ -860,6 +919,22 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 cell.imageView?.symbolConfiguration = docConfig
                 cell.imageView?.contentTintColor = doc.isUntitled ? .secondaryLabelColor : .tertiaryLabelColor
                 cell.imageView?.isHidden = false
+
+            case .tagEntry(let tag, let count):
+                let tagAttr = NSMutableAttributedString(
+                    string: tag,
+                    attributes: [.font: NSFont.systemFont(ofSize: 12), .foregroundColor: NSColor.labelColor]
+                )
+                tagAttr.append(NSAttributedString(
+                    string: "  \(count)",
+                    attributes: [.font: NSFont.systemFont(ofSize: 9), .foregroundColor: NSColor.tertiaryLabelColor]
+                ))
+                cell.textField?.attributedStringValue = tagAttr
+                let tagConfig = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+                cell.imageView?.image = NSImage(systemSymbolName: "number", accessibilityDescription: "Tag")?.withSymbolConfiguration(tagConfig)
+                cell.imageView?.symbolConfiguration = tagConfig
+                cell.imageView?.contentTintColor = .secondaryLabelColor
+                cell.imageView?.isHidden = false
             }
 
             return cell
@@ -879,6 +954,12 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 workspace.openFile(at: node.url)
             case .recentFile(let url):
                 workspace.openFile(at: url)
+            case .tagEntry(let tag, _):
+                NotificationCenter.default.post(
+                    name: .init("ClearlyFilterByTag"),
+                    object: nil,
+                    userInfo: ["tag": tag]
+                )
             default:
                 break
             }
@@ -1030,6 +1111,12 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     clearItem.target = self
                     menu.addItem(clearItem)
                 }
+
+            case .section(.tags):
+                break
+
+            case .tagEntry:
+                break
             }
         }
 

--- a/Clearly/MarkdownSyntaxHighlighter.swift
+++ b/Clearly/MarkdownSyntaxHighlighter.swift
@@ -85,6 +85,9 @@ final class MarkdownSyntaxHighlighter: NSObject {
         // Wiki-links: [[note]] or [[note|alias]] or [[note#heading]]
         add(#"(\[\[)([^\]\n]+?)(\]\])"#, .wikiLink)
 
+        // Tags: #tag (not headings, not inside code blocks)
+        add(#"(?:^|(?<=\s))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)"#, .tag)
+
         // Table rows: lines with pipes
         add("^(\\|.+\\|)\\s*$", .syntax, options: .anchorsMatchLines)
 
@@ -117,6 +120,7 @@ final class MarkdownSyntaxHighlighter: NSObject {
         case highlight
         case footnote
         case wikiLink
+        case tag
         case htmlTag
     }
 
@@ -333,6 +337,13 @@ final class MarkdownSyntaxHighlighter: NSObject {
                         textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 1))
                         textStorage.addAttribute(.foregroundColor, value: Theme.wikiLinkColor, range: match.range(at: 2))
                         textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 3))
+                    }
+
+                case .tag:
+                    let hashRange = NSRange(location: match.range.location, length: 1)
+                    textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: hashRange)
+                    if match.numberOfRanges >= 2 {
+                        textStorage.addAttribute(.foregroundColor, value: Theme.tagColor, range: match.range(at: 1))
                     }
 
                 case .htmlTag:
@@ -628,6 +639,13 @@ final class MarkdownSyntaxHighlighter: NSObject {
                         textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 1))
                         textStorage.addAttribute(.foregroundColor, value: Theme.wikiLinkColor, range: match.range(at: 2))
                         textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 3))
+                    }
+
+                case .tag:
+                    let hashRange = NSRange(location: match.range.location, length: 1)
+                    textStorage.addAttribute(.foregroundColor, value: Theme.syntaxColor, range: hashRange)
+                    if match.numberOfRanges >= 2 {
+                        textStorage.addAttribute(.foregroundColor, value: Theme.tagColor, range: match.range(at: 1))
                     }
 
                 case .htmlTag:

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -13,6 +13,7 @@ struct PreviewView: NSViewRepresentable {
     var onTaskToggle: ((Int, Bool) -> Void)?
     var onClickToSource: ((Int) -> Void)?
     var onWikiLinkClicked: ((String, String?) -> Void)?
+    var onTagClicked: ((String) -> Void)?
     var wikiFileNames: Set<String>?
     @Environment(\.colorScheme) private var colorScheme
 
@@ -48,6 +49,7 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.onTaskToggle = onTaskToggle
         context.coordinator.onClickToSource = onClickToSource
         context.coordinator.onWikiLinkClicked = onWikiLinkClicked
+        context.coordinator.onTagClicked = onTagClicked
         let coordinator = context.coordinator
         findState?.previewNavigateToNext = { [weak coordinator] in
             coordinator?.navigateToNextMatch()
@@ -119,7 +121,7 @@ struct PreviewView: NSViewRepresentable {
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
         context.coordinator.isLoadingContent = true
-        let rawBody = MarkdownRenderer.renderHTML(markdown)
+        let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
         let wikiFilesJSON: String = {
             guard let names = wikiFileNames, !names.isEmpty else { return "[]" }
@@ -326,6 +328,7 @@ struct PreviewView: NSViewRepresentable {
         var onTaskToggle: ((Int, Bool) -> Void)?
         var onClickToSource: ((Int) -> Void)?
         var onWikiLinkClicked: ((String, String?) -> Void)?
+        var onTagClicked: ((String) -> Void)?
         var skipNextReload = false
         var isLoadingContent = false
         var pendingScrollLine: Int?
@@ -586,6 +589,14 @@ struct PreviewView: NSViewRepresentable {
                 let heading = parts.count > 1 ? (parts[1].removingPercentEncoding ?? parts[1]) : nil
                 DispatchQueue.main.async { [weak self] in
                     self?.onWikiLinkClicked?(target, heading)
+                }
+                return
+            }
+            if href.hasPrefix("clearly://tag/") {
+                let tagName = String(href.dropFirst("clearly://tag/".count))
+                    .removingPercentEncoding ?? String(href.dropFirst("clearly://tag/".count))
+                DispatchQueue.main.async { [weak self] in
+                    self?.onTagClicked?(tagName)
                 }
                 return
             }

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -123,6 +123,11 @@ struct QuickSwitcherItem {
 final class QuickSwitcherManager: NSObject {
     static let shared = QuickSwitcherManager()
 
+    private enum TagFilterMode {
+        case contains
+        case exact(String)
+    }
+
     private var panel: NSPanel?
     private var searchField: NSTextField?
     private var tableView: NSTableView?
@@ -131,6 +136,7 @@ final class QuickSwitcherManager: NSObject {
 
     private var items: [QuickSwitcherItem] = []
     private var allFiles: [(filename: String, path: String, url: URL)] = []
+    private var tagFilterMode: TagFilterMode = .contains
 
     var isVisible: Bool { panel?.isVisible ?? false }
 
@@ -142,13 +148,22 @@ final class QuickSwitcherManager: NSObject {
         }
     }
 
-    func show() {
+    func show(withQuery query: String = "") {
+        show(withQuery: query, tagFilterMode: .contains)
+    }
+
+    func show(tagFilter tag: String) {
+        show(withQuery: "#\(tag)", tagFilterMode: .exact(tag))
+    }
+
+    private func show(withQuery query: String, tagFilterMode: TagFilterMode) {
         if panel == nil {
             createPanel()
         }
+        self.tagFilterMode = tagFilterMode
         refreshFileList()
-        searchField?.stringValue = ""
-        updateResults(query: "")
+        searchField?.stringValue = query
+        updateResults(query: query)
         positionPanel()
         panel?.makeKeyAndOrderFront(nil)
         searchField?.becomeFirstResponder()
@@ -227,6 +242,7 @@ final class QuickSwitcherManager: NSObject {
         tableView.selectionHighlightStyle = .regular
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.action = #selector(tableClicked)
         tableView.doubleAction = #selector(tableDoubleClicked)
         tableView.target = self
         self.tableView = tableView
@@ -322,6 +338,43 @@ final class QuickSwitcherManager: NSObject {
                     isCreateNew: false
                 )
             }
+        } else if query.hasPrefix("#") && query.count >= 2 {
+            // Tag filter: show files matching the tag
+            let tagQuery = String(query.dropFirst()).lowercased()
+            var tagResults: [QuickSwitcherItem] = []
+            for index in WorkspaceManager.shared.activeVaultIndexes {
+                // Find tags that match the query
+                let matchingTags = index.allTags().filter { entry in
+                    switch tagFilterMode {
+                    case .contains:
+                        return entry.tag.lowercased().contains(tagQuery)
+                    case .exact(let selectedTag):
+                        if selectedTag.lowercased() == tagQuery {
+                            return entry.tag.compare(selectedTag, options: [.caseInsensitive]) == .orderedSame
+                        }
+                        return entry.tag.lowercased().contains(tagQuery)
+                    }
+                }
+                var seenURLs = Set<URL>()
+                for tagEntry in matchingTags {
+                    for file in index.filesForTag(tag: tagEntry.tag) {
+                        let fileURL = index.rootURL.appendingPathComponent(file.path)
+                        guard !seenURLs.contains(fileURL) else { continue }
+                        seenURLs.insert(fileURL)
+                        tagResults.append(QuickSwitcherItem(
+                            filename: file.filename,
+                            relativePath: file.path,
+                            fullURL: fileURL,
+                            score: 100,
+                            matchedRanges: [],
+                            isCreateNew: false,
+                            contextSnippet: "#\(tagEntry.tag)"
+                        ))
+                    }
+                }
+            }
+            tagResults.sort { $0.filename.lowercased() < $1.filename.lowercased() }
+            items = tagResults
         } else {
             // Fuzzy match on filenames
             var nameMatches = allFiles.compactMap { file -> QuickSwitcherItem? in
@@ -445,6 +498,11 @@ final class QuickSwitcherManager: NSObject {
         }
 
         dismiss()
+    }
+
+    @objc private func tableClicked() {
+        guard let tableView, tableView.clickedRow >= 0 else { return }
+        openSelectedItem()
     }
 
     @objc private func tableDoubleClicked() {

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -129,6 +129,12 @@ enum Theme {
             : NSColor(red: 0.7, green: 0.35, blue: 0.25, alpha: 1)
     }
 
+    static let tagColor = NSColor(name: "themeTag") { appearance in
+        appearance.isDark
+            ? NSColor(red: 0.55, green: 0.70, blue: 0.85, alpha: 1)
+            : NSColor(red: 0.25, green: 0.45, blue: 0.70, alpha: 1)
+    }
+
     static let htmlTagColor = NSColor(name: "themeHTMLTag") { appearance in
         appearance.isDark
             ? NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -2,7 +2,7 @@ import Foundation
 import cmark
 
 enum MarkdownRenderer {
-    static func renderHTML(_ markdown: String) -> String {
+    static func renderHTML(_ markdown: String, appLinkURLs: Bool = false) -> String {
         guard !markdown.isEmpty else { return "" }
 
         let frontmatter = FrontmatterSupport.extract(from: markdown)
@@ -27,7 +27,8 @@ enum MarkdownRenderer {
         html = processHighlightMarks(html)
         html = processSuperSub(html)
         html = processEmoji(html)
-        html = processWikiLinks(html)
+        html = processWikiLinks(html, appLinkURLs: appLinkURLs)
+        html = processTags(html, appLinkURLs: appLinkURLs)
         html = processCallouts(html)
         html = processTOC(html)
         html = processCaptions(html)
@@ -246,7 +247,7 @@ enum MarkdownRenderer {
 
     // MARK: - Wiki-Links [[note]]
 
-    private static func processWikiLinks(_ html: String) -> String {
+    private static func processWikiLinks(_ html: String, appLinkURLs: Bool) -> String {
         let (protectedHTML, segments) = protectWikiLinkRegions(in: html)
         guard let regex = try? NSRegularExpression(
             pattern: #"\[\[([^\]\|#\^]+?)(?:#([^\]\|]+?))?(?:\|([^\]]+?))?\]\]"#
@@ -278,14 +279,17 @@ enum MarkdownRenderer {
                 displayText = target
             }
 
-            let encodedTarget = target.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? target
-            var href = "clearly://wiki/\(encodedTarget)"
-            if let heading {
-                let encodedHeading = heading.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? heading
-                href += "#\(encodedHeading)"
+            if appLinkURLs {
+                let encodedTarget = target.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? target
+                var href = "clearly://wiki/\(encodedTarget)"
+                if let heading {
+                    let encodedHeading = heading.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? heading
+                    href += "#\(encodedHeading)"
+                }
+                result += "<a href=\"\(href)\" class=\"wiki-link\">\(escapeHTML(displayText))</a>"
+            } else {
+                result += "<span class=\"wiki-link\">\(escapeHTML(displayText))</span>"
             }
-
-            result += "<a href=\"\(href)\" class=\"wiki-link\">\(escapeHTML(displayText))</a>"
             lastEnd = match.range.location + match.range.length
         }
         result += ns.substring(from: lastEnd)
@@ -320,6 +324,65 @@ enum MarkdownRenderer {
         for (index, segment) in segments.enumerated() {
             restored = restored.replacingOccurrences(
                 of: "__CLEARLY_PROTECTED_WIKILINK_\(index)__",
+                with: segment
+            )
+        }
+        return restored
+    }
+
+    // MARK: - Tags #tag
+
+    private static func processTags(_ html: String, appLinkURLs: Bool) -> String {
+        let (protectedHTML, segments) = protectTagRegions(in: html)
+        guard let regex = try? NSRegularExpression(
+            pattern: #"(?:^|(?<=[\s>]))#([\p{L}\p{N}_\-/]*[\p{L}_\-/][\p{L}\p{N}_\-/]*)"#,
+            options: [.anchorsMatchLines]
+        ) else {
+            return restoreTagRegions(in: protectedHTML, segments: segments)
+        }
+        let ns = protectedHTML as NSString
+        var result = ""
+        var lastEnd = 0
+        for match in regex.matches(in: protectedHTML, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            let tagName = ns.substring(with: match.range(at: 1))
+            if appLinkURLs {
+                let encodedTag = tagName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? tagName
+                result += "<a href=\"clearly://tag/\(encodedTag)\" class=\"md-tag\">#\(escapeHTML(tagName))</a>"
+            } else {
+                result += "<span class=\"md-tag\">#\(escapeHTML(tagName))</span>"
+            }
+            lastEnd = match.range.location + match.range.length
+        }
+        result += ns.substring(from: lastEnd)
+        return restoreTagRegions(in: result, segments: segments)
+    }
+
+    private static func protectTagRegions(in html: String) -> (html: String, segments: [String]) {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<(pre|code|a|script|style|span)\b[^>]*>[\s\S]*?<\/\1>"#,
+            options: [.caseInsensitive]
+        ) else {
+            return (html, [])
+        }
+        var protectedHTML = html
+        var segments: [String] = []
+        let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html)).reversed()
+        for match in matches {
+            guard let range = Range(match.range, in: protectedHTML) else { continue }
+            let segment = String(protectedHTML[range])
+            let token = "__CLEARLY_PROTECTED_TAG_\(segments.count)__"
+            segments.append(segment)
+            protectedHTML.replaceSubrange(range, with: token)
+        }
+        return (protectedHTML, segments)
+    }
+
+    private static func restoreTagRegions(in html: String, segments: [String]) -> String {
+        var restored = html
+        for (index, segment) in segments.enumerated() {
+            restored = restored.replacingOccurrences(
+                of: "__CLEARLY_PROTECTED_TAG_\(index)__",
                 with: segment
             )
         }

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -3,8 +3,9 @@ import Foundation
 enum PreviewCSS {
     static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
     let exportOverrides = forExport ? """
-    a.wiki-link { color: #34855A !important; border-bottom: none !important; }
-    a.wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
+    .wiki-link { color: #34855A !important; border-bottom: none !important; }
+    .wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
+    .md-tag { color: #3A6EA5 !important; background: rgba(58, 110, 165, 0.06) !important; }
     .code-copy-btn { display: none !important; }
     .table-copy-btn { display: none !important; }
     .sort-indicator { display: none !important; }
@@ -200,22 +201,33 @@ enum PreviewCSS {
     a:hover {
         text-decoration: underline;
     }
-    a.wiki-link {
+    .wiki-link {
         color: #34855A;
         text-decoration: none;
         border-bottom: 1px solid rgba(52, 133, 90, 0.3);
     }
-    a.wiki-link:hover {
+    .wiki-link:hover {
         text-decoration: none;
         border-bottom-color: #34855A;
     }
-    a.wiki-link-broken {
+    .wiki-link-broken {
         color: #B35C3A;
         border-bottom: 1px dashed rgba(179, 92, 58, 0.4);
     }
-    a.wiki-link-broken:hover {
+    .wiki-link-broken:hover {
         text-decoration: none;
         border-bottom-color: #B35C3A;
+    }
+    .md-tag {
+        color: #3A6EA5;
+        text-decoration: none;
+        background: rgba(58, 110, 165, 0.08);
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 0.9em;
+    }
+    .md-tag:hover {
+        background: rgba(58, 110, 165, 0.15);
     }
 
     code {
@@ -701,10 +713,12 @@ enum PreviewCSS {
             background-color: #323236;
         }
         a { color: #0A84FF; }
-        a.wiki-link { color: #5ABF80; border-bottom-color: rgba(90, 191, 128, 0.3); }
-        a.wiki-link:hover { border-bottom-color: #5ABF80; }
-        a.wiki-link-broken { color: #D97A57; border-bottom-color: rgba(217, 122, 87, 0.4); }
-        a.wiki-link-broken:hover { border-bottom-color: #D97A57; }
+        .wiki-link { color: #5ABF80; border-bottom-color: rgba(90, 191, 128, 0.3); }
+        .wiki-link:hover { border-bottom-color: #5ABF80; }
+        .wiki-link-broken { color: #D97A57; border-bottom-color: rgba(217, 122, 87, 0.4); }
+        .wiki-link-broken:hover { border-bottom-color: #D97A57; }
+        .md-tag { color: #7AB0D9; background: rgba(122, 176, 217, 0.12); }
+        .md-tag:hover { background: rgba(122, 176, 217, 0.2); }
         h6 { color: rgba(245, 245, 247, 0.55); }
         code {
             background-color: rgba(255, 255, 255, 0.06);
@@ -827,8 +841,9 @@ enum PreviewCSS {
     }
 
     @media print {
-        a.wiki-link { color: #34855A !important; border-bottom: none !important; }
-        a.wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
+        .wiki-link { color: #34855A !important; border-bottom: none !important; }
+        .wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
+        .md-tag { color: #3A6EA5 !important; background: rgba(58, 110, 165, 0.06) !important; }
         .code-filename {
             background: #EDEDF0 !important;
             color: #86868B !important;

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 5 - Completed
+## Status: Phase 6 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -171,13 +171,43 @@
 ---
 
 ### Phase 6: Tags
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `tagColor` (soft blue) to `Theme.swift` — distinct from wiki-link green and regular link blue
+- [x] Added `.tag` case to `HighlightStyle` enum in `MarkdownSyntaxHighlighter.swift`
+- [x] Added tag regex pattern `(?:^|(?<=\s))#(tag_name)` to patterns array (after wiki-links, before tables)
+- [x] Added `.tag` switch cases to both `highlightAll` and `highlightAround` methods — `#` in syntax color, name in tag color
+- [x] Added `processTags()` to `MarkdownRenderer.swift` pipeline (after processWikiLinks, before processCallouts)
+  - Uses `clearly://tag/` URL scheme, protects `<pre>`, `<code>`, `<a>`, `<script>`, `<style>`, `<span>` blocks
+  - Renders as `<a href="clearly://tag/name" class="md-tag">#name</a>`
+- [x] Added `.md-tag` CSS to `PreviewCSS.swift` in all 4 contexts (light, dark, print, export)
+  - Pill-like appearance: subtle background, rounded corners, blue color
+- [x] Added `onTagClicked` callback and `clearly://tag/` URL handling to `PreviewView.swift`
+- [x] Wired `onTagClicked` in `ContentView.swift` — posts `ClearlyFilterByTag` notification
+- [x] Added `tags` section to `FileExplorerView.swift` sidebar (between LOCATIONS and RECENTS)
+  - New `Section.tags` enum case, `OutlineItem.Kind.tagEntry(tag:count:)`
+  - Tag items cache, `refreshCachedTags()` aggregates across all vault indexes
+  - Data source: numberOfChildren, child, isExpandable, shouldSelect all handle tags
+  - Delegate: viewFor renders `#tagname count` with `number` SF Symbol
+  - Selection opens Quick Switcher with `#tag` query
+  - Autosave persistence for tag expansion state
+  - Context menu: no actions for tags (intentional for v1)
+- [x] Added `show(withQuery:)` to `QuickSwitcherManager` for pre-filled search
+- [x] Added tag-based filtering in Quick Switcher: `#` prefix triggers `VaultIndex.filesForTag()` lookup
+- [x] Added `ClearlyFilterByTag` notification observer in `ClearlyApp.swift`
+- [x] Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
 
 #### Decisions Made
-- (none yet)
+- Tag color is soft blue (distinct from green wiki-links) — visually signals "category/label"
+- CSS class is `.md-tag` (not `.tag`) to avoid collision with generic HTML tag names
+- `clearly://tag/` URL scheme matches `clearly://wiki/` pattern — reuses existing `linkClicked` handler
+- Tags section in sidebar between LOCATIONS and RECENTS — knowledge-layer grouping
+- Tag click opens Quick Switcher pre-filled with `#tag` (not inline file tree filtering) — simpler, reuses existing infrastructure
+- No keyboard shortcut for tag toggle — tags are always visible in sidebar; toggle via sidebar visibility (Cmd+Shift+L)
+- No context menu for tags in v1 — no clear actions needed yet
+- Tag protection in MarkdownRenderer includes `<span>` to avoid re-processing already-rendered tags
+- Vault revision change triggers tag cache refresh in sidebar coordinator
 
 #### Blockers
 - (none)
@@ -199,6 +229,18 @@
 ---
 
 ## Session Log
+
+### 2026-04-13 — Phase 6 Implementation
+- Added `tagColor` to Theme.swift (soft blue, light/dark adaptive)
+- Added `.tag` pattern + enum case + 2 switch cases to MarkdownSyntaxHighlighter.swift
+- Added `processTags()` with protect/restore helpers to MarkdownRenderer.swift (~50 lines)
+- Added `.md-tag` CSS in all 4 contexts (light, dark, print, export) in PreviewCSS.swift
+- Added `onTagClicked` callback + `clearly://tag/` handling in PreviewView.swift
+- Wired `onTagClicked` from ContentView.swift via `ClearlyFilterByTag` notification
+- Added TAGS section to FileExplorerView.swift sidebar: Section.tags, OutlineItem.Kind.tagEntry, full data source/delegate, vault revision tracking, cached tags refresh
+- Added `show(withQuery:)` to QuickSwitcherManager + tag-based filtering when query starts with `#`
+- Added `ClearlyFilterByTag` notification observer in ClearlyApp.swift → opens Quick Switcher with `#tag`
+- Build verified: `xcodebuild -scheme Clearly -configuration Debug build` succeeded
 
 ### 2026-04-13 — Phase 5 Implementation
 - Created BacklinksState.swift (~100 lines): ObservableObject with debounced update, linked + unlinked mention resolution, disk-based context line reading
@@ -245,6 +287,15 @@
 ---
 
 ## Files Changed
+- `Clearly/Theme.swift` — `tagColor` (soft blue, light/dark)
+- `Clearly/MarkdownSyntaxHighlighter.swift` — `.tag` enum case, regex pattern, 2 switch cases (highlightAll + highlightAround)
+- `Shared/MarkdownRenderer.swift` — `processTags()`, `protectTagRegions()`, `restoreTagRegions()` in pipeline
+- `Shared/PreviewCSS.swift` — `.md-tag` styles in light, dark, print, export contexts
+- `Clearly/PreviewView.swift` — `onTagClicked` callback, `clearly://tag/` URL handling in `handleLinkClick`
+- `Clearly/ContentView.swift` — `onTagClicked` wired to `ClearlyFilterByTag` notification
+- `Clearly/FileExplorerView.swift` — `tags` Section, `tagEntry` OutlineItem.Kind, tag cache, data source/delegate methods, context menu, persistence
+- `Clearly/QuickSwitcherPanel.swift` — `show(withQuery:)`, tag-based filtering when query starts with `#`
+- `Clearly/ClearlyApp.swift` — `ClearlyFilterByTag` notification observer → Quick Switcher
 - `Clearly/BacklinksState.swift` (new) — ObservableObject with debounced update, linked/unlinked mention queries
 - `Clearly/BacklinksView.swift` (new) — SwiftUI panel with linked/unlinked sections, hover rows, empty state
 - `Clearly/VaultIndex.swift` — `file(forURL:)`, `unlinkedMentions(for:excludingFileId:)` methods


### PR DESCRIPTION
## Summary
- Adds `#tag` syntax highlighting in the editor (blue color, distinct from green wiki-links)
- Renders tags as clickable pill-shaped links in preview with light/dark/print/export CSS
- Adds TAGS section to sidebar (auto-hides when no tags, auto-expands on first appearance) showing all indexed tags with file counts
- Clicking a tag anywhere (sidebar, preview) opens Quick Switcher filtered to files with that tag via `VaultIndex.filesForTag()`
- Single-click now opens items in the Quick Switcher (was double-click only)

## Test plan
- [ ] Type `#tag`, `#project/sub`, `#year-2024` in editor — verify blue highlighting
- [ ] Verify `#123`, `# Heading`, tags in code blocks are NOT highlighted
- [ ] Switch to preview — tags render as blue pills, clickable
- [ ] Click tag in preview or sidebar — Quick Switcher opens filtered to matching files
- [ ] Verify TAGS section hidden when no tags exist, appears and expands when first tag is indexed
- [ ] Test dark mode and PDF export styling