### PR TITLE
Fix traffic light buttons overlapping editor content

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -118,6 +118,11 @@ struct ContentView: View {
 
     private var hasTabBar: Bool { workspace.openDocuments.count >= 2 }
 
+    /// Extra leading space to clear traffic lights when sidebar is hidden and no tab bar is present
+    private var trafficLightInset: CGFloat {
+        (!workspace.isSidebarVisible && !hasTabBar) ? 90 : 0
+    }
+
     private var contentExtraTopInset: CGFloat {
         var inset: CGFloat = hasTabBar ? 16 : 0
         if isFullscreen { inset += 16 }
@@ -127,7 +132,7 @@ struct ContentView: View {
     private var editorPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
-        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: contentExtraTopInset, showLineNumbers: showLineNumbers, jumpToLineState: jumpToLineState)
+        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: contentExtraTopInset, showLineNumbers: showLineNumbers, jumpToLineState: jumpToLineState, needsTrafficLightClearance: !workspace.isSidebarVisible && !hasTabBar)
     }
 
     private var previewPane: some View {
@@ -287,6 +292,7 @@ struct ContentView: View {
         return VStack(spacing: 0) {
             if findState.isVisible {
                 FindBarView(findState: findState)
+                    .padding(.leading, trafficLightInset)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 Rectangle()
                     .fill(Color.primary.opacity(0.08))
@@ -294,6 +300,7 @@ struct ContentView: View {
             }
             if jumpToLineState.isVisible {
                 JumpToLineBar(state: jumpToLineState)
+                    .padding(.leading, trafficLightInset)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 Rectangle()
                     .fill(Color.primary.opacity(0.08))

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -14,6 +14,7 @@ struct EditorView: NSViewRepresentable {
     var extraTopInset: CGFloat = 0
     var showLineNumbers: Bool = false
     var jumpToLineState: JumpToLineState?
+    var needsTrafficLightClearance: Bool = false
     @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
@@ -56,7 +57,8 @@ struct EditorView: NSViewRepresentable {
         ]
 
         // Insets
-        textView.textContainerInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop + extraTopInset)
+        let horizontalInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
+        textView.textContainerInset = NSSize(width: horizontalInset, height: Theme.editorInsetTop + extraTopInset)
         textView.textContainer?.lineFragmentPadding = 0
 
         // Layout
@@ -210,7 +212,8 @@ struct EditorView: NSViewRepresentable {
         }
 
         // Update top inset when tab bar appears/disappears
-        let expectedInset = NSSize(width: Theme.editorInsetX, height: Theme.editorInsetTop + extraTopInset)
+        let horizontalInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
+        let expectedInset = NSSize(width: horizontalInset, height: Theme.editorInsetTop + extraTopInset)
         if textView.textContainerInset != expectedInset {
             textView.textContainerInset = expectedInset
         }


### PR DESCRIPTION
## Summary
- Adds left padding to Find bar and Go-to-line bar to clear traffic light buttons when sidebar is hidden and no tab bar is present
- Increases editor text container horizontal inset by 20pt under the same conditions so text doesn't render behind the window buttons

Fixes #153