### PR TITLE
Add first-run welcome view and Getting Started document

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -395,7 +395,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             if isDir.boolValue {
                 openedDirectory = true
                 if !workspace.locations.contains(where: { $0.url == url }) {
-                    workspace.addLocation(url: url)
+                    let shouldShowGettingStarted = workspace.isFirstRun
+                    if workspace.addLocation(url: url), shouldShowGettingStarted {
+                        workspace.handleFirstLocationIfNeeded(folderURL: url)
+                    }
                 }
             } else {
                 openedFile = workspace.openFileInNewTab(at: url) || openedFile
@@ -931,6 +934,8 @@ struct DetailView: View {
 
             if workspace.activeDocumentID != nil {
                 ContentView(workspace: workspace)
+            } else if workspace.isFirstRun && workspace.locations.isEmpty {
+                WelcomeView(workspace: workspace)
             } else {
                 NoFileView(workspace: workspace)
             }
@@ -1238,7 +1243,7 @@ struct ViewModeCommands: View {
 // MARK: - Font Size Commands
 
 struct FontSizeCommands: View {
-    @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("editorFontSize") private var fontSize: Double = 12
 
     var body: some View {
         Button("Increase Font Size") {

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
     @Bindable var workspace: WorkspaceManager
     @State private var positionSyncID = UUID().uuidString
     @State private var pendingWikiNavigation: PendingWikiNavigation?
-    @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("editorFontSize") private var fontSize: Double = 12
     @AppStorage("previewFontFamily") private var previewFontFamily = "sanFrancisco"
     @StateObject private var findState = FindState()
     @StateObject private var fileWatcher = FileWatcher()
@@ -202,7 +202,21 @@ struct ContentView: View {
 
     private func bottomBar(words: Int, chars: Int) -> some View {
         HStack(spacing: 0) {
-            // Edit/Preview on the left
+            // Sidebar toggle + Edit/Preview on the left
+            Button {
+                if let splitVC = NSApp.mainWindow?.contentViewController as? ClearlySplitViewController {
+                    let isCollapsed = splitVC.splitViewItems.first?.isCollapsed ?? true
+                    splitVC.setSidebarVisible(isCollapsed, animated: true)
+                    workspace.isSidebarVisible = isCollapsed
+                    UserDefaults.standard.set(isCollapsed, forKey: "sidebarVisible")
+                }
+            } label: {
+                Image(systemName: "sidebar.left")
+            }
+            .buttonStyle(ClearlyToolbarButtonStyle(isActive: workspace.isSidebarVisible))
+            .help("Toggle Sidebar (Cmd+L)")
+            .padding(.leading, 12)
+
             ClearlySegmentedControl(
                 selection: $workspace.currentViewMode,
                 items: [
@@ -210,7 +224,7 @@ struct ContentView: View {
                     (value: .preview, icon: "eye", label: "Preview")
                 ]
             )
-            .padding(.leading, 12)
+            .padding(.leading, 4)
 
             Spacer()
 

--- a/Clearly/ScratchpadContentView.swift
+++ b/Clearly/ScratchpadContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ScratchpadContentView: View {
     @Binding var text: String
-    @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("editorFontSize") private var fontSize: Double = 12
     var onSave: (() -> Void)?
 
     var body: some View {

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -9,7 +9,7 @@ struct SettingsView: View {
     #if canImport(Sparkle)
     let updater: SPUUpdater
     #endif
-    @AppStorage("editorFontSize") private var fontSize: Double = 16
+    @AppStorage("editorFontSize") private var fontSize: Double = 12
     @AppStorage("previewFontFamily") private var previewFontFamily = "sanFrancisco"
     @AppStorage("themePreference") private var themePreference = "system"
     @AppStorage("launchBehavior") private var launchBehavior = "lastFile"

--- a/Clearly/Theme.swift
+++ b/Clearly/Theme.swift
@@ -5,7 +5,7 @@ enum Theme {
     // MARK: - Editor Font
     static var editorFontSize: CGFloat {
         let size = UserDefaults.standard.double(forKey: "editorFontSize")
-        return size > 0 ? CGFloat(size) : 16
+        return size > 0 ? CGFloat(size) : 12
     }
     static var editorFont: NSFont { NSFont.monospacedSystemFont(ofSize: editorFontSize, weight: .regular) }
     static var editorFontSwiftUI: Font { Font.system(size: editorFontSize, design: .monospaced) }

--- a/Clearly/WelcomeView.swift
+++ b/Clearly/WelcomeView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import AppKit
+
+struct WelcomeView: View {
+    var workspace: WorkspaceManager
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack(spacing: 0) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 64, height: 64)
+                    .padding(.bottom, 16)
+
+                Text("Welcome to Clearly")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .tracking(-0.3)
+                    .padding(.bottom, 6)
+
+                Text("A quiet place for your markdown and your thinking.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 36)
+
+                HStack(spacing: 16) {
+                    WelcomePathCard(
+                        icon: "folder.badge.plus",
+                        title: "Add a Folder",
+                        description: "Point Clearly at a folder of markdown files to unlock the sidebar, backlinks, tags, and search.",
+                        isPrimary: true,
+                        colorScheme: colorScheme
+                    ) {
+                        showFolderPicker()
+                    }
+
+                    WelcomePathCard(
+                        icon: "doc.text",
+                        title: "Quick Edit",
+                        description: "Start writing right away with a blank document, or open an existing file.",
+                        isPrimary: false,
+                        colorScheme: colorScheme
+                    ) {
+                        workspace.createUntitledDocument()
+                    }
+                }
+                .frame(maxWidth: 520)
+
+                Button("or open an existing file\u{2026}") {
+                    workspace.showOpenPanel()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .padding(.top, 14)
+            }
+            .position(x: geo.size.width / 2, y: geo.size.height * 0.42)
+        }
+        .background(Theme.backgroundColorSwiftUI)
+    }
+
+    private func showFolderPicker() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.message = "Choose a folder of markdown files"
+        panel.prompt = "Add Folder"
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard !workspace.locations.contains(where: { $0.url == url }) else { return }
+
+        let shouldShowGettingStarted = workspace.isFirstRun
+        guard workspace.addLocation(url: url) else { return }
+        if shouldShowGettingStarted {
+            workspace.handleFirstLocationIfNeeded(folderURL: url)
+        }
+
+        // Show sidebar by finding the split view controller through the window hierarchy
+        if let splitVC = NSApp.mainWindow?.contentViewController as? ClearlySplitViewController {
+            splitVC.setSidebarVisible(true, animated: false)
+        }
+        workspace.isSidebarVisible = true
+        UserDefaults.standard.set(true, forKey: "sidebarVisible")
+    }
+}
+
+// MARK: - Path Card
+
+private struct WelcomePathCard: View {
+    let icon: String
+    let title: String
+    let description: String
+    let isPrimary: Bool
+    let colorScheme: ColorScheme
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 0) {
+                Image(systemName: icon)
+                    .font(.system(size: 24))
+                    .foregroundStyle(isPrimary ? Theme.accentColorSwiftUI : .secondary)
+                    .padding(.bottom, 10)
+
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .padding(.bottom, 4)
+
+                Text(description)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(2)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 24)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(cardFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(cardStroke, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(Theme.Motion.hover) {
+                isHovered = hovering
+            }
+        }
+    }
+
+    private var cardFill: Color {
+        if isPrimary {
+            let base = colorScheme == .dark ? 0.08 : 0.05
+            let hover = isHovered ? 0.04 : 0.0
+            return Theme.accentColorSwiftUI.opacity(base + hover)
+        } else {
+            let base = colorScheme == .dark ? 0.04 : 0.02
+            let hover = isHovered ? 0.03 : 0.0
+            return Color.primary.opacity(base + hover)
+        }
+    }
+
+    private var cardStroke: Color {
+        if isPrimary {
+            return Theme.accentColorSwiftUI.opacity(colorScheme == .dark ? 0.25 : 0.15)
+        } else {
+            return Color.primary.opacity(colorScheme == .dark ? 0.10 : 0.06)
+        }
+    }
+}

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -59,12 +59,19 @@ final class WorkspaceManager {
     private static let folderIconsKey = "folderIcons"
     private static let folderColorsKey = "folderColors"
     private static let showHiddenFilesKey = "showHiddenFiles"
+    private static let hasEverAddedLocationKey = "hasEverAddedLocation"
+    private static let hasDeliveredGettingStartedKey = "hasDeliveredGettingStarted"
     private static let wikiLinkPattern = try! NSRegularExpression(pattern: "\\[\\[[^\\]]*\\]\\]")
 
     /// Custom folder icons keyed by folder path (URL.path → SF Symbol name).
     var folderIcons: [String: String] = [:]
     /// Custom folder colors keyed by folder path (URL.path → color name).
     var folderColors: [String: String] = [:]
+
+    /// True when the user has never added a location (first-run state).
+    var isFirstRun: Bool {
+        !UserDefaults.standard.bool(forKey: Self.hasEverAddedLocationKey)
+    }
 
     private enum DirtyDocumentDisposition {
         case save
@@ -81,6 +88,11 @@ final class WorkspaceManager {
         folderColors = UserDefaults.standard.dictionary(forKey: Self.folderColorsKey) as? [String: String] ?? [:]
         restoreLocations()
         restoreRecents()
+
+        // Backfill for users upgrading from before the welcome view
+        if !locations.isEmpty && !UserDefaults.standard.bool(forKey: Self.hasEverAddedLocationKey) {
+            UserDefaults.standard.set(true, forKey: Self.hasEverAddedLocationKey)
+        }
 
         let launchBehavior = UserDefaults.standard.string(forKey: Self.launchBehaviorKey) ?? "lastFile"
         if launchBehavior == "newDocument" {
@@ -600,19 +612,20 @@ final class WorkspaceManager {
 
     // MARK: - Locations
 
-    func addLocation(url: URL) {
+    @discardableResult
+    func addLocation(url: URL) -> Bool {
         guard let bookmarkData = try? url.bookmarkData(
             options: .withSecurityScope,
             includingResourceValuesForKeys: nil,
             relativeTo: nil
         ) else {
             DiagnosticLog.log("Failed to create bookmark for location: \(url.path)")
-            return
+            return false
         }
 
         guard url.startAccessingSecurityScopedResource() else {
             DiagnosticLog.log("Failed to access location: \(url.path)")
-            return
+            return false
         }
         accessedURLs.insert(url)
 
@@ -629,6 +642,43 @@ final class WorkspaceManager {
 
         DiagnosticLog.log("Added location: \(url.lastPathComponent)")
         loadTree(for: location.id, at: url)
+
+        if !UserDefaults.standard.bool(forKey: Self.hasEverAddedLocationKey) {
+            UserDefaults.standard.set(true, forKey: Self.hasEverAddedLocationKey)
+        }
+        return true
+    }
+
+    /// On first-ever location add, creates a Getting Started document and opens it.
+    func handleFirstLocationIfNeeded(folderURL: URL) {
+        guard !UserDefaults.standard.bool(forKey: Self.hasDeliveredGettingStartedKey) else { return }
+        UserDefaults.standard.set(true, forKey: Self.hasDeliveredGettingStartedKey)
+
+        showSidebar()
+
+        let fileName = "Getting Started.md"
+        let fileURL = folderURL.appendingPathComponent(fileName)
+
+        guard !FileManager.default.fileExists(atPath: fileURL.path) else {
+            _ = openFile(at: fileURL)
+            return
+        }
+
+        guard let bundledURL = Bundle.main.url(forResource: "getting-started", withExtension: "md"),
+              let content = try? String(contentsOf: bundledURL, encoding: .utf8) else {
+            DiagnosticLog.log("Failed to load getting-started.md from bundle")
+            return
+        }
+
+        do {
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+            DiagnosticLog.log("Created Getting Started.md in \(folderURL.lastPathComponent)")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                _ = self?.openFile(at: fileURL)
+            }
+        } catch {
+            DiagnosticLog.log("Failed to write Getting Started.md: \(error.localizedDescription)")
+        }
     }
 
     func removeLocation(_ location: BookmarkedLocation) {
@@ -844,7 +894,11 @@ final class WorkspaceManager {
         if isDir.boolValue {
             // Don't add duplicate locations
             guard !locations.contains(where: { $0.url == url }) else { return }
-            addLocation(url: url)
+            let shouldShowGettingStarted = isFirstRun
+            guard addLocation(url: url) else { return }
+            if shouldShowGettingStarted {
+                handleFirstLocationIfNeeded(folderURL: url)
+            }
             showSidebar()
             presentMainWindow()
         } else {

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -126,7 +126,7 @@ enum PreviewCSS {
         line-height: 1.75;
         max-width: 61em;
         margin: 0 auto;
-        padding: 16px 64px 48px;
+        padding: 40px 64px 48px;
         color: #1D1D1F;
         background-color: #FFFFFF;
         -webkit-font-smoothing: antialiased;

--- a/Shared/Resources/getting-started.md
+++ b/Shared/Resources/getting-started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+You just added your first location — nice. The sidebar on the left now shows every markdown file in that folder. Here's a quick tour of what you can do from here.
+
+## Connect your notes
+
+The real power of Clearly is linking your thinking together.
+
+### Wiki links
+
+Type `[[` in the editor to link to another file. Clearly will suggest matches as you type. Links look like this: `[[Some Other Note]]`. You can alias them too: `[[Some Other Note|click here]]`.
+
+In preview mode, wiki links are clickable and navigate between your notes.
+
+### Tags
+
+Add `#tags` anywhere in your text. They work in the editor, in preview, and Clearly indexes them across your entire vault. Use slashes for hierarchy: `#work/projects`.
+
+## Find things fast
+
+- **Quick Switcher** (`Cmd+P`) — Jump to any file by name
+- **Backlinks** (`Cmd+Shift+B`) — See every page that links to the current one
+- **Outline** (`Cmd+Shift+O`) — Navigate by headings in the current document
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+1` | Editor mode |
+| `Cmd+2` | Preview mode |
+| `Cmd+P` | Quick Switcher |
+| `Cmd+L` | Toggle sidebar |
+| `Cmd+Shift+O` | Document outline |
+| `Cmd+Shift+B` | Backlinks panel |
+
+## Go deeper
+
+For a full showcase of Clearly's markdown support — tables, math, diagrams, code blocks, callouts, and more — open **Help > Sample Document** from the menu bar.
+
+Happy writing.

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,8 @@ targets:
         buildPhase: resources
       - path: Shared/Resources/demo.md
         buildPhase: resources
+      - path: Shared/Resources/getting-started.md
+        buildPhase: resources
     dependencies:
       - package: cmark-gfm
         product: cmark


### PR DESCRIPTION
## Summary

- Replaces the bare "No File Open" empty state on first launch with a welcome view showing the app icon, two action cards ("Add a Folder" for the knowledge-base path, "Quick Edit" for single-file editing), and an "open an existing file" link
- When the user adds their first location, a brief `Getting Started.md` is created in that folder and auto-opened, walking through wiki links, tags, backlinks, and key shortcuts
- Adds a sidebar toggle button to the bottom bar next to the Edit/Preview segmented control
- Changes default editor font size from 16 to 12
- Increases preview mode top padding from 16px to 40px

## Test plan
- [ ] Clear all app state (`defaults delete com.sabotage.clearly.dev`) and launch — should see the welcome view with two cards
- [ ] Click "Add a Folder" — sidebar should appear, `Getting Started.md` created and opened
- [ ] Quit and relaunch — should see NoFileView (not the welcome view again)
- [ ] Test "Quick Edit" card — creates untitled doc, no sidebar
- [ ] Verify sidebar toggle button in bottom bar works
- [ ] Verify existing users with locations don't see the welcome view (backfill logic)
- [ ] Test dark mode appearance