### PR TITLE
Add preview font picker: San Francisco, New York, SF Mono (#126)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -553,7 +553,20 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         viewMenu.insertItem(lineNumbersItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
         viewMenu.insertItem(editorItem, at: insertIndex); insertIndex += 1
-        viewMenu.insertItem(previewItem, at: insertIndex)
+        viewMenu.insertItem(previewItem, at: insertIndex); insertIndex += 1
+
+        // Preview Font submenu
+        viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
+        let fontSubmenu = NSMenu(title: "Preview Font")
+        for (title, value) in [("San Francisco", "sanFrancisco"), ("New York", "newYork"), ("SF Mono", "sfMono")] {
+            let item = NSMenuItem(title: title, action: #selector(setPreviewFontAction(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = value
+            fontSubmenu.addItem(item)
+        }
+        let fontMenuItem = NSMenuItem(title: "Preview Font", action: nil, keyEquivalent: "")
+        fontMenuItem.submenu = fontSubmenu
+        viewMenu.insertItem(fontMenuItem, at: insertIndex)
     }
 
     @objc private func switchToEditorAction(_ sender: Any?) {
@@ -574,6 +587,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
     @objc private func toggleLineNumbersAction(_ sender: Any?) {
         NotificationCenter.default.post(name: .init("ClearlyToggleLineNumbers"), object: nil)
+    }
+
+    @objc private func setPreviewFontAction(_ sender: NSMenuItem) {
+        guard let value = sender.representedObject as? String else { return }
+        UserDefaults.standard.set(value, forKey: "previewFontFamily")
     }
 
     private func injectSpellingMenuIfNeeded() {
@@ -635,9 +653,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         let workspace = WorkspaceManager.shared
         guard workspace.activeDocumentID != nil else { return }
         let fontSize = UserDefaults.standard.double(forKey: "editorFontSize")
+        let fontFamily = UserDefaults.standard.string(forKey: "previewFontFamily") ?? "sanFrancisco"
         PDFExporter().exportPDF(
             markdown: workspace.currentFileText,
             fontSize: CGFloat(fontSize > 0 ? fontSize : 16),
+            fontFamily: fontFamily,
             fileURL: workspace.currentFileURL
         )
     }
@@ -646,9 +666,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         let workspace = WorkspaceManager.shared
         guard workspace.activeDocumentID != nil else { return }
         let fontSize = UserDefaults.standard.double(forKey: "editorFontSize")
+        let fontFamily = UserDefaults.standard.string(forKey: "previewFontFamily") ?? "sanFrancisco"
         PDFExporter().printHTML(
             markdown: workspace.currentFileText,
             fontSize: CGFloat(fontSize > 0 ? fontSize : 16),
+            fontFamily: fontFamily,
             fileURL: workspace.currentFileURL
         )
     }
@@ -660,6 +682,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         }
         if menuItem.action == #selector(toggleLineNumbersAction(_:)) {
             menuItem.state = UserDefaults.standard.bool(forKey: "showLineNumbers") ? .on : .off
+            return true
+        }
+        if menuItem.action == #selector(setPreviewFontAction(_:)) {
+            let current = UserDefaults.standard.string(forKey: "previewFontFamily") ?? "sanFrancisco"
+            menuItem.state = (menuItem.representedObject as? String) == current ? .on : .off
             return true
         }
         return true

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -117,9 +117,11 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     override func printView(_ sender: Any?) {
         let fontSize = UserDefaults.standard.double(forKey: "editorFontSize")
+        let fontFamily = UserDefaults.standard.string(forKey: "previewFontFamily") ?? "sanFrancisco"
         PDFExporter().printHTML(
             markdown: string,
             fontSize: CGFloat(fontSize > 0 ? fontSize : 16),
+            fontFamily: fontFamily,
             fileURL: documentURL
         )
     }

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -106,6 +106,7 @@ struct ContentView: View {
     @State private var positionSyncID = UUID().uuidString
     @State private var pendingWikiNavigation: PendingWikiNavigation?
     @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("previewFontFamily") private var previewFontFamily = "sanFrancisco"
     @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
     @StateObject private var outlineState = OutlineState()
@@ -139,6 +140,7 @@ struct ContentView: View {
         return PreviewView(
             markdown: workspace.currentFileText,
             fontSize: editorFontSize,
+            fontFamily: previewFontFamily,
             mode: workspace.currentViewMode,
             positionSyncID: positionSyncID,
             fileURL: fileURL,

--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -12,7 +12,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
     private var documentURL: URL?
     private var isPrint = false
 
-    func exportPDF(markdown: String, fontSize: CGFloat, fileURL: URL? = nil) {
+    func exportPDF(markdown: String, fontSize: CGFloat, fontFamily: String = "sanFrancisco", fileURL: URL? = nil) {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.pdf]
         panel.nameFieldStringValue = "Untitled.pdf"
@@ -22,18 +22,18 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         exportURL = url
         documentURL = fileURL
         isPrint = false
-        loadHTML(markdown: markdown, fontSize: fontSize)
+        loadHTML(markdown: markdown, fontSize: fontSize, fontFamily: fontFamily)
     }
 
-    func printHTML(markdown: String, fontSize: CGFloat, fileURL: URL? = nil) {
+    func printHTML(markdown: String, fontSize: CGFloat, fontFamily: String = "sanFrancisco", fileURL: URL? = nil) {
         PDFExporter.current = self
         exportURL = nil
         documentURL = fileURL
         isPrint = true
-        loadHTML(markdown: markdown, fontSize: fontSize)
+        loadHTML(markdown: markdown, fontSize: fontSize, fontFamily: fontFamily)
     }
 
-    private func loadHTML(markdown: String, fontSize: CGFloat) {
+    private func loadHTML(markdown: String, fontSize: CGFloat, fontFamily: String = "sanFrancisco") {
         // Both print and export use full page width — NSPrintOperation handles margins
         let renderWidth = Self.pageSize.width
         let config = WKWebViewConfiguration()
@@ -60,7 +60,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         <html>
         <head>
         <meta charset="utf-8">
-        <style>\(PreviewCSS.css(fontSize: fontSize, forExport: false))</style>
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, forExport: false))</style>
         </head>
         <body>\(htmlBody)</body>
         \(MathSupport.scriptHTML(for: htmlBody))

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -5,6 +5,7 @@ import Combine
 struct PreviewView: NSViewRepresentable {
     let markdown: String
     var fontSize: CGFloat = 18
+    var fontFamily: String = "sanFrancisco"
     var mode: ViewMode
     var positionSyncID: String
     var fileURL: URL?
@@ -19,7 +20,7 @@ struct PreviewView: NSViewRepresentable {
     @Environment(\.colorScheme) private var colorScheme
 
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)"
+        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)"
     }
 
     private var wikiFilesKey: String {
@@ -152,7 +153,7 @@ struct PreviewView: NSViewRepresentable {
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css(fontSize: fontSize))
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily))
         mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
         mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
         @media (prefers-color-scheme: dark) {

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     let updater: SPUUpdater
     #endif
     @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("previewFontFamily") private var previewFontFamily = "sanFrancisco"
     @AppStorage("themePreference") private var themePreference = "system"
     @AppStorage("launchBehavior") private var launchBehavior = "lastFile"
 
@@ -54,6 +55,11 @@ struct SettingsView: View {
                     .font(.system(size: 13, weight: .medium))
                     .monospacedDigit()
                     .frame(width: 30, alignment: .trailing)
+            }
+            Picker("Preview Font", selection: $previewFontFamily) {
+                Text("San Francisco").tag("sanFrancisco")
+                Text("New York").tag("newYork")
+                Text("SF Mono").tag("sfMono")
             }
             KeyboardShortcuts.Recorder("New Scratchpad:", name: .newScratchpad)
             Toggle("Launch at Login", isOn: $launchAtLogin)

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -1,7 +1,20 @@
 import Foundation
 
 enum PreviewCSS {
-    static func css(fontSize: CGFloat = 18, forExport: Bool = false) -> String {
+    static func css(fontSize: CGFloat = 18, fontFamily: String = "sanFrancisco", forExport: Bool = false) -> String {
+    let bodyFontFamily: String
+    let headingFontFamily: String
+    switch fontFamily {
+    case "newYork":
+        bodyFontFamily = "\"New York\", \"Iowan Old Style\", Georgia, serif"
+        headingFontFamily = "\"New York\", \"Iowan Old Style\", Georgia, serif"
+    case "sfMono":
+        bodyFontFamily = "\"SF Mono\", SFMono-Regular, Menlo, monospace"
+        headingFontFamily = "\"SF Mono\", SFMono-Regular, Menlo, monospace"
+    default:
+        bodyFontFamily = "system-ui, -apple-system, BlinkMacSystemFont, \"SF Pro Text\", \"SF Pro Display\", \"Helvetica Neue\", sans-serif"
+        headingFontFamily = "system-ui, -apple-system, BlinkMacSystemFont, \"SF Pro Display\", \"Helvetica Neue\", sans-serif"
+    }
     let exportOverrides = forExport ? """
     .wiki-link { color: #34855A !important; border-bottom: none !important; }
     .wiki-link-broken { color: #B35C3A !important; border-bottom: none !important; }
@@ -108,7 +121,7 @@ enum PreviewCSS {
     }
 
     body {
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", sans-serif;
+        font-family: \(bodyFontFamily);
         font-size: \(Int(fontSize))px;
         line-height: 1.75;
         max-width: 61em;
@@ -121,7 +134,7 @@ enum PreviewCSS {
     }
 
     h1, h2, h3, h4, h5, h6 {
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+        font-family: \(headingFontFamily);
         line-height: 1.25;
         margin-top: 2em;
         margin-bottom: 0.75em;


### PR DESCRIPTION
## Summary
- Adds a preview font family setting with three choices: San Francisco (sans-serif), New York (serif), and SF Mono (monospace)
- Accessible from Settings > General picker and View > Preview Font submenu with checkmarks
- Applies to in-app preview, PDF export, and print — editor stays monospace
- Code blocks always render in SF Mono regardless of choice

Fixes #126