### PR TITLE
Fix app freeze on large vaults (#132)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen
 
 **Key pattern**: The editor uses AppKit (`NSTextView`) bridged to SwiftUI via `NSViewRepresentable`, not SwiftUI's `TextEditor`. This is intentional — it provides undo support, find panel, and `NSTextStorageDelegate`-based syntax highlighting.
 
+**Threading rule for `FileNode.buildTree()`**: This method does recursive filesystem I/O and must never run on the main thread. Use `WorkspaceManager.loadTree(for:at:reindex:)` which dispatches to a background queue, guards against stale completions via a generation counter, and assigns the result on main. The same applies to any new code that calls `FileManager.contentsOfDirectory` over potentially large directory trees.
+
 **NSViewRepresentable binding gotcha**: SwiftUI can call `updateNSView` at any time — layout passes, state changes, etc. — not just in response to binding changes. When the user types, the text view's content changes immediately but the `@Binding` update is async. If `updateNSView` fires in between, it sees a mismatch and overwrites the text view with the stale binding value, causing the cursor to jump. A simple `isUpdating` boolean set inside the async block does NOT protect against this because SwiftUI defers the actual `updateNSView` call past the flag's lifetime. The fix is `pendingBindingUpdates` — a counter incremented synchronously in `textDidChange` and decremented in the async block. `updateNSView` skips text replacement while this counter is > 0. This pattern applies to any `NSViewRepresentable` that pushes changes from the AppKit side back to SwiftUI bindings asynchronously.
 
 ## Dual Distribution: Sparkle + App Store

--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -442,7 +442,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             let locCount = workspace.locations.count
             let recCount = workspace.recentFiles.count
             let openCount = workspace.openDocuments.count
-            let treeHash = workspace.locations.reduce(0) { $0 ^ $1.fileTree.hashValue }
+            let treeHash = workspace.treeRevision
             let activeID = workspace.activeDocumentID
             let vaultRev = workspace.vaultIndexRevision
 

--- a/Clearly/SidebarViewController.swift
+++ b/Clearly/SidebarViewController.swift
@@ -57,6 +57,7 @@ class SidebarViewController: NSViewController {
         outlineView.floatsGroupRows = false
         outlineView.intercellSpacing = NSSize(width: 0, height: 0)
         outlineView.backgroundColor = .clear
+        outlineView.autoresizesOutlineColumn = false
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("name"))
         column.isEditable = false

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -718,10 +718,9 @@ final class VaultIndex: @unchecked Sendable {
 
         var files: [URL] = []
         for case let url as URL in enumerator {
+            guard FileNode.markdownExtensions.contains(url.pathExtension.lowercased()) else { continue }
             guard let isFile = try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isFile else { continue }
-            if FileNode.markdownExtensions.contains(url.pathExtension.lowercased()) {
-                files.append(url)
-            }
+            files.append(url)
         }
         return files
     }

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -39,12 +39,15 @@ final class WorkspaceManager {
 
     private var fsStreams: [UUID: FSEventStreamRef] = [:]
     @ObservationIgnored private var vaultIndexes: [UUID: VaultIndex] = [:]
+    @ObservationIgnored private var refreshWork: [UUID: DispatchWorkItem] = [:]
+    @ObservationIgnored private var treeBuildGeneration: [UUID: Int] = [:]
     private var autoSaveWork: DispatchWorkItem?
     private var lastSavedText: String = ""
     private var accessedURLs: Set<URL> = []
 
     var activeVaultIndexes: [VaultIndex] { Array(vaultIndexes.values) }
     private(set) var vaultIndexRevision: Int = 0
+    private(set) var treeRevision: Int = 0
 
     // MARK: - UserDefaults Keys
 
@@ -89,6 +92,7 @@ final class WorkspaceManager {
 
     deinit {
         autoSaveWork?.cancel()
+        refreshWork.values.forEach { $0.cancel() }
         for index in vaultIndexes.values { index.close() }
         vaultIndexes.removeAll()
         stopAllFSStreams()
@@ -107,8 +111,10 @@ final class WorkspaceManager {
     func toggleShowHiddenFiles() {
         showHiddenFiles.toggle()
         UserDefaults.standard.set(showHiddenFiles, forKey: Self.showHiddenFilesKey)
-        for index in locations.indices {
-            locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
+        for location in locations {
+            refreshWork[location.id]?.cancel()
+            refreshWork.removeValue(forKey: location.id)
+            loadTree(for: location.id, at: location.url)
         }
         reindexAllVaults()
     }
@@ -567,6 +573,31 @@ final class WorkspaceManager {
         return nil
     }
 
+    private func nextTreeBuildGeneration(for locationID: UUID) -> Int {
+        let generation = (treeBuildGeneration[locationID] ?? 0) + 1
+        treeBuildGeneration[locationID] = generation
+        return generation
+    }
+
+    private func loadTree(for locationID: UUID, at url: URL, reindex index: VaultIndex? = nil) {
+        let generation = nextTreeBuildGeneration(for: locationID)
+        let showHidden = showHiddenFiles
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let tree = FileNode.buildTree(at: url, showHiddenFiles: showHidden)
+            DispatchQueue.main.async {
+                guard let self,
+                      self.treeBuildGeneration[locationID] == generation,
+                      let idx = self.locations.firstIndex(where: { $0.id == locationID }) else { return }
+                self.locations[idx].fileTree = tree
+                self.treeRevision += 1
+                if let index {
+                    self.reindexVault(index)
+                }
+            }
+        }
+    }
+
     // MARK: - Locations
 
     func addLocation(url: URL) {
@@ -585,11 +616,10 @@ final class WorkspaceManager {
         }
         accessedURLs.insert(url)
 
-        let tree = FileNode.buildTree(at: url, showHiddenFiles: showHiddenFiles)
         let location = BookmarkedLocation(
             url: url,
             bookmarkData: bookmarkData,
-            fileTree: tree,
+            fileTree: [],
             isAccessible: true
         )
         locations.append(location)
@@ -598,10 +628,12 @@ final class WorkspaceManager {
         openVaultIndex(for: location)
 
         DiagnosticLog.log("Added location: \(url.lastPathComponent)")
+        loadTree(for: location.id, at: url)
     }
 
     func removeLocation(_ location: BookmarkedLocation) {
         stopFSStream(for: location.id)
+        treeBuildGeneration.removeValue(forKey: location.id)
         vaultIndexes[location.id]?.close()
         vaultIndexes.removeValue(forKey: location.id)
         vaultIndexRevision += 1
@@ -614,11 +646,21 @@ final class WorkspaceManager {
     }
 
     func refreshTree(for locationID: UUID) {
-        guard let index = locations.firstIndex(where: { $0.id == locationID }) else { return }
-        locations[index].fileTree = FileNode.buildTree(at: locations[index].url, showHiddenFiles: showHiddenFiles)
+        refreshWork[locationID]?.cancel()
 
-        // Re-index on file system changes (hash check makes this efficient)
-        reindexVault(vaultIndexes[locationID])
+        let work = DispatchWorkItem { [weak self] in
+            guard let self,
+                  let idx = self.locations.firstIndex(where: { $0.id == locationID }) else { return }
+            self.refreshWork.removeValue(forKey: locationID)
+            self.loadTree(
+                for: locationID,
+                at: self.locations[idx].url,
+                reindex: self.vaultIndexes[locationID]
+            )
+        }
+
+        refreshWork[locationID] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
     }
 
     // MARK: - Recents
@@ -879,17 +921,17 @@ final class WorkspaceManager {
             guard url.startAccessingSecurityScopedResource() else { continue }
             accessedURLs.insert(url)
 
-            let tree = FileNode.buildTree(at: url, showHiddenFiles: showHiddenFiles)
             let location = BookmarkedLocation(
                 id: bookmark.id,
                 url: url,
                 bookmarkData: bookmarkData,
-                fileTree: tree,
+                fileTree: [],
                 isAccessible: true
             )
             locations.append(location)
             startFSStream(for: location)
             openVaultIndex(for: location)
+            loadTree(for: bookmark.id, at: url)
         }
 
         if !stored.isEmpty {
@@ -1034,6 +1076,9 @@ final class WorkspaceManager {
     }
 
     private func stopFSStream(for locationID: UUID) {
+        refreshWork[locationID]?.cancel()
+        refreshWork.removeValue(forKey: locationID)
+        treeBuildGeneration.removeValue(forKey: locationID)
         guard let stream = fsStreams.removeValue(forKey: locationID) else { return }
         FSEventStreamStop(stream)
         FSEventStreamInvalidate(stream)


### PR DESCRIPTION
## Summary

- Moved all `FileNode.buildTree()` calls off the main thread to background queues, fixing UI freezes when adding locations with 84+ folders. Locations now appear immediately with an empty tree that populates progressively.
- Added 0.3s debounce on FSEventStream-triggered tree refreshes so rapid filesystem changes coalesce into a single rebuild instead of cascading main-thread blocks.
- Replaced the O(n) recursive `fileTree.hashValue` computation (running every 0.25s in sidebar polling) with an O(1) `treeRevision` counter.
- Optimized `collectMarkdownFiles` to check file extensions before making `resourceValues` syscalls, skipping non-markdown files earlier.

## Test plan

- [ ] Add a vault with 84+ folders — UI should stay responsive, sidebar populates progressively
- [ ] Relaunch app with large vault saved — no freeze on startup
- [ ] Toggle "Show Hidden Files" with large vault — no freeze
- [ ] Make rapid file changes in a vault folder — sidebar updates once, not per-change
- [ ] Open Quick Switcher before tree loads — shows results once index is ready
- [ ] Remove and re-add a location — no crash from stale state

Fixes #132