### PR TITLE
Add tabbed documents with tab bar, per-tab view mode, keyboard shortcuts (#129)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -125,6 +125,7 @@ struct LauncherSceneMarker: NSViewRepresentable {
 final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var observers: [Any] = []
     private var commandQMonitor: Any?
+    private var closeTabMonitor: Any?
     private var showHiddenFilesMonitor: Any?
     private var sidebarToggleMonitor: Any?
     private var quickSwitcherMonitor: Any?
@@ -156,12 +157,6 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         window.setContentSize(NSSize(width: 960, height: 900))
         window.center()
         window.setFrameAutosaveName("ClearlyMainWindow")
-
-        // Empty toolbar triggers macOS 26's larger ~26pt corner radius
-        let toolbar = NSToolbar(identifier: "ClearlyMainToolbar")
-        toolbar.showsBaselineSeparator = false
-        toolbar.displayMode = .iconOnly
-        window.toolbar = toolbar
 
         let themePreference = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
         let appearance: NSAppearance? = switch themePreference {
@@ -298,6 +293,20 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             return nil
         }
 
+        closeTabMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
+            guard chars == "w" && mods == [.command] else { return event }
+            guard let window = event.window,
+                  window.identifier == WindowRouter.mainWindowIdentifier else { return event }
+            let workspace = WorkspaceManager.shared
+            if let activeID = workspace.activeDocumentID {
+                workspace.closeDocument(activeID)
+                return nil
+            }
+            return event
+        }
+
         showHiddenFilesMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
             guard self.shouldToggleHiddenFiles(for: event) else { return event }
@@ -317,11 +326,23 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
                 return nil
             }
             if chars == "1" && mods == [.command] {
-                NotificationCenter.default.post(name: .init("ClearlySetViewMode"), object: "edit")
+                WorkspaceManager.shared.currentViewMode = .edit
                 return nil
             }
             if chars == "2" && mods == [.command] {
-                NotificationCenter.default.post(name: .init("ClearlySetViewMode"), object: "preview")
+                WorkspaceManager.shared.currentViewMode = .preview
+                return nil
+            }
+            if chars == "t" && mods == [.command] {
+                WorkspaceManager.shared.createUntitledDocument()
+                return nil
+            }
+            if chars == "[" && mods == [.command, .shift] {
+                WorkspaceManager.shared.selectPreviousTab()
+                return nil
+            }
+            if chars == "]" && mods == [.command, .shift] {
+                WorkspaceManager.shared.selectNextTab()
                 return nil
             }
             if chars == "o" && mods == [.command, .shift] {
@@ -371,7 +392,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
                     workspace.addLocation(url: url)
                 }
             } else {
-                openedFile = workspace.openFile(at: url) || openedFile
+                openedFile = workspace.openFileInNewTab(at: url) || openedFile
             }
         }
         if openedDirectory {
@@ -403,6 +424,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         if let commandQMonitor {
             NSEvent.removeMonitor(commandQMonitor)
             self.commandQMonitor = nil
+        }
+        if let closeTabMonitor {
+            NSEvent.removeMonitor(closeTabMonitor)
+            self.closeTabMonitor = nil
         }
         if let showHiddenFilesMonitor {
             NSEvent.removeMonitor(showHiddenFilesMonitor)
@@ -524,11 +549,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     @objc private func switchToEditorAction(_ sender: Any?) {
-        NotificationCenter.default.post(name: .init("ClearlySetViewMode"), object: "edit")
+        WorkspaceManager.shared.currentViewMode = .edit
     }
 
     @objc private func switchToPreviewAction(_ sender: Any?) {
-        NotificationCenter.default.post(name: .init("ClearlySetViewMode"), object: "preview")
+        WorkspaceManager.shared.currentViewMode = .preview
     }
 
     @objc private func toggleOutlineAction(_ sender: Any?) {
@@ -806,10 +831,10 @@ class ClearlySplitViewController: NSSplitViewController {
         addSplitViewItem(sidebarItem)
 
         // Detail
-        // Detail
         let detailHost = NSHostingController(rootView:
             DetailView(workspace: workspace)
         )
+        detailHost.safeAreaRegions = []
         let detailItem = NSSplitViewItem(viewController: detailHost)
         detailItem.minimumThickness = 400
         addSplitViewItem(detailItem)
@@ -856,10 +881,14 @@ struct DetailView: View {
     @Bindable var workspace: WorkspaceManager
 
     var body: some View {
-        if workspace.activeDocumentID != nil {
-            ContentView(workspace: workspace)
-        } else {
-            NoFileView(workspace: workspace)
+        VStack(spacing: 0) {
+            TabBarView(workspace: workspace)
+
+            if workspace.activeDocumentID != nil {
+                ContentView(workspace: workspace)
+            } else {
+                NoFileView(workspace: workspace)
+            }
         }
     }
 }
@@ -950,6 +979,11 @@ struct ClearlyApp: App {
                     workspace.createUntitledDocument()
                 }
                 .keyboardShortcut("n", modifiers: .command)
+
+                Button("New Tab") {
+                    workspace.createUntitledDocument()
+                }
+                .keyboardShortcut("t", modifiers: .command)
 
                 Button("Open…") {
                     workspace.showOpenPanel()

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -7,11 +7,6 @@ extension Notification.Name {
     static let navigateWikiLink = Notification.Name("navigateWikiLink")
 }
 
-enum ViewMode: String, CaseIterable {
-    case edit
-    case preview
-}
-
 struct ViewModeKey: FocusedValueKey {
     typealias Value = Binding<ViewMode>
 }
@@ -64,15 +59,14 @@ extension FocusedValues {
 }
 
 struct FocusedValuesModifier: ViewModifier {
-    var workspace: WorkspaceManager
-    @Binding var mode: ViewMode
+    @Bindable var workspace: WorkspaceManager
     var findState: FindState
     var outlineState: OutlineState
     var backlinksState: BacklinksState
 
     func body(content: Content) -> some View {
         content
-            .focusedSceneValue(\.viewMode, $mode)
+            .focusedSceneValue(\.viewMode, $workspace.currentViewMode)
             .focusedSceneValue(\.documentText, workspace.currentFileText)
             .focusedSceneValue(\.documentFileURL, workspace.currentFileURL)
             .focusedSceneValue(\.findState, findState)
@@ -99,7 +93,6 @@ struct ContentView: View {
     }
 
     @Bindable var workspace: WorkspaceManager
-    @State private var mode: ViewMode
     @State private var positionSyncID = UUID().uuidString
     @State private var pendingWikiNavigation: PendingWikiNavigation?
     @AppStorage("editorFontSize") private var fontSize: Double = 16
@@ -108,16 +101,12 @@ struct ContentView: View {
     @StateObject private var outlineState = OutlineState()
     @StateObject private var backlinksState = BacklinksState()
 
-    init(workspace: WorkspaceManager) {
-        self.workspace = workspace
-        let storedMode = UserDefaults.standard.string(forKey: "viewMode")
-        self._mode = State(initialValue: ViewMode(rawValue: storedMode ?? "") ?? .edit)
-    }
+    private var hasTabBar: Bool { workspace.openDocuments.count >= 2 }
 
     private var editorPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
-        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: mode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState)
+        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: hasTabBar ? 16 : 0)
     }
 
     private var previewPane: some View {
@@ -138,7 +127,7 @@ struct ContentView: View {
         return PreviewView(
             markdown: workspace.currentFileText,
             fontSize: editorFontSize,
-            mode: mode,
+            mode: workspace.currentViewMode,
             positionSyncID: positionSyncID,
             fileURL: fileURL,
             findState: findState,
@@ -163,8 +152,8 @@ struct ContentView: View {
                 }
                 workspace.currentFileText = lines.joined(separator: "\n")
             },
-            onClickToSource: { line in
-                mode = .edit
+            onClickToSource: { [workspace] line in
+                workspace.currentViewMode = .edit
                 NotificationCenter.default.post(name: .scrollEditorToLine, object: nil, userInfo: ["line": line])
             },
             onWikiLinkClicked: { target, heading in
@@ -177,7 +166,8 @@ struct ContentView: View {
                     userInfo: ["tag": tagName]
                 )
             },
-            wikiFileNames: allWikiFileNames
+            wikiFileNames: allWikiFileNames,
+            extraTopInset: hasTabBar ? 16 : 0
         )
     }
 
@@ -187,7 +177,7 @@ struct ContentView: View {
         HStack(spacing: 0) {
             // Edit/Preview on the left
             ClearlySegmentedControl(
-                selection: $mode,
+                selection: $workspace.currentViewMode,
                 items: [
                     (value: .edit, icon: "pencil", label: "Edit"),
                     (value: .preview, icon: "eye", label: "Preview")
@@ -282,13 +272,13 @@ struct ContentView: View {
             }
             ZStack {
                 editorPane
-                    .opacity(mode == .edit ? 1 : 0)
-                    .allowsHitTesting(mode == .edit)
+                    .opacity(workspace.currentViewMode == .edit ? 1 : 0)
+                    .allowsHitTesting(workspace.currentViewMode == .edit)
                 previewPane
-                    .opacity(mode == .preview ? 1 : 0)
-                    .allowsHitTesting(mode == .preview)
+                    .opacity(workspace.currentViewMode == .preview ? 1 : 0)
+                    .allowsHitTesting(workspace.currentViewMode == .preview)
             }
-            .layoutPriority(1)
+                        .layoutPriority(1)
 
             if backlinksState.isVisible {
                 Rectangle()
@@ -325,11 +315,8 @@ struct ContentView: View {
 
     var body: some View {
         mainContent
-            .onChange(of: mode) { _, newMode in
-                UserDefaults.standard.set(newMode.rawValue, forKey: "viewMode")
-            }
-            .animation(Theme.Motion.smooth, value: mode)
-            .modifier(FocusedValuesModifier(workspace: workspace, mode: $mode, findState: findState, outlineState: outlineState, backlinksState: backlinksState))
+            .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
+            .modifier(FocusedValuesModifier(workspace: workspace, findState: findState, outlineState: outlineState, backlinksState: backlinksState))
             .onAppear {
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
@@ -342,10 +329,6 @@ struct ContentView: View {
                 outlineState.parseHeadings(from: workspace.currentFileText)
                 backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
                 applyPendingWikiNavigationIfNeeded()
-                // New untitled docs always open in edit mode
-                if let newID, let doc = workspace.openDocuments.first(where: { $0.id == newID }), doc.isUntitled {
-                    mode = .edit
-                }
             }
             .onChange(of: workspace.currentFileURL) { _, _ in
                 setupFileWatcher()
@@ -354,11 +337,6 @@ struct ContentView: View {
                 workspace.contentDidChange()
                 fileWatcher.updateCurrentText(newText)
                 outlineState.parseHeadings(from: newText)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .init("ClearlySetViewMode"))) { notification in
-                if let modeStr = notification.object as? String, let newMode = ViewMode(rawValue: modeStr) {
-                    mode = newMode
-                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleOutline"))) { _ in
                 withAnimation(Theme.Motion.smooth) {
@@ -426,7 +404,7 @@ struct ContentView: View {
                     )
                 }
             } else {
-                mode = destinationMode
+                workspace.currentViewMode = destinationMode
                 pendingWikiNavigation = nil
             }
             return
@@ -444,7 +422,7 @@ struct ContentView: View {
     }
 
     private func scheduleWikiNavigation(lineNumber: Int, destinationMode: ViewMode) {
-        mode = destinationMode
+        workspace.currentViewMode = destinationMode
         let notificationName: Notification.Name = destinationMode == .preview ? .scrollPreviewToLine : .scrollEditorToLine
         DispatchQueue.main.async {
             NotificationCenter.default.post(

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -11,6 +11,7 @@ struct EditorView: NSViewRepresentable {
     var positionSyncID: String
     var findState: FindState?
     var outlineState: OutlineState?
+    var extraTopInset: CGFloat = 0
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -53,7 +54,7 @@ struct EditorView: NSViewRepresentable {
         ]
 
         // Insets
-        textView.textContainerInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop)
+        textView.textContainerInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop + extraTopInset)
         textView.textContainer?.lineFragmentPadding = 0
 
         // Layout
@@ -150,6 +151,12 @@ struct EditorView: NSViewRepresentable {
 
         // Keep coordinator's parent fresh so the binding never goes stale
         context.coordinator.parent = self
+
+        // Update top inset when tab bar appears/disappears
+        let expectedInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop + extraTopInset)
+        if textView.textContainerInset != expectedInset {
+            textView.textContainerInset = expectedInset
+        }
 
         let didChangeDocument = context.coordinator.lastPositionSyncID != positionSyncID
         context.coordinator.lastPositionSyncID = positionSyncID

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -947,13 +947,23 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             let row = outlineView.selectedRow
             guard row >= 0, let outlineItem = outlineView.item(atRow: row) as? OutlineItem else { return }
 
+            let cmdHeld = NSEvent.modifierFlags.contains(.command)
+
             switch outlineItem.kind {
             case .openDocument(let doc):
                 workspace.switchToDocument(doc.id)
             case .fileNode(let node) where !node.isDirectory:
-                workspace.openFile(at: node.url)
+                if cmdHeld {
+                    workspace.openFileInNewTab(at: node.url)
+                } else {
+                    workspace.openFile(at: node.url)
+                }
             case .recentFile(let url):
-                workspace.openFile(at: url)
+                if cmdHeld {
+                    workspace.openFileInNewTab(at: url)
+                } else {
+                    workspace.openFile(at: url)
+                }
             case .tagEntry(let tag, _):
                 NotificationCenter.default.post(
                     name: .init("ClearlyFilterByTag"),
@@ -1039,6 +1049,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
 
                     menu.addItem(.separator())
                 } else {
+                    let openTabItem = NSMenuItem(title: "Open in New Tab", action: #selector(openInNewTabAction(_:)), keyEquivalent: "")
+                    openTabItem.representedObject = node.url
+                    openTabItem.target = self
+                    menu.addItem(openTabItem)
+
                     let newFileItem = NSMenuItem(title: "New File…", action: #selector(newFileInFolderAction(_:)), keyEquivalent: "")
                     newFileItem.representedObject = parentURL
                     newFileItem.target = self
@@ -1071,6 +1086,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 menu.addItem(deleteItem)
 
             case .recentFile(let url):
+                let openTabItem = NSMenuItem(title: "Open in New Tab", action: #selector(openInNewTabAction(_:)), keyEquivalent: "")
+                openTabItem.representedObject = url
+                openTabItem.target = self
+                menu.addItem(openTabItem)
+
                 let revealItem = NSMenuItem(title: "Reveal in Finder", action: #selector(revealInFinderAction(_:)), keyEquivalent: "")
                 revealItem.representedObject = url
                 revealItem.target = self
@@ -1225,6 +1245,11 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             guard let locationID = sender.representedObject as? UUID,
                   let location = workspace.locations.first(where: { $0.id == locationID }) else { return }
             workspace.removeLocation(location)
+        }
+
+        @objc func openInNewTabAction(_ sender: NSMenuItem) {
+            guard let url = sender.representedObject as? URL else { return }
+            workspace.openFileInNewTab(at: url)
         }
 
         @objc func closeOpenDocAction(_ sender: NSMenuItem) {

--- a/Clearly/OpenDocument.swift
+++ b/Clearly/OpenDocument.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum ViewMode: String, CaseIterable {
+    case edit
+    case preview
+}
+
 /// Represents a single document that is currently open in the editor.
 /// Can be either file-backed (has a fileURL) or untitled (in-memory only).
 struct OpenDocument: Identifiable {
@@ -8,6 +13,7 @@ struct OpenDocument: Identifiable {
     var text: String
     var lastSavedText: String
     var untitledNumber: Int?
+    var viewMode: ViewMode = .edit
 
     var isDirty: Bool { text != lastSavedText }
     var isUntitled: Bool { fileURL == nil }

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -15,6 +15,7 @@ struct PreviewView: NSViewRepresentable {
     var onWikiLinkClicked: ((String, String?) -> Void)?
     var onTagClicked: ((String) -> Void)?
     var wikiFileNames: Set<String>?
+    var extraTopInset: CGFloat = 0
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
@@ -160,7 +161,7 @@ struct PreviewView: NSViewRepresentable {
         }
         </style>
         </head>
-        <body>\(htmlBody)</body>
+        <body\(extraTopInset > 0 ? " style=\"padding-top: \(Int(extraTopInset))px\"" : "")>\(htmlBody)</body>
         <script>
         document.querySelectorAll('img').forEach(function(img) {
             if (!img.complete) {

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -483,7 +483,7 @@ final class QuickSwitcherManager: NSObject {
         } else {
             WorkspaceManager.shared.openFile(at: item.fullURL)
             if let line = item.lineNumber {
-                let currentMode = ViewMode(rawValue: UserDefaults.standard.string(forKey: "viewMode") ?? "") ?? .edit
+                let currentMode = WorkspaceManager.shared.currentViewMode
                 let notificationName: Notification.Name = currentMode == .preview
                     ? .scrollPreviewToLine
                     : .scrollEditorToLine

--- a/Clearly/TabBarView.swift
+++ b/Clearly/TabBarView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct TabBarView: View {
+    @Bindable var workspace: WorkspaceManager
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var tabBackground: Color {
+        colorScheme == .dark
+            ? Color(nsColor: .windowBackgroundColor).opacity(0.6)
+            : Color.primary.opacity(0.04)
+    }
+
+    var body: some View {
+        if workspace.openDocuments.count >= 2 {
+            VStack(spacing: 0) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 1) {
+                        ForEach(Array(workspace.openDocuments.enumerated()), id: \.element.id) { index, doc in
+                            TabItemView(
+                                doc: doc,
+                                isActive: doc.id == workspace.activeDocumentID,
+                                isLast: index == workspace.openDocuments.count - 1,
+                                onSelect: { workspace.switchToDocument(doc.id) },
+                                onClose: { workspace.closeDocument(doc.id) }
+                            )
+                        }
+                        Spacer()
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 5)
+                }
+                .frame(height: 38)
+
+                Rectangle()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(height: 1)
+            }
+            .frame(maxWidth: .infinity)
+            .background(tabBackground)
+        }
+    }
+}
+
+private struct TabItemView: View {
+    let doc: OpenDocument
+    let isActive: Bool
+    let isLast: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovering = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: onSelect) {
+                HStack(spacing: 5) {
+                    Text(displayName)
+                        .font(.system(size: 12, weight: isActive ? .medium : .regular))
+                        .foregroundStyle(isActive ? .primary : .secondary)
+                        .lineLimit(1)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            // Close / dirty indicator
+            Group {
+                if doc.isDirty && !(isActive || isHovering) {
+                    Circle()
+                        .fill(Color.primary.opacity(0.3))
+                        .frame(width: 6, height: 6)
+                        .padding(.leading, 6)
+                } else if isActive || isHovering {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                            .frame(width: 16, height: 16)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.leading, 2)
+                } else {
+                    Spacer()
+                        .frame(width: 8)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isActive
+                    ? (colorScheme == .dark ? Color.white.opacity(0.08) : Color.white)
+                    : Color.clear)
+                .shadow(color: isActive ? Color.black.opacity(colorScheme == .dark ? 0.3 : 0.06) : .clear, radius: 1, y: 0.5)
+        )
+        .onHover { hovering in
+            isHovering = hovering
+        }
+    }
+
+    private var displayName: String {
+        if let url = doc.fileURL {
+            return url.deletingPathExtension().lastPathComponent
+        }
+        return doc.displayName
+    }
+}

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -22,6 +22,7 @@ final class WorkspaceManager {
     var currentFileURL: URL?
     var currentFileText: String = ""
     var isDirty: Bool = false
+    var currentViewMode: ViewMode = .edit
 
     // MARK: - Open Documents
 
@@ -190,6 +191,22 @@ final class WorkspaceManager {
         return true
     }
 
+    func selectNextTab() {
+        guard let id = activeDocumentID,
+              let idx = openDocuments.firstIndex(where: { $0.id == id }),
+              openDocuments.count > 1 else { return }
+        let next = (idx + 1) % openDocuments.count
+        switchToDocument(openDocuments[next].id)
+    }
+
+    func selectPreviousTab() {
+        guard let id = activeDocumentID,
+              let idx = openDocuments.firstIndex(where: { $0.id == id }),
+              openDocuments.count > 1 else { return }
+        let prev = (idx - 1 + openDocuments.count) % openDocuments.count
+        switchToDocument(openDocuments[prev].id)
+    }
+
     @discardableResult
     func prepareForAppTermination() -> Bool {
         snapshotActiveDocument()
@@ -239,9 +256,10 @@ final class WorkspaceManager {
 
     // MARK: - Open File
 
+    /// Opens a file by replacing the active tab's content (no new tab created).
     @discardableResult
     func openFile(at url: URL) -> Bool {
-        // If already open, just switch to it
+        // If already open in a tab, just switch to it
         if let existing = openDocuments.first(where: { $0.fileURL == url }) {
             return switchToDocument(existing.id)
         }
@@ -250,6 +268,66 @@ final class WorkspaceManager {
         guard saveFileBacked() else { return false }
 
         // Load new file
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            DiagnosticLog.log("Failed to read file: \(url.lastPathComponent)")
+            return false
+        }
+
+        if let idx = activeDocumentIndex {
+            // If the active document is dirty and untitled, prompt before replacing
+            snapshotActiveDocument()
+            let activeDoc = openDocuments[idx]
+            if activeDoc.isDirty && activeDoc.isUntitled {
+                switch promptToSaveChanges(for: activeDoc) {
+                case .save:
+                    guard saveDocument(at: idx, treatCancelAsFailure: true) else { return false }
+                case .discard:
+                    break
+                case .cancel:
+                    return false
+                }
+            }
+            // Replace the active tab's content in place
+            openDocuments[idx].fileURL = url
+            openDocuments[idx].text = text
+            openDocuments[idx].lastSavedText = text
+            openDocuments[idx].untitledNumber = nil
+            currentFileURL = url
+            currentFileText = text
+            lastSavedText = text
+            isDirty = false
+        } else {
+            // No active document — create one
+            let doc = OpenDocument(
+                id: UUID(),
+                fileURL: url,
+                text: text,
+                lastSavedText: text,
+                untitledNumber: nil
+            )
+            openDocuments.append(doc)
+            activateDocument(doc)
+        }
+
+        addToRecents(url)
+        persistLastOpenFile(url)
+
+        DiagnosticLog.log("Opened file: \(url.lastPathComponent)")
+        presentMainWindow()
+        return true
+    }
+
+    /// Opens a file in a new tab (Cmd+click or Cmd+T then navigate).
+    @discardableResult
+    func openFileInNewTab(at url: URL) -> Bool {
+        // If already open in a tab, just switch to it
+        if let existing = openDocuments.first(where: { $0.fileURL == url }) {
+            return switchToDocument(existing.id)
+        }
+
+        guard saveFileBacked() else { return false }
+
         guard let data = try? Data(contentsOf: url),
               let text = String(data: data, encoding: .utf8) else {
             DiagnosticLog.log("Failed to read file: \(url.lastPathComponent)")
@@ -271,7 +349,7 @@ final class WorkspaceManager {
         addToRecents(url)
         persistLastOpenFile(url)
 
-        DiagnosticLog.log("Opened file: \(url.lastPathComponent)")
+        DiagnosticLog.log("Opened file in new tab: \(url.lastPathComponent)")
         presentMainWindow()
         return true
     }
@@ -1022,6 +1100,7 @@ final class WorkspaceManager {
         flushActiveEditorBuffer()
         openDocuments[idx].text = currentFileText
         openDocuments[idx].lastSavedText = lastSavedText
+        openDocuments[idx].viewMode = currentViewMode
     }
 
     private func flushActiveEditorBuffer() {
@@ -1048,6 +1127,7 @@ final class WorkspaceManager {
         currentFileText = doc.text
         lastSavedText = doc.lastSavedText
         isDirty = doc.isDirty
+        currentViewMode = doc.viewMode
     }
 
     /// Set the given document as active and sync stored properties.
@@ -1057,6 +1137,7 @@ final class WorkspaceManager {
         currentFileText = doc.text
         lastSavedText = doc.lastSavedText
         isDirty = doc.isDirty
+        currentViewMode = doc.viewMode
     }
 
     private func persistLastOpenFile(_ url: URL) {


### PR DESCRIPTION
## Summary
- Adds browser-style tab bar that appears when 2+ documents are open, with active tab styling (white raised card), close buttons, and dirty indicators
- Normal sidebar clicks replace the current tab's content; Cmd+click or "Open in New Tab" context menu opens in a new tab; Cmd+T creates a new empty tab
- Per-tab view mode (edit/preview) — each tab remembers its own mode via `OpenDocument.viewMode`, synced through `WorkspaceManager.currentViewMode`
- Keyboard shortcuts: Cmd+W closes active tab, Cmd+Shift+[/] cycles tabs, Cmd+T new tab
- Removes NSToolbar and titlebar safe area gap so tabs sit flush at top of detail pane

## Test plan
- [ ] Open a file, click another file in sidebar — should replace current tab (no tab bar)
- [ ] Cmd+click a file or right-click → "Open in New Tab" — tab bar appears
- [ ] Cmd+T creates empty tab, clicking a file populates it
- [ ] Cmd+W closes active tab; closing last tab shows empty state
- [ ] Cmd+Shift+[ and Cmd+Shift+] cycle between tabs
- [ ] Switch to preview in one tab, switch tabs, come back — mode preserved
- [ ] File menu shows "New Tab" with Cmd+T shortcut

Fixes #129