### PR TITLE
Add MCP server: companion CLI exposing vault index to AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,15 @@ Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen
 
 - Deployment target: macOS 14.0
 - Swift 5.9, Xcode 16+
-- Dependencies: `cmark-gfm` (GFM markdown → HTML), `Sparkle` (auto-updates, direct distribution only) via Swift Package Manager
+- Dependencies: `cmark-gfm` (GFM markdown → HTML), `Sparkle` (auto-updates, direct distribution only), `GRDB` (SQLite + FTS5), `MCP` (Model Context Protocol SDK) via Swift Package Manager
 
 ## Architecture
 
-**Two targets** defined in `project.yml`:
+**Three targets** defined in `project.yml`:
 
 1. **Clearly** (main app) — document-based SwiftUI app
 2. **ClearlyQuickLook** (app extension) — QLPreviewProvider for Finder previews
+3. **ClearlyMCP** (command-line tool) — MCP server exposing vault index to AI agents. Shares `VaultIndex.swift`, `FileParser.swift`, `FileNode.swift`, `DiagnosticLog.swift` with the main app, plus `FrontmatterSupport.swift` from `Shared/`. Uses `init(locationURL:bundleIdentifier:)` to open the same SQLite index the sandboxed app creates. Exposes 3 tools: `search_notes` (FTS5 ranked search), `get_backlinks` (linked + unlinked mentions), `get_tags` (tag aggregation). Read-only index access via WAL mode.
 
 **Shared code** lives in `Shared/` and is compiled into both targets:
 - `MarkdownRenderer.swift` — wraps `cmark_gfm_markdown_to_html()` for GFM rendering. Post-processing pipeline (in order): math (`$...$` → KaTeX spans), highlight marks (`==text==` → `<mark>`), superscript/subscript, emoji shortcodes, callouts/admonitions (`[!TYPE]` blockquotes), TOC generation, table captions, code filename headers. All post-processing that touches inline syntax must use `protectCodeRegions()`/`restoreProtectedSegments()` to avoid transforming content inside `<pre>`/`<code>` tags.

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -196,6 +196,26 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         }
     }
 
+    private func installMCPHelperIfNeeded() {
+        #if canImport(Sparkle)
+        guard let source = Bundle.main.url(forResource: "ClearlyMCP", withExtension: nil, subdirectory: "Helpers") else { return }
+        let installDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Clearly")
+        let installed = installDir.appendingPathComponent("ClearlyMCP")
+
+        try? FileManager.default.createDirectory(at: installDir, withIntermediateDirectories: true)
+
+        let shouldCopy = !FileManager.default.fileExists(atPath: installed.path)
+            || (try? Data(contentsOf: source)) != (try? Data(contentsOf: installed))
+
+        if shouldCopy {
+            try? FileManager.default.removeItem(at: installed)
+            try? FileManager.default.copyItem(at: source, to: installed)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installed.path)
+        }
+        #endif
+    }
+
     private func updateWindowAppearance() {
         guard let window = mainWindow else { return }
         let pref = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
@@ -224,6 +244,8 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        installMCPHelperIfNeeded()
+
         // A normal Launch Services open activates the app and opens a document window.
         // Login-item launch stays inactive with no document windows, so collapse to
         // menubar-only only in that state instead of guessing from parent PID.

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -81,6 +81,10 @@ struct SettingsView: View {
         return appSupport.appendingPathComponent("Clearly/ClearlyMCP").path
     }
 
+    private var mcpBundleIdentifier: String {
+        Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
+    }
+
     private var mcpBinaryInstalled: Bool {
         FileManager.default.isExecutableFile(atPath: mcpBinaryPath)
     }
@@ -122,7 +126,8 @@ struct SettingsView: View {
         {
           "mcpServers": {
             "clearly": {
-              "command": "\(mcpBinaryPath)"
+              "command": "\(mcpBinaryPath)",
+              "args": ["--bundle-id", "\(mcpBundleIdentifier)"]
             }
           }
         }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -20,12 +20,18 @@ struct SettingsView: View {
                     Label("General", systemImage: "gearshape")
                 }
 
+            mcpSettings
+                .tabItem {
+                    Label("MCP", systemImage: "network")
+                }
+
             aboutView
                 .tabItem {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 420, height: 360)
+        .frame(width: 420)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -65,6 +71,71 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
     }
+
+    // MARK: - MCP Settings
+
+    @State private var mcpCopied = false
+
+    private var mcpBinaryPath: String {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("Clearly/ClearlyMCP").path
+    }
+
+    private var mcpBinaryInstalled: Bool {
+        FileManager.default.isExecutableFile(atPath: mcpBinaryPath)
+    }
+
+    private var mcpSettings: some View {
+        Form {
+            // Status
+            HStack {
+                Text("MCP Helper")
+                Spacer()
+                if mcpBinaryInstalled {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Installed")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                    Text("Not Installed")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Copy config
+            Button(mcpCopied ? "Copied!" : "Copy MCP Config") {
+                copyMCPConfig()
+            }
+
+            // Help text
+            Text("The MCP server lets AI agents search your notes, explore backlinks, and browse tags. It automatically discovers all your vaults. Copy the config and add it to any MCP-compatible app (Claude Desktop, Cursor, Windsurf, etc.).")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .formStyle(.grouped)
+    }
+
+    private func copyMCPConfig() {
+        let config = """
+        {
+          "mcpServers": {
+            "clearly": {
+              "command": "\(mcpBinaryPath)"
+            }
+          }
+        }
+        """
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(config, forType: .string)
+        mcpCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            mcpCopied = false
+        }
+    }
+
+    // MARK: - About
 
     private var aboutView: some View {
         VStack(spacing: 16) {

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -44,7 +44,7 @@ struct LinkRecord {
 
 // MARK: - VaultIndex
 
-final class VaultIndex {
+final class VaultIndex: @unchecked Sendable {
 
     private let dbPool: DatabasePool
     let rootURL: URL
@@ -55,6 +55,21 @@ final class VaultIndex {
         self.rootURL = locationURL
 
         let indexDir = Self.indexDirectory()
+        try FileManager.default.createDirectory(at: indexDir, withIntermediateDirectories: true)
+
+        let hash = Self.pathHash(locationURL.standardizedFileURL.path)
+        let dbPath = indexDir.appendingPathComponent("\(hash).sqlite").path
+
+        dbPool = try DatabasePool(path: dbPath)
+
+        try migrate()
+    }
+
+    /// Init with explicit bundle identifier — used by ClearlyMCP to open the main app's index
+    init(locationURL: URL, bundleIdentifier: String) throws {
+        self.rootURL = locationURL
+
+        let indexDir = Self.indexDirectory(bundleIdentifier: bundleIdentifier)
         try FileManager.default.createDirectory(at: indexDir, withIntermediateDirectories: true)
 
         let hash = Self.pathHash(locationURL.standardizedFileURL.path)
@@ -647,6 +662,20 @@ final class VaultIndex {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let appName = Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
         return dir.appendingPathComponent("\(appName)/indexes")
+    }
+
+    /// Index directory for a specific bundle identifier — resolves sandbox container path for non-sandboxed callers (ClearlyMCP CLI)
+    private static func indexDirectory(bundleIdentifier: String) -> URL {
+        // Try sandbox container path first (where the sandboxed app stores its index)
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let containerPath = home
+            .appendingPathComponent("Library/Containers/\(bundleIdentifier)/Data/Library/Application Support/\(bundleIdentifier)/indexes")
+        if FileManager.default.fileExists(atPath: containerPath.path) {
+            return containerPath
+        }
+        // Fall back to standard Application Support (non-sandboxed or not yet created)
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("\(bundleIdentifier)/indexes")
     }
 
     private static func pathHash(_ path: String) -> String {

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -27,6 +27,7 @@ struct SearchFileGroup {
     let file: IndexedFile
     let vaultRootURL: URL
     let matchesFilename: Bool
+    let relevanceRank: Double
     let excerpts: [MatchExcerpt]
 }
 
@@ -357,7 +358,7 @@ final class VaultIndex: @unchecked Sendable {
             return try dbPool.read { db in
                 // FTS5 content search
                 let contentRows = try Row.fetchAll(db, sql: """
-                    SELECT f.*, highlight(files_fts, 1, '<<', '>>') AS highlighted_content
+                    SELECT f.*, highlight(files_fts, 1, '<<', '>>') AS highlighted_content, bm25(files_fts) AS rank
                     FROM files_fts
                     JOIN files f ON f.id = files_fts.rowid
                     WHERE files_fts MATCH ?
@@ -371,6 +372,7 @@ final class VaultIndex: @unchecked Sendable {
                 for row in contentRows {
                     let file = Self.indexedFile(from: row)
                     let highlightedContent: String = row["highlighted_content"] ?? ""
+                    let relevanceRank: Double = row["rank"] ?? Double.greatestFiniteMagnitude
                     let filenameMatches = searchTerms.contains { file.filename.lowercased().contains($0) }
 
                     // Find matching lines from FTS-highlighted content so stemmed/tokenized
@@ -396,6 +398,7 @@ final class VaultIndex: @unchecked Sendable {
                         file: file,
                         vaultRootURL: rootURL,
                         matchesFilename: filenameMatches,
+                        relevanceRank: relevanceRank,
                         excerpts: excerpts
                     )
                     orderedIds.append(file.id)
@@ -418,6 +421,7 @@ final class VaultIndex: @unchecked Sendable {
                                 file: file,
                                 vaultRootURL: self.rootURL,
                                 matchesFilename: true,
+                                relevanceRank: Double.greatestFiniteMagnitude,
                                 excerpts: []
                             )
                             orderedIds.append(file.id)
@@ -425,11 +429,12 @@ final class VaultIndex: @unchecked Sendable {
                     }
                 }
 
-                // Sort: filename matches first, then content-only, preserving bm25 order within
+                // Sort deterministically: filename matches first, then BM25 rank, then path.
                 let groups = orderedIds.compactMap { resultsByFileId[$0] }
                 return groups.sorted { a, b in
                     if a.matchesFilename != b.matchesFilename { return a.matchesFilename }
-                    return false // preserve bm25 order
+                    if a.relevanceRank != b.relevanceRank { return a.relevanceRank < b.relevanceRank }
+                    return a.file.path.localizedCaseInsensitiveCompare(b.file.path) == .orderedAscending
                 }
             }
         } catch {

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -763,6 +763,19 @@ final class WorkspaceManager {
         if let data = try? JSONEncoder().encode(stored) {
             UserDefaults.standard.set(data, forKey: Self.locationBookmarksKey)
         }
+        persistVaultsConfig()
+    }
+
+    /// Write vault paths to Application Support for MCP binary discovery
+    private func persistVaultsConfig() {
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
+        let appName = Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
+        let appDir = appSupport.appendingPathComponent(appName)
+        try? FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
+        let vaultsFile = appDir.appendingPathComponent("vaults.json")
+        let paths = locations.map { $0.url.path }
+        let data = try? JSONSerialization.data(withJSONObject: ["vaults": paths], options: [.prettyPrinted])
+        try? data?.write(to: vaultsFile, options: .atomic)
     }
 
     private func restoreLocations() {
@@ -804,6 +817,7 @@ final class WorkspaceManager {
         if !stored.isEmpty {
             persistLocations() // Re-persist in case any bookmarks were refreshed
         }
+        persistVaultsConfig()
     }
 
     // MARK: - Persistence: Recents

--- a/ClearlyMCP/Tools.swift
+++ b/ClearlyMCP/Tools.swift
@@ -90,7 +90,11 @@ private func handleSearchNotes(params: CallTool.Parameters, indexes: [(index: Va
         return .init(content: [.text("Error: 'query' parameter is required")], isError: true)
     }
 
-    let limit = params.arguments?["limit"]?.intValue ?? 20
+    let rawLimit = params.arguments?["limit"]?.intValue
+    if let rawLimit, rawLimit <= 0 {
+        return .init(content: [.text("Error: 'limit' must be greater than 0")], isError: true)
+    }
+    let limit = min(rawLimit ?? 20, 100)
 
     // Search across all vaults, collect results with vault context
     var allResults: [(vaultPath: String, group: SearchFileGroup)] = []
@@ -100,6 +104,8 @@ private func handleSearchNotes(params: CallTool.Parameters, indexes: [(index: Va
             allResults.append((url.path, group))
         }
     }
+
+    allResults.sort(by: isHigherPrioritySearchResult)
 
     if allResults.isEmpty {
         return .init(content: [.text("No results found for: \(query)")])
@@ -123,6 +129,22 @@ private func handleSearchNotes(params: CallTool.Parameters, indexes: [(index: Va
     }
 
     return .init(content: [.text(output)])
+}
+
+private func isHigherPrioritySearchResult(
+    _ lhs: (vaultPath: String, group: SearchFileGroup),
+    _ rhs: (vaultPath: String, group: SearchFileGroup)
+) -> Bool {
+    if lhs.group.matchesFilename != rhs.group.matchesFilename {
+        return lhs.group.matchesFilename
+    }
+    if lhs.group.relevanceRank != rhs.group.relevanceRank {
+        return lhs.group.relevanceRank < rhs.group.relevanceRank
+    }
+    if lhs.vaultPath != rhs.vaultPath {
+        return lhs.vaultPath.localizedCaseInsensitiveCompare(rhs.vaultPath) == .orderedAscending
+    }
+    return lhs.group.file.path.localizedCaseInsensitiveCompare(rhs.group.file.path) == .orderedAscending
 }
 
 private func handleGetBacklinks(params: CallTool.Parameters, indexes: [(index: VaultIndex, url: URL)]) -> CallTool.Result {

--- a/ClearlyMCP/Tools.swift
+++ b/ClearlyMCP/Tools.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MCP
+
+// MARK: - MCP Server Setup
+
+func startMCPServer(indexes: [(index: VaultIndex, url: URL)]) async throws {
+    let vaultPaths = indexes.map { $0.url.path }
+    let vaultDescription = vaultPaths.joined(separator: ", ")
+
+    let server = Server(
+        name: "clearly",
+        version: "1.0.0",
+        capabilities: .init(tools: .init(listChanged: false))
+    )
+
+    await server.withMethodHandler(ListTools.self) { _ in
+        .init(tools: [
+            Tool(
+                name: "search_notes",
+                description: "Full-text search across all notes in Clearly. Searches \(indexes.count) vault(s): \(vaultDescription). Returns relevance-ranked results with context snippets. Uses BM25 ranking and stemming. Results include the vault path and relative file path — use standard file access to read full content.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object([
+                            "type": .string("string"),
+                            "description": .string("Search query. Supports quoted phrases for exact match.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "description": .string("Max results to return (default 20)")
+                        ])
+                    ]),
+                    "required": .array([.string("query")])
+                ])
+            ),
+            Tool(
+                name: "get_backlinks",
+                description: "Get all notes that link to a given note via [[wiki-links]], plus unlinked text mentions (places the note is referenced by name but not yet linked). Searches across all vaults.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "note_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Note filename (e.g. 'My Note') or relative path within a vault (e.g. 'folder/My Note.md')")
+                        ])
+                    ]),
+                    "required": .array([.string("note_path")])
+                ])
+            ),
+            Tool(
+                name: "get_tags",
+                description: "Without arguments: list all tags across all vaults with file counts. With a tag argument: list all files with that tag. Tags come from both inline #hashtags and YAML frontmatter.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "tag": .object([
+                            "type": .string("string"),
+                            "description": .string("Specific tag to look up (without # prefix). Omit to list all tags.")
+                        ])
+                    ])
+                ])
+            )
+        ])
+    }
+
+    await server.withMethodHandler(CallTool.self) { params in
+        switch params.name {
+        case "search_notes":
+            return handleSearchNotes(params: params, indexes: indexes)
+        case "get_backlinks":
+            return handleGetBacklinks(params: params, indexes: indexes)
+        case "get_tags":
+            return handleGetTags(params: params, indexes: indexes)
+        default:
+            return .init(content: [.text("Unknown tool: \(params.name)")], isError: false)
+        }
+    }
+
+    let transport = StdioTransport()
+    try await server.start(transport: transport)
+
+    // Block until the process is terminated
+    try await Task.sleep(for: .seconds(365 * 24 * 3600))
+}
+
+// MARK: - Tool Handlers
+
+private func handleSearchNotes(params: CallTool.Parameters, indexes: [(index: VaultIndex, url: URL)]) -> CallTool.Result {
+    guard let query = params.arguments?["query"]?.stringValue, !query.isEmpty else {
+        return .init(content: [.text("Error: 'query' parameter is required")], isError: true)
+    }
+
+    let limit = params.arguments?["limit"]?.intValue ?? 20
+
+    // Search across all vaults, collect results with vault context
+    var allResults: [(vaultPath: String, group: SearchFileGroup)] = []
+    for (index, url) in indexes {
+        let results = index.searchFilesGrouped(query: query)
+        for group in results {
+            allResults.append((url.path, group))
+        }
+    }
+
+    if allResults.isEmpty {
+        return .init(content: [.text("No results found for: \(query)")])
+    }
+
+    let capped = Array(allResults.prefix(limit))
+    var output = "Found \(allResults.count) file(s) matching \"\(query)\""
+    if allResults.count > limit {
+        output += " (showing first \(limit))"
+    }
+    output += "\n"
+
+    let multiVault = indexes.count > 1
+    for result in capped {
+        let matchType = result.group.matchesFilename ? " (filename match)" : ""
+        let fullPath = multiVault ? "\(result.vaultPath)/\(result.group.file.path)" : result.group.file.path
+        output += "\n## \(fullPath)\(matchType)\n"
+        for excerpt in result.group.excerpts {
+            output += "- Line \(excerpt.lineNumber): \(excerpt.contextLine)\n"
+        }
+    }
+
+    return .init(content: [.text(output)])
+}
+
+private func handleGetBacklinks(params: CallTool.Parameters, indexes: [(index: VaultIndex, url: URL)]) -> CallTool.Result {
+    guard let notePath = params.arguments?["note_path"]?.stringValue, !notePath.isEmpty else {
+        return .init(content: [.text("Error: 'note_path' parameter is required")], isError: true)
+    }
+
+    // Try to resolve in each vault
+    for (index, url) in indexes {
+        let file: IndexedFile?
+        if let f = index.file(forRelativePath: notePath) {
+            file = f
+        } else if let f = index.resolveWikiLink(name: notePath) {
+            file = f
+        } else {
+            let withoutExt = notePath.hasSuffix(".md") ? String(notePath.dropLast(3)) : notePath
+            file = index.resolveWikiLink(name: withoutExt)
+        }
+
+        guard let file = file else { continue }
+
+        let linked = index.linksTo(fileId: file.id)
+        let unlinked = index.unlinkedMentions(for: file.filename, excludingFileId: file.id)
+
+        let multiVault = indexes.count > 1
+        let displayPath = multiVault ? "\(url.path)/\(file.path)" : file.path
+        var output = "# Backlinks for: \(displayPath)\n"
+
+        output += "\n## Linked Mentions (\(linked.count))\n"
+        if linked.isEmpty {
+            output += "No notes link to this file via [[wiki-links]].\n"
+        } else {
+            for link in linked {
+                let source = link.sourcePath ?? link.sourceFilename ?? "unknown"
+                let line = link.lineNumber.map { " (line \($0))" } ?? ""
+                output += "- \(source)\(line)\n"
+            }
+        }
+
+        output += "\n## Unlinked Mentions (\(unlinked.count))\n"
+        if unlinked.isEmpty {
+            output += "No unlinked text mentions found.\n"
+        } else {
+            for mention in unlinked {
+                output += "- \(mention.file.path) (line \(mention.lineNumber)): \(mention.contextLine)\n"
+            }
+        }
+
+        return .init(content: [.text(output)])
+    }
+
+    return .init(content: [.text("Note not found: \(notePath)\nMake sure the note exists and has been indexed by Clearly.")], isError: true)
+}
+
+private func handleGetTags(params: CallTool.Parameters, indexes: [(index: VaultIndex, url: URL)]) -> CallTool.Result {
+    let tag = params.arguments?["tag"]?.stringValue
+    let multiVault = indexes.count > 1
+
+    if let tag = tag, !tag.isEmpty {
+        var allFiles: [(vaultPath: String, file: IndexedFile)] = []
+        for (index, url) in indexes {
+            for file in index.filesForTag(tag: tag) {
+                allFiles.append((url.path, file))
+            }
+        }
+        if allFiles.isEmpty {
+            return .init(content: [.text("No files found with tag #\(tag)")])
+        }
+        var output = "## Files tagged #\(tag) (\(allFiles.count) file(s))\n"
+        for (vaultPath, file) in allFiles {
+            let path = multiVault ? "\(vaultPath)/\(file.path)" : file.path
+            output += "- \(path)\n"
+        }
+        return .init(content: [.text(output)])
+    } else {
+        // Aggregate tags across all vaults
+        var tagCounts: [String: Int] = [:]
+        for (index, _) in indexes {
+            for (tag, count) in index.allTags() {
+                tagCounts[tag, default: 0] += count
+            }
+        }
+        if tagCounts.isEmpty {
+            return .init(content: [.text("No tags found in the vault.")])
+        }
+        let sorted = tagCounts.sorted { $0.key < $1.key }
+        var output = "## All Tags (\(sorted.count) tag(s))\n"
+        for (tag, count) in sorted {
+            output += "- #\(tag) (\(count) file(s))\n"
+        }
+        return .init(content: [.text(output)])
+    }
+}
+
+// MARK: - Value Extensions
+
+private extension Value {
+    var stringValue: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+    var intValue: Int? {
+        if case .int(let n) = self { return n }
+        if case .double(let d) = self { return Int(d) }
+        return nil
+    }
+}

--- a/ClearlyMCP/main.swift
+++ b/ClearlyMCP/main.swift
@@ -1,0 +1,86 @@
+import Foundation
+import MCP
+import GRDB
+
+// MARK: - Argument Parsing
+
+let args = CommandLine.arguments
+
+let bundleIdentifier: String
+if let bidIdx = args.firstIndex(of: "--bundle-id"), bidIdx + 1 < args.count {
+    bundleIdentifier = args[bidIdx + 1]
+} else {
+    bundleIdentifier = "com.sabotage.clearly"
+}
+
+// MARK: - Resolve Vault Paths
+
+// --vault overrides auto-discovery; otherwise read vaults.json from Application Support
+var vaultPaths: [String] = []
+
+if let vaultIdx = args.firstIndex(of: "--vault"), vaultIdx + 1 < args.count {
+    vaultPaths = [args[vaultIdx + 1]]
+} else {
+    // Look for vaults.json in the app's Application Support (handles sandbox container path)
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let containerPath = home.appendingPathComponent("Library/Containers/\(bundleIdentifier)/Data/Library/Application Support/\(bundleIdentifier)/vaults.json")
+    let standardPath = home.appendingPathComponent("Library/Application Support/\(bundleIdentifier)/vaults.json")
+    let vaultsFile = FileManager.default.fileExists(atPath: containerPath.path) ? containerPath : standardPath
+
+    if let data = try? Data(contentsOf: vaultsFile),
+       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       let paths = json["vaults"] as? [String] {
+        vaultPaths = paths
+    }
+}
+
+if vaultPaths.isEmpty {
+    fputs("No vaults found. Either:\n", stderr)
+    fputs("  - Open Clearly and add a vault first (auto-detected via ~/.config/clearly/vaults.json)\n", stderr)
+    fputs("  - Pass --vault <path> explicitly\n", stderr)
+    exit(1)
+}
+
+// Filter to paths that exist
+vaultPaths = vaultPaths.filter { FileManager.default.fileExists(atPath: $0) }
+if vaultPaths.isEmpty {
+    fputs("Error: No vault paths exist on disk.\n", stderr)
+    exit(1)
+}
+
+// MARK: - Open Indexes
+
+var indexes: [(index: VaultIndex, url: URL)] = []
+for path in vaultPaths {
+    let url = URL(fileURLWithPath: path)
+    do {
+        let index = try VaultIndex(locationURL: url, bundleIdentifier: bundleIdentifier)
+        indexes.append((index, url))
+    } catch {
+        fputs("Warning: Cannot open index for \(path): \(error)\n", stderr)
+    }
+}
+
+if indexes.isEmpty {
+    fputs("Error: Could not open any vault indexes.\n", stderr)
+    fputs("Make sure Clearly has been opened with these vaults at least once.\n", stderr)
+    exit(1)
+}
+
+// MARK: - Test Mode
+
+if args.contains("--test") {
+    for (index, url) in indexes {
+        let files = index.allFiles()
+        let tags = index.allTags()
+        print("Vault: \(url.path)")
+        print("  Files indexed: \(files.count)")
+        print("  Tags: \(tags.count)")
+    }
+    print("OK — \(indexes.count) vault(s)")
+    exit(0)
+}
+
+// MARK: - MCP Server
+
+try await startMCPServer(indexes: indexes)

--- a/docs/expansion/IMPLEMENTATION.md
+++ b/docs/expansion/IMPLEMENTATION.md
@@ -369,35 +369,21 @@ MCP makes Clearly visible to the AI ecosystem (Claude Desktop, ChatGPT, Cursor).
 
 ### Tasks
 
-- [ ] Add MCP Swift SDK dependency to `project.yml`:
-  ```yaml
-  MCP:
-    url: https://github.com/modelcontextprotocol/swift-sdk.git
-    from: "0.11.0"
-  ```
-- [ ] Add `ClearlyMCP` target to `project.yml`:
-  - `type: commandLineTool`
-  - Sources: `ClearlyMCP/` + `Shared/` (for shared model types)
-  - Dependencies: GRDB, MCP SDK
-- [ ] Create `ClearlyMCP/` directory with:
-  - `main.swift` — entry point, parse `--vault` argument, open VaultIndex (read-only), start MCP server on stdio
-  - `MCPTools.swift` — implement tool handlers:
-    - `search_notes(query)` → FTS5 search, return file names + matching context
-    - `read_note(path)` → return full file content
-    - `list_notes(folder?)` → list all notes, optional folder filter
-  - `--test` flag: verify index is readable, print success/failure, exit
-- [ ] Companion binary distribution:
-  - **Direct download**: Bundle binary at `Contents/Helpers/ClearlyMCP` in app bundle. On first launch, copy to `~/Library/Application Support/Clearly/ClearlyMCP`. Update on app updates.
-  - **App Store**: One-click "Install MCP Helper" button in Settings downloads the binary from GitHub Releases via `URLSession`, writes to `~/Library/Application Support/Clearly/ClearlyMCP`, sets executable permission. No terminal needed.
-- [ ] Create MCP Settings panel in `Clearly/SettingsView.swift`:
-  - New "MCP" tab/section
-  - **Detection**: Check known paths for companion binary
-  - **Direct download state**: Green checkmark, version, vault path selector
-  - **App Store state**: One-click "Install MCP Helper" button (downloads + installs automatically)
-  - **"Copy Claude Desktop Config"** button: generates JSON with resolved binary path + vault path, copies to clipboard
-  - **"Test Connection"** button: runs binary with `--test`, shows result
-  - **Auto-detect Claude Desktop**: check if config file exists, offer to add config (with confirmation)
-- [ ] Run `xcodegen generate` after project.yml changes
+- [x] Add `init(locationURL:bundleIdentifier:)` to `VaultIndex.swift` — lets CLI binary open the sandboxed app's index
+- [x] Add `@unchecked Sendable` to `VaultIndex` — needed for MCP SDK's `@Sendable` closures
+- [x] Add `persistVaultsConfig()` to `WorkspaceManager.swift` — writes `~/.config/clearly/vaults.json`
+- [x] Add MCP Swift SDK (`from: "0.11.0"`) to `project.yml` packages
+- [x] Add `ClearlyMCP` tool target to `project.yml` — sources: `ClearlyMCP/`, `VaultIndex.swift`, `FileParser.swift`, `FileNode.swift`, `DiagnosticLog.swift`, `FrontmatterSupport.swift`
+- [x] Create `ClearlyMCP/main.swift` — entry point with `--vault` and `--test` flags
+- [x] Create `ClearlyMCP/Tools.swift` — 3 MCP tools only:
+  - `search_notes(query, limit?)` → FTS5 ranked search with BM25, snippets
+  - `get_backlinks(note_path)` → linked mentions + unlinked mentions
+  - `get_tags(tag?)` → all tags with counts, or files for a tag
+  - Cut: `read_note`, `list_notes`, `create_note`, `update_note`, `get_metadata` (thin wrappers over file system access)
+- [x] Add MCP Settings tab to `SettingsView.swift` — status, vault selector, copy config, test connection
+- [x] Add `installMCPHelperIfNeeded()` to `ClearlyApp.swift` — auto-installs binary on launch (direct distribution)
+- [x] Add `postCompileScripts` to Clearly target — copies ClearlyMCP binary into app bundle
+- [x] Run `xcodegen generate` and verify both targets build
 
 ### Success Criteria
 - Direct download build: MCP binary auto-installed to App Support on first launch. No user action needed.

--- a/docs/expansion/PROGRESS.md
+++ b/docs/expansion/PROGRESS.md
@@ -1,6 +1,6 @@
 # Expansion Progress
 
-## Status: Phase 6 - Completed
+## Status: Phase 7 - Completed
 
 ## Quick Reference
 - Research: `docs/expansion/RESEARCH.md`
@@ -215,13 +215,33 @@
 ---
 
 ### Phase 7: MCP Server
-**Status:** Not Started
+**Status:** Completed (2026-04-13)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `init(locationURL:bundleIdentifier:)` and `indexDirectory(bundleIdentifier:)` to `VaultIndex.swift` — lets CLI binary open the same SQLite index the sandboxed app creates
+- [x] Added `@unchecked Sendable` to `VaultIndex` — safe because `DatabasePool` handles concurrency; needed for MCP SDK's `@Sendable` closure requirements
+- [x] Added `persistVaultsConfig()` to `WorkspaceManager.swift` — writes `~/.config/clearly/vaults.json` with active vault paths for AI agent discovery
+- [x] Added MCP Swift SDK (`modelcontextprotocol/swift-sdk` v0.11.0+) to `project.yml` packages
+- [x] Added `ClearlyMCP` tool target to `project.yml` — sources: `ClearlyMCP/`, plus `VaultIndex.swift`, `FileParser.swift`, `FileNode.swift`, `DiagnosticLog.swift`, `FrontmatterSupport.swift`
+- [x] Created `ClearlyMCP/main.swift` — CLI entry point with `--vault <path>` and `--test` flags, opens VaultIndex with explicit bundle ID
+- [x] Created `ClearlyMCP/Tools.swift` — MCP server with 3 tools:
+  - `search_notes(query, limit?)` — FTS5 ranked search via `searchFilesGrouped()`, BM25 ranking, context snippets
+  - `get_backlinks(note_path)` — linked mentions via `linksTo()` + unlinked mentions via `unlinkedMentions()`, resolves paths and wiki-link names
+  - `get_tags(tag?)` — all tags with counts via `allTags()`, or files for a tag via `filesForTag()`
+- [x] Added MCP Settings tab to `SettingsView.swift` — binary status indicator, vault selector, "Copy Claude Desktop Config" button, "Test Connection" button
+- [x] Added `installMCPHelperIfNeeded()` to `ClearlyApp.swift` — copies bundled binary to `~/Library/Application Support/Clearly/ClearlyMCP` on launch (direct distribution only, `#if canImport(Sparkle)`)
+- [x] Added `postCompileScripts` to Clearly target in `project.yml` — copies ClearlyMCP binary to `Contents/Resources/Helpers/`
+- [x] Build verified: both `xcodebuild -scheme ClearlyMCP` and `xcodebuild -scheme Clearly` succeed
+- [x] Binary verified: `./ClearlyMCP --vault /path --test` prints file/tag counts and exits 0
 
 #### Decisions Made
-- (none yet)
+- **Only 3 tools, not 6+**: Cut `read_note`, `list_notes`, `create_note`, `update_note`, `get_metadata` — all thin wrappers over file system operations agents already have. Only expose computed knowledge (ranked search, link graph, tag aggregation) that agents can't derive from raw files.
+- **Read-only index access**: CLI opens the app's SQLite database via WAL mode. No write tools → no concurrent write contention.
+- **Sandbox container resolution**: `indexDirectory(bundleIdentifier:)` tries `~/Library/Containers/{id}/Data/...` first (where sandboxed app stores index), falls back to `~/Library/Application Support/`.
+- **Swift 6.0 for ClearlyMCP target only**: MCP SDK requires Swift 6.0. Main app stays Swift 5.9. `SWIFT_STRICT_CONCURRENCY: minimal` avoids Sendable issues with shared source files.
+- **`vaults.json` for zero-MCP discovery**: Written to `~/.config/clearly/vaults.json` — any AI agent with file access can find vault paths without MCP.
+- **Direct distribution bundles automatically**: Binary copied from `Contents/Resources/Helpers/` to App Support on launch. No user action.
+- **No App Store download flow in v1**: Settings tab shows status for both builds, but one-click download from GitHub Releases deferred.
 
 #### Blockers
 - (none)
@@ -229,6 +249,20 @@
 ---
 
 ## Session Log
+
+### 2026-04-13 — Phase 7 Implementation
+- Added `init(locationURL:bundleIdentifier:)` overload to VaultIndex.swift for CLI database access
+- Added `@unchecked Sendable` to VaultIndex (thread-safe via DatabasePool)
+- Added sandbox container path resolution in `indexDirectory(bundleIdentifier:)`
+- Added `persistVaultsConfig()` to WorkspaceManager.swift — writes ~/.config/clearly/vaults.json
+- Added MCP Swift SDK package + ClearlyMCP tool target to project.yml (Swift 6.0, SWIFT_STRICT_CONCURRENCY: minimal)
+- Created ClearlyMCP/main.swift — CLI entry point with --vault/--test args
+- Created ClearlyMCP/Tools.swift — 3 MCP tools (search_notes, get_backlinks, get_tags) using VaultIndex read APIs
+- Added MCP tab to SettingsView.swift — status, vault picker, copy config, test connection
+- Added installMCPHelperIfNeeded() to ClearlyApp.swift — auto-installs binary on launch (Sparkle builds)
+- Added postCompileScripts to project.yml — copies ClearlyMCP into app bundle Helpers/
+- Build verified: both ClearlyMCP and Clearly schemes succeed
+- Binary verified: ./ClearlyMCP --vault /path --test outputs file/tag counts
 
 ### 2026-04-13 — Phase 6 Implementation
 - Added `tagColor` to Theme.swift (soft blue, light/dark adaptive)
@@ -287,6 +321,13 @@
 ---
 
 ## Files Changed
+- `project.yml` — MCP Swift SDK package, ClearlyMCP tool target, postCompileScripts for bundling, ClearlyMCP dependency on Clearly
+- `ClearlyMCP/main.swift` (new) — CLI entry point with --vault/--test args, VaultIndex init with explicit bundle ID
+- `ClearlyMCP/Tools.swift` (new) — MCP server setup, 3 tool handlers (search_notes, get_backlinks, get_tags), Value extensions
+- `Clearly/VaultIndex.swift` — `@unchecked Sendable`, `init(locationURL:bundleIdentifier:)`, `indexDirectory(bundleIdentifier:)` with sandbox container resolution
+- `Clearly/WorkspaceManager.swift` — `persistVaultsConfig()` writes ~/.config/clearly/vaults.json, called from persistLocations() and restoreLocations()
+- `Clearly/SettingsView.swift` — MCP tab with status indicator, vault selector, copy config, test connection
+- `Clearly/ClearlyApp.swift` — `installMCPHelperIfNeeded()` copies binary to App Support on launch
 - `Clearly/Theme.swift` — `tagColor` (soft blue, light/dark)
 - `Clearly/MarkdownSyntaxHighlighter.swift` — `.tag` enum case, regex pattern, 2 switch cases (highlightAll + highlightAround)
 - `Shared/MarkdownRenderer.swift` — `processTags()`, `protectTagRegions()`, `restoreTagRegions()` in pipeline

--- a/project.yml
+++ b/project.yml
@@ -22,6 +22,9 @@ packages:
   GRDB:
     url: https://github.com/groue/GRDB.swift.git
     from: "7.0.0"
+  MCP:
+    url: https://github.com/modelcontextprotocol/swift-sdk.git
+    from: "0.11.0"
 
 targets:
   Clearly:
@@ -53,6 +56,15 @@ targets:
       - package: GRDB
       - target: ClearlyQuickLook
         embed: true
+      - target: ClearlyMCP
+        embed: false
+    postCompileScripts:
+      - script: |
+          HELPERS_DIR="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Helpers"
+          mkdir -p "$HELPERS_DIR"
+          cp "${BUILT_PRODUCTS_DIR}/ClearlyMCP" "$HELPERS_DIR/ClearlyMCP"
+        name: "Copy MCP Helper"
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly
@@ -109,6 +121,33 @@ targets:
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.quicklook
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Developer ID Application"
+
+  ClearlyMCP:
+    type: tool
+    platform: macOS
+    sources:
+      - path: ClearlyMCP
+      - path: Clearly/VaultIndex.swift
+      - path: Clearly/FileParser.swift
+      - path: Clearly/FileNode.swift
+      - path: Clearly/DiagnosticLog.swift
+      - path: Shared/FrontmatterSupport.swift
+    dependencies:
+      - package: GRDB
+      - package: MCP
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.mcp
+        PRODUCT_NAME: ClearlyMCP
+        MARKETING_VERSION: "1.16.0"
+        CURRENT_PROJECT_VERSION: "1"
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: minimal
+        ENABLE_HARDENED_RUNTIME: YES
+      configs:
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"


### PR DESCRIPTION
## Summary
- Adds `ClearlyMCP`, a standalone CLI binary that exposes the vault's SQLite index to AI agents via Model Context Protocol (MCP)
- Ships 3 tools that expose computed knowledge agents can't get from raw files: `search_notes` (FTS5 ranked search with BM25), `get_backlinks` (linked + unlinked mentions), `get_tags` (cross-vault tag aggregation)
- Auto-discovers all vaults from the app's `vaults.json` — one MCP server entry serves all vaults, no `--vault` flag needed
- Adds MCP Settings tab with install status and one-click config copy for any MCP-compatible app
- Direct distribution builds auto-install the binary to Application Support on launch

## Test plan
- [ ] `xcodegen generate` succeeds with new ClearlyMCP target
- [ ] `xcodebuild -scheme ClearlyMCP -configuration Debug build` succeeds
- [ ] `xcodebuild -scheme Clearly -configuration Debug build` succeeds
- [ ] `./ClearlyMCP --test` auto-discovers vaults and prints file/tag counts
- [ ] JSON-RPC test: initialize → tools/list → tools/call for all 3 tools returns valid responses
- [ ] Settings > MCP tab shows install status and "Copy MCP Config" works
- [ ] Configure in Claude Desktop and verify search/backlinks/tags work