### PR TITLE
Validate directory access when restoring location bookmarks

### DIFF
--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -902,6 +902,7 @@ final class WorkspaceManager {
         guard let data = UserDefaults.standard.data(forKey: Self.locationBookmarksKey),
               let stored = try? JSONDecoder().decode([StoredBookmark].self, from: data) else { return }
 
+        var didRefreshBookmarks = false
         for bookmark in stored {
             var isStale = false
             guard let url = try? URL(
@@ -915,11 +916,22 @@ final class WorkspaceManager {
             if isStale {
                 if let refreshed = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil) {
                     bookmarkData = refreshed
+                    didRefreshBookmarks = true
                 }
             }
 
             guard url.startAccessingSecurityScopedResource() else { continue }
             accessedURLs.insert(url)
+
+            // Verify we can actually read the directory — stale bookmarks can resolve
+            // and grant scoped access but still fail at the filesystem level (e.g. after
+            // an app upgrade or iCloud permission change).
+            if (try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)) == nil {
+                DiagnosticLog.log("Location bookmark resolved but directory unreadable, skipping: \(url.lastPathComponent)")
+                url.stopAccessingSecurityScopedResource()
+                accessedURLs.remove(url)
+                continue
+            }
 
             let location = BookmarkedLocation(
                 id: bookmark.id,
@@ -934,8 +946,8 @@ final class WorkspaceManager {
             loadTree(for: bookmark.id, at: url)
         }
 
-        if !stored.isEmpty {
-            persistLocations() // Re-persist in case any bookmarks were refreshed
+        if didRefreshBookmarks {
+            persistLocations()
         }
         persistVaultsConfig()
     }


### PR DESCRIPTION
## Summary
- Stale security-scoped bookmarks (e.g. from app upgrades) can resolve and start access successfully but still fail at the filesystem level. This caused broken vault indexing, non-functional wiki-links/tags, and potential app freezes.
- After `startAccessingSecurityScopedResource()` succeeds, we now verify the directory is actually readable before proceeding. Unreadable locations are skipped and logged.
- Also fixes unnecessary `persistLocations()` call on every launch — now only persists when a stale bookmark was actually refreshed.

Fixes #154

## Test plan
- [ ] Add a vault folder, quit the app, revoke folder access (e.g. move the folder), relaunch — verify the location is silently skipped and the app doesn't freeze
- [ ] Add a vault folder normally — verify wiki-links, tags, and file tree all work as expected
- [ ] Upgrade from an older version with an existing vault — verify the vault is restored correctly