### PR TITLE
Toggle Go to Line and Find bars with keyboard shortcuts

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -1202,7 +1202,7 @@ struct FindCommand: View {
 
     var body: some View {
         Button("Find…") {
-            findState?.present()
+            findState?.toggle()
         }
         .keyboardShortcut("f", modifiers: .command)
     }

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -267,7 +267,7 @@ struct ContentView: View {
                 .help("Document Outline (Shift+Cmd+O)")
 
                 Button {
-                    findState.present()
+                    findState.toggle()
                 } label: {
                     Image(systemName: "magnifyingglass")
                 }
@@ -373,7 +373,7 @@ struct ContentView: View {
             }
             .onChange(of: workspace.activeDocumentID) { _, newID in
                 positionSyncID = UUID().uuidString
-                findState.isVisible = false
+                findState.dismiss()
                 jumpToLineState.dismiss()
                 setupFileWatcher()
                 outlineState.parseHeadings(from: workspace.currentFileText)
@@ -408,7 +408,7 @@ struct ContentView: View {
             .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyJumpToLine"))) { _ in
                 guard workspace.currentViewMode == .edit else { return }
                 withAnimation(Theme.Motion.smooth) {
-                    jumpToLineState.present()
+                    jumpToLineState.toggle()
                 }
             }
             .onChange(of: workspace.vaultIndexRevision) { _, _ in

--- a/Clearly/FindBarView.swift
+++ b/Clearly/FindBarView.swift
@@ -24,7 +24,7 @@ struct FindBarView: View {
                         }
                     }
                     .onExitCommand {
-                        findState.isVisible = false
+                        findState.dismiss()
                     }
 
                 if !findState.query.isEmpty {
@@ -62,7 +62,7 @@ struct FindBarView: View {
             }
 
             Button("Done") {
-                findState.isVisible = false
+                findState.dismiss()
             }
             .buttonStyle(.plain)
             .font(.system(size: 12, weight: .medium))

--- a/Clearly/FindState.swift
+++ b/Clearly/FindState.swift
@@ -31,8 +31,20 @@ final class FindState: ObservableObject {
         }
     }
 
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            present()
+        }
+    }
+
     func present() {
         isVisible = true
         focusRequest = UUID()
+    }
+
+    func dismiss() {
+        isVisible = false
     }
 }

--- a/Clearly/JumpToLineState.swift
+++ b/Clearly/JumpToLineState.swift
@@ -8,6 +8,14 @@ final class JumpToLineState: ObservableObject {
     var onJump: ((Int) -> Void)?
     var editorLineInfo: (() -> (current: Int, total: Int))?
 
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            present()
+        }
+    }
+
     func present() {
         if let info = editorLineInfo?() {
             totalLines = info.total

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -902,7 +902,7 @@ final class WorkspaceManager {
         guard let data = UserDefaults.standard.data(forKey: Self.locationBookmarksKey),
               let stored = try? JSONDecoder().decode([StoredBookmark].self, from: data) else { return }
 
-        var didRefreshBookmarks = false
+        var didMutateStoredBookmarks = false
         for bookmark in stored {
             var isStale = false
             guard let url = try? URL(
@@ -910,28 +910,24 @@ final class WorkspaceManager {
                 options: .withSecurityScope,
                 relativeTo: nil,
                 bookmarkDataIsStale: &isStale
-            ) else { continue }
+            ) else {
+                didMutateStoredBookmarks = true
+                continue
+            }
 
             var bookmarkData = bookmark.bookmarkData
             if isStale {
                 if let refreshed = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil) {
                     bookmarkData = refreshed
-                    didRefreshBookmarks = true
+                    didMutateStoredBookmarks = true
                 }
             }
 
-            guard url.startAccessingSecurityScopedResource() else { continue }
-            accessedURLs.insert(url)
-
-            // Verify we can actually read the directory — stale bookmarks can resolve
-            // and grant scoped access but still fail at the filesystem level (e.g. after
-            // an app upgrade or iCloud permission change).
-            if (try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)) == nil {
-                DiagnosticLog.log("Location bookmark resolved but directory unreadable, skipping: \(url.lastPathComponent)")
-                url.stopAccessingSecurityScopedResource()
-                accessedURLs.remove(url)
+            guard url.startAccessingSecurityScopedResource() else {
+                didMutateStoredBookmarks = true
                 continue
             }
+            accessedURLs.insert(url)
 
             let location = BookmarkedLocation(
                 id: bookmark.id,
@@ -944,12 +940,32 @@ final class WorkspaceManager {
             startFSStream(for: location)
             openVaultIndex(for: location)
             loadTree(for: bookmark.id, at: url)
+            validateRestoredLocationAccess(for: location)
         }
 
-        if didRefreshBookmarks {
+        if didMutateStoredBookmarks {
             persistLocations()
         }
         persistVaultsConfig()
+    }
+
+    private func validateRestoredLocationAccess(for location: BookmarkedLocation) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let canReadDirectory = (try? FileManager.default.contentsOfDirectory(
+                at: location.url,
+                includingPropertiesForKeys: nil,
+                options: []
+            )) != nil
+
+            guard !canReadDirectory else { return }
+
+            DispatchQueue.main.async {
+                guard let self,
+                      let existing = self.locations.first(where: { $0.id == location.id }) else { return }
+                DiagnosticLog.log("Location bookmark unreadable after restore, removing: \(existing.url.lastPathComponent)")
+                self.removeLocation(existing)
+            }
+        }
     }
 
     // MARK: - Persistence: Recents


### PR DESCRIPTION
## Summary
- Cmd+Shift+L now toggles the Go to Line bar open/closed instead of only opening it
- Cmd+F now toggles the Find bar open/closed instead of only opening it
- Toolbar search button also toggles the Find bar
- Adds `toggle()` and `dismiss()` methods to both `JumpToLineState` and `FindState`

Fixes #152

## Test plan
- [ ] Cmd+Shift+L opens Go to Line bar, pressing again closes it
- [ ] Escape closes the Go to Line bar
- [ ] Cmd+F opens Find bar, pressing again closes it
- [ ] Escape closes the Find bar
- [ ] Toolbar magnifying glass icon toggles the Find bar