### PR TITLE
Add line numbers gutter and jump-to-line bar (#128)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -314,15 +314,19 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             return nil
         }
 
-        // Cmd+Shift+L toggles sidebar, Cmd+1/2 switches mode, Cmd+Shift+O toggles outline
+        // Cmd+L toggles sidebar, Cmd+Shift+L jumps to line, Cmd+1/2 switches mode
         sidebarToggleMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
             guard event.type == .keyDown else { return event }
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
 
-            if chars == "l" && mods == [.command, .shift] {
+            if chars == "l" && mods == [.command] {
                 self.doToggleSidebar()
+                return nil
+            }
+            if chars == "l" && mods == [.command, .shift] {
+                NotificationCenter.default.post(name: .init("ClearlyJumpToLine"), object: nil)
                 return nil
             }
             if chars == "1" && mods == [.command] {
@@ -486,7 +490,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         guard !viewMenu.items.contains(where: { $0.title == "Toggle Sidebar" }) else { return }
 
         let sidebarItem = NSMenuItem(title: "Toggle Sidebar", action: #selector(toggleSidebarMenuAction(_:)), keyEquivalent: "l")
-        sidebarItem.keyEquivalentModifierMask = [.command, .shift]
+        sidebarItem.keyEquivalentModifierMask = [.command]
         sidebarItem.target = self
 
         // Insert at the beginning of the View menu
@@ -531,6 +535,9 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         backlinksItem.keyEquivalentModifierMask = [.command, .shift]
         backlinksItem.target = self
 
+        let lineNumbersItem = NSMenuItem(title: "Line Numbers", action: #selector(toggleLineNumbersAction(_:)), keyEquivalent: "")
+        lineNumbersItem.target = self
+
         let editorItem = NSMenuItem(title: "Editor", action: #selector(switchToEditorAction(_:)), keyEquivalent: "1")
         editorItem.keyEquivalentModifierMask = [.command]
         editorItem.target = self
@@ -543,6 +550,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         var insertIndex = 1
         viewMenu.insertItem(outlineItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(backlinksItem, at: insertIndex); insertIndex += 1
+        viewMenu.insertItem(lineNumbersItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
         viewMenu.insertItem(editorItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(previewItem, at: insertIndex)
@@ -562,6 +570,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
     @objc private func toggleBacklinksAction(_ sender: Any?) {
         NotificationCenter.default.post(name: .init("ClearlyToggleBacklinks"), object: nil)
+    }
+
+    @objc private func toggleLineNumbersAction(_ sender: Any?) {
+        NotificationCenter.default.post(name: .init("ClearlyToggleLineNumbers"), object: nil)
     }
 
     private func injectSpellingMenuIfNeeded() {
@@ -645,6 +657,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         if menuItem.action == #selector(exportPDFAction(_:)) ||
            menuItem.action == #selector(printDocumentAction(_:)) {
             return WorkspaceManager.shared.activeDocumentID != nil
+        }
+        if menuItem.action == #selector(toggleLineNumbersAction(_:)) {
+            menuItem.state = UserDefaults.standard.bool(forKey: "showLineNumbers") ? .on : .off
+            return true
         }
         return true
     }

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -31,6 +31,10 @@ struct BacklinksStateKey: FocusedValueKey {
     typealias Value = BacklinksState
 }
 
+struct JumpToLineStateKey: FocusedValueKey {
+    typealias Value = JumpToLineState
+}
+
 extension FocusedValues {
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -56,6 +60,10 @@ extension FocusedValues {
         get { self[BacklinksStateKey.self] }
         set { self[BacklinksStateKey.self] = newValue }
     }
+    var jumpToLineState: JumpToLineState? {
+        get { self[JumpToLineStateKey.self] }
+        set { self[JumpToLineStateKey.self] = newValue }
+    }
 }
 
 struct FocusedValuesModifier: ViewModifier {
@@ -63,6 +71,7 @@ struct FocusedValuesModifier: ViewModifier {
     var findState: FindState
     var outlineState: OutlineState
     var backlinksState: BacklinksState
+    var jumpToLineState: JumpToLineState
 
     func body(content: Content) -> some View {
         content
@@ -72,6 +81,7 @@ struct FocusedValuesModifier: ViewModifier {
             .focusedSceneValue(\.findState, findState)
             .focusedSceneValue(\.outlineState, outlineState)
             .focusedSceneValue(\.backlinksState, backlinksState)
+            .focusedSceneValue(\.jumpToLineState, jumpToLineState)
     }
 }
 
@@ -100,13 +110,15 @@ struct ContentView: View {
     @StateObject private var fileWatcher = FileWatcher()
     @StateObject private var outlineState = OutlineState()
     @StateObject private var backlinksState = BacklinksState()
+    @StateObject private var jumpToLineState = JumpToLineState()
+    @AppStorage("showLineNumbers") private var showLineNumbers = false
 
     private var hasTabBar: Bool { workspace.openDocuments.count >= 2 }
 
     private var editorPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
-        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: hasTabBar ? 16 : 0)
+        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: hasTabBar ? 16 : 0, showLineNumbers: showLineNumbers, jumpToLineState: jumpToLineState)
     }
 
     private var previewPane: some View {
@@ -270,6 +282,13 @@ struct ContentView: View {
                     .fill(Color.primary.opacity(0.08))
                     .frame(height: 1)
             }
+            if jumpToLineState.isVisible {
+                JumpToLineBar(state: jumpToLineState)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                Rectangle()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(height: 1)
+            }
             ZStack {
                 editorPane
                     .opacity(workspace.currentViewMode == .edit ? 1 : 0)
@@ -316,7 +335,7 @@ struct ContentView: View {
     var body: some View {
         mainContent
             .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
-            .modifier(FocusedValuesModifier(workspace: workspace, findState: findState, outlineState: outlineState, backlinksState: backlinksState))
+            .modifier(FocusedValuesModifier(workspace: workspace, findState: findState, outlineState: outlineState, backlinksState: backlinksState, jumpToLineState: jumpToLineState))
             .onAppear {
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
@@ -325,10 +344,15 @@ struct ContentView: View {
             .onChange(of: workspace.activeDocumentID) { _, newID in
                 positionSyncID = UUID().uuidString
                 findState.isVisible = false
+                jumpToLineState.dismiss()
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
                 backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
                 applyPendingWikiNavigationIfNeeded()
+            }
+            .onChange(of: workspace.currentViewMode) { _, newMode in
+                guard newMode != .edit else { return }
+                jumpToLineState.dismiss()
             }
             .onChange(of: workspace.currentFileURL) { _, _ in
                 setupFileWatcher()
@@ -346,6 +370,15 @@ struct ContentView: View {
             .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleBacklinks"))) { _ in
                 withAnimation(Theme.Motion.smooth) {
                     backlinksState.toggle()
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleLineNumbers"))) { _ in
+                showLineNumbers.toggle()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyJumpToLine"))) { _ in
+                guard workspace.currentViewMode == .edit else { return }
+                withAnimation(Theme.Motion.smooth) {
+                    jumpToLineState.present()
                 }
             }
             .onChange(of: workspace.vaultIndexRevision) { _, _ in

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -12,13 +12,15 @@ struct EditorView: NSViewRepresentable {
     var findState: FindState?
     var outlineState: OutlineState?
     var extraTopInset: CGFloat = 0
+    var showLineNumbers: Bool = false
+    var jumpToLineState: JumpToLineState?
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
 
-    func makeNSView(context: Context) -> NSScrollView {
+    func makeNSView(context: Context) -> NSView {
         DiagnosticLog.log("makeNSView: creating EditorView (\(text.count) chars)")
         let scrollView = NSScrollView()
         scrollView.hasVerticalScroller = true
@@ -85,6 +87,13 @@ struct EditorView: NSViewRepresentable {
         }
 
         scrollView.documentView = textView
+
+        // Line number gutter (plain NSView, not NSRulerView)
+        let gutter = LineNumberGutterView()
+        gutter.textView = textView
+        gutter.isHidden = !showLineNumbers
+        context.coordinator.gutterView = gutter
+
         context.coordinator.textView = textView
         context.coordinator.findState = findState
         context.coordinator.outlineState = outlineState
@@ -137,20 +146,68 @@ struct EditorView: NSViewRepresentable {
             object: nil
         )
 
+        // Frame changes (window resize causing rewrap) — trigger gutter redraw
+        textView.postsFrameChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.textViewFrameDidChange(_:)),
+            name: NSView.frameDidChangeNotification,
+            object: textView
+        )
+
+        // Wire jump-to-line
+        if let jumpState = jumpToLineState {
+            let coord = context.coordinator
+            jumpState.onJump = { [weak coord] line in
+                coord?.jumpToLine(line)
+            }
+            jumpState.editorLineInfo = { [weak coord] in
+                coord?.currentLineInfo() ?? (1, 1)
+            }
+        }
+
+        // Container: gutter | scrollView side by side
+        let container = NSView()
+        container.addSubview(gutter)
+        container.addSubview(scrollView)
+
+        // Layout via autoresizing
+        gutter.autoresizingMask = [.height]
+        scrollView.autoresizingMask = [.width, .height]
+
+        let gutterWidth = showLineNumbers ? gutter.preferredWidth() : 0
+        gutter.frame = NSRect(x: 0, y: 0, width: gutterWidth, height: 0)
+        scrollView.frame = NSRect(x: gutterWidth, y: 0, width: 0, height: 0)
+
         DiagnosticLog.log("makeNSView: EditorView ready")
-        return scrollView
+        return container
     }
 
-    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+    static func dismantleNSView(_ container: NSView, coordinator: Coordinator) {
         NotificationCenter.default.removeObserver(coordinator)
         DiagnosticLog.log("dismantleNSView: EditorView torn down")
     }
 
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? ClearlyTextView else { return }
+    func updateNSView(_ container: NSView, context: Context) {
+        guard let scrollView = container.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView,
+              let textView = scrollView.documentView as? ClearlyTextView else { return }
+        let gutter = container.subviews.first(where: { $0 is LineNumberGutterView }) as? LineNumberGutterView
 
         // Keep coordinator's parent fresh so the binding never goes stale
         context.coordinator.parent = self
+
+        // Toggle line number gutter visibility
+        if let gutter {
+            let gutterWidth = showLineNumbers ? gutter.preferredWidth() : 0
+            if gutter.isHidden == showLineNumbers {
+                gutter.isHidden = !showLineNumbers
+            }
+            let expectedGutterWidth = showLineNumbers ? gutterWidth : 0
+            if abs(gutter.frame.width - expectedGutterWidth) > 0.5 || abs(scrollView.frame.minX - expectedGutterWidth) > 0.5 {
+                gutter.frame = NSRect(x: 0, y: 0, width: expectedGutterWidth, height: container.bounds.height)
+                scrollView.frame = NSRect(x: expectedGutterWidth, y: 0, width: container.bounds.width - expectedGutterWidth, height: container.bounds.height)
+            }
+        }
 
         // Update top inset when tab bar appears/disappears
         let expectedInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop + extraTopInset)
@@ -221,6 +278,9 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "appearance")
             context.coordinator.isHighlightingInProgress = false
             context.coordinator.restoreFindHighlightsIfNeeded()
+
+            // Refresh ruler when appearance/font changes
+            context.coordinator.gutterView?.appearanceDidChange()
         }
 
         // Only update text if it changed externally (not from user typing).
@@ -239,6 +299,8 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "externalText")
             context.coordinator.isHighlightingInProgress = false
             context.coordinator.restoreFindHighlightsIfNeeded()
+            context.coordinator.gutterView?.textDidChange()
+            context.coordinator.gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
             context.coordinator.isUpdating = false
         } else if context.coordinator.isUpdating && count <= 5 {
             DiagnosticLog.log("updateNSView #\(count): skipped text check (isUpdating)")
@@ -259,6 +321,7 @@ struct EditorView: NSViewRepresentable {
         var lastEditedRange: NSRange?
         var lastReplacementLength: Int = 0
         weak var textView: NSTextView?
+        weak var gutterView: LineNumberGutterView?
         var lastMode: ViewMode?
         var lastPositionSyncID: String?
         var findState: FindState?
@@ -289,6 +352,11 @@ struct EditorView: NSViewRepresentable {
             textView.showFindIndicator(for: range)
         }
 
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+        }
+
         @objc func handleScrollToLine(_ notification: Notification) {
             guard let line = notification.userInfo?["line"] as? Int,
                   let textView,
@@ -314,6 +382,45 @@ struct EditorView: NSViewRepresentable {
         @objc func flushEditorBuffer(_ notification: Notification) {
             guard let textView else { return }
             parent.text = textView.string
+        }
+
+        @objc func textViewFrameDidChange(_ notification: Notification) {
+            gutterView?.scrollOrFrameDidChange()
+        }
+
+        func jumpToLine(_ line: Int) {
+            guard let textView, line > 0 else { return }
+            let text = textView.string
+            let lines = (text as NSString).components(separatedBy: "\n")
+            let targetLine = min(line, lines.count)
+            var charOffset = 0
+            for i in 0..<(targetLine - 1) {
+                charOffset += (lines[i] as NSString).length + 1
+            }
+            let nsText = text as NSString
+            let location = min(charOffset, nsText.length)
+            let range = NSRange(location: location, length: 0)
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+            if targetLine - 1 < lines.count {
+                let lineLen = (lines[targetLine - 1] as NSString).length
+                let highlightRange = NSRange(location: location, length: min(lineLen, nsText.length - location))
+                textView.showFindIndicator(for: highlightRange)
+            }
+        }
+
+        func currentLineInfo() -> (current: Int, total: Int) {
+            guard let textView else { return (1, 1) }
+            let text = textView.string as NSString
+            let location = min(textView.selectedRange().location, text.length)
+            var lineNumber = 1
+            var i = 0
+            while i < location {
+                if text.character(at: i) == 0x0A { lineNumber += 1 }
+                i += 1
+            }
+            let totalLines = text.components(separatedBy: "\n").count
+            return (lineNumber, totalLines)
         }
 
         func cancelPendingBindingUpdate() {
@@ -398,6 +505,9 @@ struct EditorView: NSViewRepresentable {
 
             // Re-apply find highlights after syntax highlighting
             restoreFindHighlightsIfNeeded()
+
+            // Update line number ruler
+            gutterView?.textDidChange()
 
             // Wiki-link auto-complete trigger/update
             handleWikiLinkCompletion(textView)
@@ -520,6 +630,8 @@ struct EditorView: NSViewRepresentable {
             let viewportHeight = clipView.bounds.height
             let maxScroll = max(1, docHeight - viewportHeight)
             ScrollBridge.setFraction(clipView.bounds.origin.y / maxScroll, for: parent.positionSyncID)
+
+            gutterView?.scrollOrFrameDidChange()
         }
 
         // MARK: - Find

--- a/Clearly/JumpToLineBar.swift
+++ b/Clearly/JumpToLineBar.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct JumpToLineBar: View {
+    @ObservedObject var state: JumpToLineState
+    @FocusState private var isFieldFocused: Bool
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "number")
+                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 12))
+
+                TextField("Line number", text: $state.lineText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13).monospacedDigit())
+                    .focused($isFieldFocused)
+                    .onSubmit {
+                        state.commit()
+                    }
+                    .onExitCommand {
+                        state.dismiss()
+                    }
+                    .onChange(of: state.lineText) { _, newValue in
+                        let filtered = newValue.filter(\.isNumber)
+                        if filtered != newValue {
+                            state.lineText = filtered
+                        }
+                    }
+
+                if state.totalLines > 0 {
+                    Text("of \(state.totalLines)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.accentColor.opacity(isFieldFocused ? 0.4 : 0), lineWidth: 1)
+                    .animation(Theme.Motion.hover, value: isFieldFocused)
+            )
+
+            Button("Go") {
+                state.commit()
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(Color.accentColor)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Theme.backgroundColorSwiftUI)
+        .onAppear {
+            isFieldFocused = true
+        }
+        .onChange(of: state.focusRequest) { _, _ in
+            isFieldFocused = true
+        }
+    }
+}

--- a/Clearly/JumpToLineState.swift
+++ b/Clearly/JumpToLineState.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+final class JumpToLineState: ObservableObject {
+    @Published var isVisible = false
+    @Published var lineText = ""
+    @Published var focusRequest = UUID()
+    var totalLines: Int = 1
+    var onJump: ((Int) -> Void)?
+    var editorLineInfo: (() -> (current: Int, total: Int))?
+
+    func present() {
+        if let info = editorLineInfo?() {
+            totalLines = info.total
+            lineText = "\(info.current)"
+        }
+        isVisible = true
+        focusRequest = UUID()
+    }
+
+    func dismiss() {
+        isVisible = false
+    }
+
+    func commit() {
+        guard let line = Int(lineText), line >= 1 else { return }
+        onJump?(min(line, totalLines))
+        dismiss()
+    }
+}

--- a/Clearly/LineNumberRulerView.swift
+++ b/Clearly/LineNumberRulerView.swift
@@ -1,0 +1,157 @@
+import AppKit
+
+final class LineNumberGutterView: NSView {
+    weak var textView: NSTextView?
+    private var currentLineIndex: Int = 0 // 0-based
+
+    override var isFlipped: Bool { true }
+
+    init() {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.masksToBounds = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Width
+
+    func preferredWidth() -> CGFloat {
+        guard let textView else { return 36 }
+        let lineCount = max(1, (textView.string as NSString).components(separatedBy: "\n").count)
+        let digits = max(2, String(lineCount).count)
+        let charWidth = NSString(string: "8").size(withAttributes: [.font: Theme.editorFont]).width
+        return ceil(CGFloat(digits) * charWidth + 20)
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        Theme.backgroundColor.setFill()
+        dirtyRect.fill()
+
+        guard let textView,
+              let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return }
+
+        let text = textView.string as NSString
+
+        // Convert coordinate systems: gutter ↔ text view
+        let relativePoint = convert(NSZeroPoint, from: textView)
+
+        guard text.length > 0 else {
+            let y = relativePoint.y + textView.textContainerOrigin.y
+            drawLineNumber(1, at: y, isCurrent: true)
+            return
+        }
+
+        guard let scrollView = textView.enclosingScrollView else { return }
+        let visibleRect = scrollView.contentView.bounds
+
+        // Visible glyph range
+        let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textContainer)
+        guard visibleGlyphRange.length > 0 else { return }
+
+        let visibleCharRange = layoutManager.characterRange(forGlyphRange: visibleGlyphRange, actualGlyphRange: nil)
+
+        // Find the logical line number at the start of the visible range
+        var lineNumber = 1
+        var scanIndex = 0
+        let startChar = visibleCharRange.location
+        while scanIndex < startChar {
+            if text.character(at: scanIndex) == 0x0A {
+                lineNumber += 1
+            }
+            scanIndex += 1
+        }
+
+        // Walk back to the start of the first visible logical line
+        var lineStart = startChar
+        if lineStart > 0 {
+            let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            lineStart = lineRange.location
+        }
+
+        let containerOrigin = textView.textContainerOrigin
+
+        // Enumerate logical lines in the visible range
+        var charIndex = lineStart
+        while charIndex <= NSMaxRange(visibleCharRange) && charIndex <= text.length {
+            let lineRange: NSRange
+            if charIndex < text.length {
+                lineRange = text.lineRange(for: NSRange(location: charIndex, length: 0))
+            } else {
+                if layoutManager.extraLineFragmentTextContainer != nil {
+                    let extraRect = layoutManager.extraLineFragmentRect
+                    let y = relativePoint.y + containerOrigin.y + extraRect.origin.y
+                    drawLineNumber(lineNumber, at: y, isCurrent: lineNumber - 1 == currentLineIndex)
+                }
+                break
+            }
+
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: lineRange, actualCharacterRange: nil)
+            guard glyphRange.length > 0 else {
+                charIndex = NSMaxRange(lineRange)
+                lineNumber += 1
+                continue
+            }
+
+            var effectiveRange = NSRange(location: 0, length: 0)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphRange.location, effectiveRange: &effectiveRange, withoutAdditionalLayout: true)
+
+            let y = relativePoint.y + containerOrigin.y + lineRect.origin.y
+            drawLineNumber(lineNumber, at: y, isCurrent: lineNumber - 1 == currentLineIndex)
+
+            charIndex = NSMaxRange(lineRange)
+            lineNumber += 1
+        }
+    }
+
+    private func drawLineNumber(_ number: Int, at y: CGFloat, isCurrent: Bool) {
+        let font = Theme.editorFont
+        let color = isCurrent ? Theme.textColor : Theme.syntaxColor
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color
+        ]
+
+        let string = "\(number)" as NSString
+        let size = string.size(withAttributes: attrs)
+
+        let x = bounds.width - size.width - 8
+        let adjustedY = y + (Theme.editorLineHeight - size.height) / 2
+
+        string.draw(at: NSPoint(x: x, y: adjustedY), withAttributes: attrs)
+    }
+
+    // MARK: - Update triggers
+
+    func textDidChange() {
+        needsDisplay = true
+    }
+
+    func selectionDidChange(selectedRange: NSRange) {
+        guard let textView else { return }
+        let text = textView.string as NSString
+        var line = 0
+        var i = 0
+        let location = min(selectedRange.location, text.length)
+        while i < location {
+            if text.character(at: i) == 0x0A { line += 1 }
+            i += 1
+        }
+        if currentLineIndex != line {
+            currentLineIndex = line
+            needsDisplay = true
+        }
+    }
+
+    func scrollOrFrameDidChange() {
+        needsDisplay = true
+    }
+
+    func appearanceDidChange() {
+        needsDisplay = true
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a toggleable line number gutter (View → Line Numbers, off by default) using a plain NSView alongside the scroll view — highlights current line, dynamic width based on digit count
- Adds Jump to Line bar (Cmd+Shift+L) matching the existing find bar style, pre-populated with current line number, Enter to jump with yellow flash highlight
- Moves sidebar toggle shortcut from Cmd+Shift+L to Cmd+L to free up the shortcut
- Adds "Line Numbers" checkmark menu item in View menu with persistent preference via @AppStorage

## Test plan
- [ ] Toggle View → Line Numbers on/off, verify gutter appears/disappears cleanly
- [ ] Verify line numbers align with editor text and current line is highlighted
- [ ] Type text and confirm numbers update, check digit boundary (e.g. 99→100 widens gutter)
- [ ] Cmd+Shift+L opens Jump to Line bar, type number + Enter jumps to line
- [ ] Cmd+L toggles sidebar (no shortcut conflict)
- [ ] Toggle dark/light mode with line numbers on
- [ ] Change font size with line numbers on

Fixes #128