### PR TITLE
Add middle-click to close tabs (#162)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -129,6 +129,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     private var closeTabMonitor: Any?
     private var showHiddenFilesMonitor: Any?
     private var sidebarToggleMonitor: Any?
+    private var middleClickMonitor: Any?
     private var quickSwitcherMonitor: Any?
     private var themeObserver: Any?
     private var isProgrammaticallyClosingWindows = false
@@ -309,6 +310,16 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             return event
         }
 
+        middleClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .otherMouseUp) { event in
+            guard event.buttonNumber == 2 else { return event }
+            let workspace = WorkspaceManager.shared
+            if let hoveredID = workspace.hoveredTabID {
+                workspace.closeDocument(hoveredID)
+                return nil
+            }
+            return event
+        }
+
         showHiddenFilesMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
             guard self.shouldToggleHiddenFiles(for: event) else { return event }
@@ -437,6 +448,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         if let closeTabMonitor {
             NSEvent.removeMonitor(closeTabMonitor)
             self.closeTabMonitor = nil
+        }
+        if let middleClickMonitor {
+            NSEvent.removeMonitor(middleClickMonitor)
+            self.middleClickMonitor = nil
         }
         if let showHiddenFilesMonitor {
             NSEvent.removeMonitor(showHiddenFilesMonitor)

--- a/Clearly/TabBarView.swift
+++ b/Clearly/TabBarView.swift
@@ -26,7 +26,8 @@ struct TabBarView: View {
                                 isActive: doc.id == workspace.activeDocumentID,
                                 isLast: index == workspace.openDocuments.count - 1,
                                 onSelect: { workspace.switchToDocument(doc.id) },
-                                onClose: { workspace.closeDocument(doc.id) }
+                                onClose: { workspace.closeDocument(doc.id) },
+                                onHover: { hovering in workspace.hoveredTabID = hovering ? doc.id : nil }
                             )
                         }
                         Spacer()
@@ -53,6 +54,7 @@ private struct TabItemView: View {
     let isLast: Bool
     let onSelect: () -> Void
     let onClose: () -> Void
+    let onHover: (Bool) -> Void
 
     @State private var isHovering = false
     @Environment(\.colorScheme) private var colorScheme
@@ -104,6 +106,7 @@ private struct TabItemView: View {
         )
         .onHover { hovering in
             isHovering = hovering
+            onHover(hovering)
         }
     }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -32,6 +32,7 @@ final class WorkspaceManager {
 
     var openDocuments: [OpenDocument] = []
     var activeDocumentID: UUID?
+    var hoveredTabID: UUID?
     private var nextUntitledNumber: Int = 1
 
     // MARK: - Sidebar


### PR DESCRIPTION
## Summary
- Adds middle-click (mouse button 3) support for closing tabs, matching standard browser behavior
- Uses an `NSEvent` local monitor for `.otherMouseUp` alongside the existing Cmd+W monitor pattern
- Leverages existing per-tab hover tracking to identify which tab was middle-clicked — no coordinate math or private APIs needed

Fixes #162