### PR TITLE
Add configurable content width for readable line length

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -113,6 +113,7 @@ struct ContentView: View {
     @StateObject private var backlinksState = BacklinksState()
     @StateObject private var jumpToLineState = JumpToLineState()
     @AppStorage("showLineNumbers") private var showLineNumbers = false
+    @AppStorage("contentWidth") private var contentWidth = "off"
     @State private var isFullscreen = false
     @Environment(\.colorScheme) private var colorScheme
 
@@ -129,10 +130,19 @@ struct ContentView: View {
         return inset
     }
 
+    private var contentWidthEm: CGFloat? {
+        switch contentWidth {
+        case "narrow": return 36
+        case "medium": return 48
+        case "wide":   return 60
+        default:       return nil
+        }
+    }
+
     private var editorPane: some View {
         let editorFontSize = CGFloat(fontSize)
         let fileURL = workspace.currentFileURL
-        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: contentExtraTopInset, showLineNumbers: showLineNumbers, jumpToLineState: jumpToLineState, needsTrafficLightClearance: !workspace.isSidebarVisible && !hasTabBar)
+        return EditorView(text: $workspace.currentFileText, fontSize: editorFontSize, fileURL: fileURL, mode: workspace.currentViewMode, positionSyncID: positionSyncID, findState: findState, outlineState: outlineState, extraTopInset: contentExtraTopInset, showLineNumbers: showLineNumbers, jumpToLineState: jumpToLineState, needsTrafficLightClearance: !workspace.isSidebarVisible && !hasTabBar, contentWidthEm: contentWidthEm)
     }
 
     private var previewPane: some View {
@@ -194,6 +204,7 @@ struct ContentView: View {
                 )
             },
             wikiFileNames: allWikiFileNames,
+            contentWidthEm: contentWidthEm,
             extraTopInset: contentExtraTopInset
         )
     }

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -15,7 +15,18 @@ struct EditorView: NSViewRepresentable {
     var showLineNumbers: Bool = false
     var jumpToLineState: JumpToLineState?
     var needsTrafficLightClearance: Bool = false
+    var contentWidthEm: CGFloat? = nil
     @Environment(\.colorScheme) private var colorScheme
+
+    private static func computeHorizontalInset(
+        scrollViewWidth: CGFloat, contentWidthEm: CGFloat?,
+        fontSize: CGFloat, needsTrafficLightClearance: Bool
+    ) -> CGFloat {
+        let minInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
+        guard let emValue = contentWidthEm else { return minInset }
+        let maxWidthPoints = emValue * fontSize
+        return max(minInset, (scrollViewWidth - maxWidthPoints) / 2.0)
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -57,7 +68,10 @@ struct EditorView: NSViewRepresentable {
         ]
 
         // Insets
-        let horizontalInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
+        let horizontalInset = Self.computeHorizontalInset(
+            scrollViewWidth: 0, contentWidthEm: contentWidthEm,
+            fontSize: fontSize, needsTrafficLightClearance: needsTrafficLightClearance
+        )
         textView.textContainerInset = NSSize(width: horizontalInset, height: Theme.editorInsetTop + extraTopInset)
         textView.textContainer?.lineFragmentPadding = 0
 
@@ -211,8 +225,14 @@ struct EditorView: NSViewRepresentable {
             }
         }
 
-        // Update top inset when tab bar appears/disappears
-        let horizontalInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
+        // Update insets (content width, tab bar, traffic light clearance)
+        context.coordinator.contentWidthEm = contentWidthEm
+        context.coordinator.cachedFontSize = fontSize
+        context.coordinator.cachedNeedsTrafficLightClearance = needsTrafficLightClearance
+        let horizontalInset = Self.computeHorizontalInset(
+            scrollViewWidth: scrollView.frame.width, contentWidthEm: contentWidthEm,
+            fontSize: fontSize, needsTrafficLightClearance: needsTrafficLightClearance
+        )
         let expectedInset = NSSize(width: horizontalInset, height: Theme.editorInsetTop + extraTopInset)
         if textView.textContainerInset != expectedInset {
             textView.textContainerInset = expectedInset
@@ -331,6 +351,9 @@ struct EditorView: NSViewRepresentable {
         var outlineState: OutlineState?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?
+        var contentWidthEm: CGFloat?
+        var cachedFontSize: CGFloat = 12
+        var cachedNeedsTrafficLightClearance: Bool = false
         var updateCount = 0
         private var lastScrollTime: TimeInterval = 0
         private var editGeneration: UInt = 0
@@ -389,6 +412,20 @@ struct EditorView: NSViewRepresentable {
 
         @objc func textViewFrameDidChange(_ notification: Notification) {
             gutterView?.scrollOrFrameDidChange()
+
+            // Recalculate horizontal inset on window resize to keep text centered
+            guard let textView, let scrollView = textView.enclosingScrollView else { return }
+            let horizontalInset = EditorView.computeHorizontalInset(
+                scrollViewWidth: scrollView.frame.width,
+                contentWidthEm: contentWidthEm,
+                fontSize: cachedFontSize,
+                needsTrafficLightClearance: cachedNeedsTrafficLightClearance
+            )
+            let currentVertical = textView.textContainerInset.height
+            let newInset = NSSize(width: horizontalInset, height: currentVertical)
+            if abs(textView.textContainerInset.width - newInset.width) > 0.5 {
+                textView.textContainerInset = newInset
+            }
         }
 
         func jumpToLine(_ line: Int) {

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -16,11 +16,18 @@ struct PreviewView: NSViewRepresentable {
     var onWikiLinkClicked: ((String, String?) -> Void)?
     var onTagClicked: ((String) -> Void)?
     var wikiFileNames: Set<String>?
+    var contentWidthEm: CGFloat? = nil
     var extraTopInset: CGFloat = 0
     @Environment(\.colorScheme) private var colorScheme
 
+    private var bodyMaxWidthCSS: String {
+        guard let contentWidthEm else { return "none" }
+        // Body padding is part of the box width, so add it back to match editor text width.
+        return "calc(\(Int(contentWidthEm))em + 128px)"
+    }
+
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)"
+        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")"
     }
 
     private var wikiFilesKey: String {
@@ -153,7 +160,7 @@ struct PreviewView: NSViewRepresentable {
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily))
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: bodyMaxWidthCSS))
         mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
         mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
         @media (prefers-color-scheme: dark) {

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @AppStorage("previewFontFamily") private var previewFontFamily = "sanFrancisco"
     @AppStorage("themePreference") private var themePreference = "system"
     @AppStorage("launchBehavior") private var launchBehavior = "lastFile"
+    @AppStorage("contentWidth") private var contentWidth = "off"
 
     var body: some View {
         TabView {
@@ -60,6 +61,12 @@ struct SettingsView: View {
                 Text("San Francisco").tag("sanFrancisco")
                 Text("New York").tag("newYork")
                 Text("SF Mono").tag("sfMono")
+            }
+            Picker("Content Width", selection: $contentWidth) {
+                Text("Off").tag("off")
+                Text("Narrow").tag("narrow")
+                Text("Medium").tag("medium")
+                Text("Wide").tag("wide")
             }
             KeyboardShortcuts.Recorder("New Scratchpad:", name: .newScratchpad)
             Toggle("Launch at Login", isOn: $launchAtLogin)

--- a/Shared/PreviewCSS.swift
+++ b/Shared/PreviewCSS.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum PreviewCSS {
-    static func css(fontSize: CGFloat = 18, fontFamily: String = "sanFrancisco", forExport: Bool = false) -> String {
+    static func css(fontSize: CGFloat = 18, fontFamily: String = "sanFrancisco", forExport: Bool = false, bodyMaxWidth: String = "61em") -> String {
     let bodyFontFamily: String
     let headingFontFamily: String
     switch fontFamily {
@@ -124,7 +124,7 @@ enum PreviewCSS {
         font-family: \(bodyFontFamily);
         font-size: \(Int(fontSize))px;
         line-height: 1.75;
-        max-width: 61em;
+        max-width: \(bodyMaxWidth);
         margin: 0 auto;
         padding: 40px 64px 48px;
         color: #1D1D1F;


### PR DESCRIPTION
## Summary
- Adds a "Content Width" preference (Off / Narrow / Medium / Wide) in Preferences > General
- Both editor and preview respect the same setting — editor centers text via dynamic `textContainerInset`, preview uses matching CSS `max-width` with `calc()` to account for body padding
- Em-based values scale naturally with font size; default is "Off" preserving current behavior
- QuickLook, PDF export, and scratchpad are unaffected

## Test plan
- [ ] Open Preferences > General, verify Content Width picker appears after Preview Font
- [ ] Set to Medium/Narrow/Wide, verify editor text column narrows and centers
- [ ] Switch to Preview mode, verify preview column matches editor width
- [ ] Resize window while a width is active, verify smooth recentering
- [ ] Change font size, verify column width scales proportionally
- [ ] Set to Off, verify both editor and preview return to default behavior

Fixes #146