### PR TITLE
Persist sidebar width across app restarts (#164)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -886,6 +886,7 @@ class ClearlySplitViewController: NSSplitViewController {
         let detailItem = NSSplitViewItem(viewController: detailHost)
         detailItem.minimumThickness = 400
         addSplitViewItem(detailItem)
+        splitView.autosaveName = "ClearlySidebar"
 
         if !workspace.isSidebarVisible {
             needsInitialCollapse = true


### PR DESCRIPTION
## Summary
- Sets `autosaveName` on the NSSplitView so macOS automatically saves and restores the sidebar divider position across app launches.

Fixes #164