### PR TITLE
Prioritize Direct Download over Mac App Store on website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -103,12 +103,14 @@
                     Write with syntax highlighting. Link your thoughts. Search everything. Preview beautifully. Free and open source.
                 </p>
                 <div class="mt-8 flex flex-wrap items-center justify-center gap-4">
-                    <a href="https://apps.apple.com/app/clearly-markdown/id6760669470" class="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-white text-zinc-950 text-sm font-medium hover:bg-zinc-200 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">
-                        <svg width="14" height="14" viewBox="0 0 814 1000" fill="currentColor"><path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57.8-155.5-127.4c-58.5-81.7-105.3-209-105.3-329.1 0-193.1 125.6-295.7 249.2-295.7 65.7 0 120.5 43.2 161.7 43.2 39.2 0 100.4-45.8 174.5-45.8 28.2 0 129.3 2.6 196.3 99.8zm-135.5-183.1c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.2 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
-                        Mac App Store
+                    <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg" class="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-white text-zinc-950 text-sm font-medium hover:bg-zinc-200 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11.251.068a.5.5 0 0 1 .227.58L9.677 6.5H13a.5.5 0 0 1 .364.843l-8 8.5a.5.5 0 0 1-.842-.49L6.323 9.5H3a.5.5 0 0 1-.364-.843l8-8.5a.5.5 0 0 1 .615-.09z"/></svg>
+                        Direct Download
                     </a>
-                    <a href="https://github.com/Shpigford/clearly/releases/latest/download/Clearly.dmg" class="text-sm text-zinc-400 hover:text-white transition-colors">Direct Download</a>
-                    <a href="https://github.com/Shpigford/clearly" class="text-sm text-zinc-500 hover:text-zinc-300 transition-colors">GitHub</a>
+                    <a href="https://apps.apple.com/app/clearly-markdown/id6760669470" class="text-sm text-zinc-400 hover:text-white transition-colors">Mac App Store</a>
+                    <a href="https://github.com/Shpigford/clearly" class="text-zinc-500 hover:text-zinc-300 transition-colors" aria-label="GitHub">
+                        <svg width="18" height="18" viewBox="0 0 98 96" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"/></svg>
+                    </a>
                 </div>
                 <p class="mt-4 text-sm text-zinc-700">Requires macOS Sonoma or later.</p>
             </div>


### PR DESCRIPTION
## Summary
- Direct Download (DMG) is now the primary CTA button, replacing Mac App Store
- Mac App Store demoted to a secondary text link
- GitHub text link replaced with the octocat icon for a cleaner layout