### PR TITLE
Highlight selected text on mode switch and fix scroll sync (#97, #104)

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -5,6 +5,8 @@ extension Notification.Name {
     static let scrollPreviewToLine = Notification.Name("scrollPreviewToLine")
     static let flushEditorBuffer = Notification.Name("flushEditorBuffer")
     static let navigateWikiLink = Notification.Name("navigateWikiLink")
+    static let highlightTextInEditor = Notification.Name("highlightTextInEditor")
+    static let highlightTextInPreview = Notification.Name("highlightTextInPreview")
 }
 
 struct ViewModeKey: FocusedValueKey {
@@ -405,9 +407,21 @@ struct ContentView: View {
                 backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
                 applyPendingWikiNavigationIfNeeded()
             }
-            .onChange(of: workspace.currentViewMode) { _, newMode in
-                guard newMode != .edit else { return }
-                jumpToLineState.dismiss()
+            .onChange(of: workspace.currentViewMode) { oldMode, newMode in
+                if newMode != .edit {
+                    jumpToLineState.dismiss()
+                }
+                // Highlight selected text in the destination view on mode switch
+                guard oldMode != newMode,
+                      let text = SelectionBridge.selection(for: positionSyncID) else { return }
+                if oldMode == .edit && newMode == .preview {
+                    NotificationCenter.default.post(name: .highlightTextInPreview, object: nil, userInfo: ["text": text])
+                } else if oldMode == .preview && newMode == .edit {
+                    // Small delay for editor scroll restore to complete first
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        NotificationCenter.default.post(name: .highlightTextInEditor, object: nil, userInfo: ["text": text])
+                    }
+                }
             }
             .onChange(of: workspace.currentFileURL) { _, _ in
                 setupFileWatcher()

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -162,6 +162,13 @@ struct EditorView: NSViewRepresentable {
             object: nil
         )
 
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleHighlightText(_:)),
+            name: .highlightTextInEditor,
+            object: nil
+        )
+
         // Frame changes (window resize causing rewrap) — trigger gutter redraw
         textView.postsFrameChangedNotifications = true
         NotificationCenter.default.addObserver(
@@ -381,6 +388,15 @@ struct EditorView: NSViewRepresentable {
         func textViewDidChangeSelection(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+
+            // Store current selection for highlight-on-mode-switch
+            let range = textView.selectedRange()
+            if range.length > 0 {
+                let text = (textView.string as NSString).substring(with: range)
+                SelectionBridge.setSelection(text, for: parent.positionSyncID)
+            } else {
+                SelectionBridge.setSelection(nil, for: parent.positionSyncID)
+            }
         }
 
         @objc func handleScrollToLine(_ notification: Notification) {
@@ -403,6 +419,31 @@ struct EditorView: NSViewRepresentable {
                 let highlightRange = NSRange(location: min(charOffset, nsText.length), length: min(lineLen, nsText.length - charOffset))
                 textView.showFindIndicator(for: highlightRange)
             }
+        }
+
+        @objc func handleHighlightText(_ notification: Notification) {
+            guard let searchText = notification.userInfo?["text"] as? String,
+                  !searchText.isEmpty,
+                  let textView else { return }
+            let nsText = textView.string as NSString
+            guard nsText.length > 0 else { return }
+
+            // Determine visible character range to prioritize matches near current viewport
+            var searchStart = 0
+            if let layoutManager = textView.layoutManager, let container = textView.textContainer {
+                let glyphRange = layoutManager.glyphRange(forBoundingRect: textView.visibleRect, in: container)
+                let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+                searchStart = charRange.location
+            }
+
+            // Search forward from visible start, then wrap around
+            var foundRange = nsText.range(of: searchText, options: [], range: NSRange(location: searchStart, length: nsText.length - searchStart))
+            if foundRange.location == NSNotFound {
+                foundRange = nsText.range(of: searchText, options: [], range: NSRange(location: 0, length: min(searchStart + searchText.count, nsText.length)))
+            }
+            guard foundRange.location != NSNotFound else { return }
+            textView.scrollRangeToVisible(foundRange)
+            textView.showFindIndicator(for: foundRange)
         }
 
         @objc func flushEditorBuffer(_ notification: Notification) {
@@ -669,7 +710,8 @@ struct EditorView: NSViewRepresentable {
             let docHeight = scrollView.documentView?.frame.height ?? 1
             let viewportHeight = clipView.bounds.height
             let maxScroll = max(1, docHeight - viewportHeight)
-            ScrollBridge.setFraction(clipView.bounds.origin.y / maxScroll, for: parent.positionSyncID)
+            let fraction = min(max(clipView.bounds.origin.y / maxScroll, 0), 1)
+            ScrollBridge.setFraction(fraction, for: parent.positionSyncID)
 
             gutterView?.scrollOrFrameDidChange()
         }

--- a/Clearly/PositionSync.swift
+++ b/Clearly/PositionSync.swift
@@ -25,3 +25,20 @@ enum ScrollBridge {
         fractions[id] = value
     }
 }
+
+/// Stores current text selection per window so the destination view can highlight it on mode switch.
+enum SelectionBridge {
+    private static var selections: [String: String] = [:]
+
+    static func selection(for id: String) -> String? {
+        selections[id]
+    }
+
+    static func setSelection(_ text: String?, for id: String) {
+        if let text, !text.isEmpty {
+            selections[id] = text
+        } else {
+            selections[id] = nil
+        }
+    }
+}

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -46,6 +46,7 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "copyToClipboard")
         config.userContentController.add(context.coordinator, name: "taskToggle")
         config.userContentController.add(context.coordinator, name: "clickToSource")
+        config.userContentController.add(context.coordinator, name: "selectionCapture")
         config.userContentController.addUserScript(Self.copyButtonUserScript())
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
@@ -76,6 +77,12 @@ struct PreviewView: NSViewRepresentable {
             context.coordinator,
             selector: #selector(Coordinator.handleScrollToLine(_:)),
             name: .scrollPreviewToLine,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleHighlightText(_:)),
+            name: .highlightTextInPreview,
             object: nil
         )
 
@@ -153,6 +160,16 @@ struct PreviewView: NSViewRepresentable {
                 _scrollTicking = false;
             });
         });
+        // Capture text selection for highlight-on-mode-switch.
+        var _lastSelText = '';
+        document.addEventListener('selectionchange', function() {
+            var sel = window.getSelection();
+            var text = sel ? sel.toString() : '';
+            if (text !== _lastSelText) {
+                _lastSelText = text;
+                window.webkit.messageHandlers.selectionCapture.postMessage({ text: text });
+            }
+        });
         """
         let html = """
         <!DOCTYPE html>
@@ -162,6 +179,8 @@ struct PreviewView: NSViewRepresentable {
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: bodyMaxWidthCSS))
         mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
+        mark.clearly-mode-highlight { background: rgba(255, 210, 50, 0.5); border-radius: 3px; padding: 0 1px; transition: background 1.5s ease; }
+        mark.clearly-mode-highlight.fade { background: transparent; }
         mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
         @media (prefers-color-scheme: dark) {
             mark.clearly-find { background-color: rgba(180, 150, 0, 0.4); }
@@ -341,6 +360,7 @@ struct PreviewView: NSViewRepresentable {
         var skipNextReload = false
         var isLoadingContent = false
         var pendingScrollLine: Int?
+        var pendingHighlightText: String?
         weak var webView: WKWebView?
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
@@ -402,6 +422,80 @@ struct PreviewView: NSViewRepresentable {
             pendingScrollLine = line
             guard !isLoadingContent else { return }
             scrollToPendingLine()
+        }
+
+        @objc func handleHighlightText(_ notification: Notification) {
+            guard let searchText = notification.userInfo?["text"] as? String,
+                  !searchText.isEmpty else { return }
+            pendingHighlightText = searchText
+            guard !isLoadingContent, let webView else { return }
+            applyPendingHighlight()
+        }
+
+        private func applyPendingHighlight() {
+            guard let searchText = pendingHighlightText, let webView else { return }
+            pendingHighlightText = nil
+            let escaped = searchText
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+            let js = """
+            (function() {
+                // Remove any previous mode-highlight marks
+                document.querySelectorAll('mark.clearly-mode-highlight').forEach(function(m) {
+                    var p = m.parentNode;
+                    p.replaceChild(document.createTextNode(m.textContent), m);
+                    p.normalize();
+                });
+                var query = '\(escaped)';
+                // Walk text nodes to find the match nearest the current viewport
+                var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+                var candidates = [];
+                var node;
+                while (node = walker.nextNode()) {
+                    var idx = node.textContent.indexOf(query);
+                    if (idx >= 0) {
+                        candidates.push({ node: node, offset: idx });
+                    }
+                }
+                if (candidates.length === 0) return;
+                // Pick the candidate closest to the viewport center
+                var viewCenter = window.scrollY + window.innerHeight / 2;
+                var best = candidates[0];
+                var bestDist = Infinity;
+                for (var i = 0; i < candidates.length; i++) {
+                    var range = document.createRange();
+                    range.setStart(candidates[i].node, candidates[i].offset);
+                    range.setEnd(candidates[i].node, candidates[i].offset + query.length);
+                    var rect = range.getBoundingClientRect();
+                    var dist = Math.abs(rect.top + window.scrollY - viewCenter);
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        best = candidates[i];
+                    }
+                }
+                // Wrap the match in a highlight mark
+                var range = document.createRange();
+                range.setStart(best.node, best.offset);
+                range.setEnd(best.node, best.offset + query.length);
+                var mark = document.createElement('mark');
+                mark.className = 'clearly-mode-highlight';
+                range.surroundContents(mark);
+                mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                // Fade out after a brief pause
+                setTimeout(function() {
+                    mark.classList.add('fade');
+                    setTimeout(function() {
+                        var p = mark.parentNode;
+                        if (p) {
+                            p.replaceChild(document.createTextNode(mark.textContent), mark);
+                            p.normalize();
+                        }
+                    }, 1600);
+                }, 100);
+            })();
+            """
+            webView.evaluateJavaScript(js)
         }
 
         private func scrollToPendingLine() {
@@ -574,6 +668,7 @@ struct PreviewView: NSViewRepresentable {
                 performFind(query: query)
             }
             scrollToPendingLine()
+            applyPendingHighlight()
         }
 
         private func resolvedLinkURL(for href: String) -> URL? {
@@ -645,6 +740,13 @@ struct PreviewView: NSViewRepresentable {
                 DispatchQueue.main.async { [weak self] in
                     self?.onClickToSource?(line)
                 }
+                return
+            }
+
+            if message.name == "selectionCapture",
+               let body = message.body as? [String: Any],
+               let text = body["text"] as? String {
+                SelectionBridge.setSelection(text, for: self.positionSyncID)
                 return
             }
 


### PR DESCRIPTION
## Summary
- When switching between Editor and Preview with text selected, the destination view briefly highlights the matching text with a yellow flash that fades after ~1.5s — making mode transitions seamless on long documents
- Fixes scroll position jumping on mode switch by clamping the scroll fraction to 0–1 (negative values from the text container inset caused the preview to scroll to the top)
- Adds `SelectionBridge` (mirrors existing `ScrollBridge` pattern) to store selection state per window, with `NotificationCenter`-based coordination between views

## Test plan
- [ ] Open a long markdown file, scroll to middle, switch modes with ⌘1/⌘2 — scroll position should be preserved
- [ ] Select text in Editor, press ⌘2 — yellow highlight should appear at the matching text in Preview and fade out
- [ ] Select text in Preview, press ⌘1 — yellow flash should appear on matching text in Editor
- [ ] Switch modes with no text selected — no highlight should appear

Fixes #97
Fixes #104