### PR TITLE
Skip heavy directories and respect .gitignore in sidebar and vault index

### DIFF
--- a/Clearly/FileNode.swift
+++ b/Clearly/FileNode.swift
@@ -15,7 +15,8 @@ struct FileNode: Identifiable, Hashable {
     ]
 
     /// Build a file tree from a directory URL, filtering to markdown files.
-    static func buildTree(at url: URL, showHiddenFiles: Bool = false) -> [FileNode] {
+    /// Skips hardcoded heavy directories and respects `.gitignore` rules.
+    static func buildTree(at url: URL, showHiddenFiles: Bool = false, ignoreRules: IgnoreRules? = nil) -> [FileNode] {
         let fm = FileManager.default
         let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
         guard let contents = try? fm.contentsOfDirectory(
@@ -23,6 +24,8 @@ struct FileNode: Identifiable, Hashable {
             includingPropertiesForKeys: [.isDirectoryKey, .nameKey],
             options: options
         ) else { return [] }
+
+        var rules = ignoreRules ?? IgnoreRules(rootURL: url)
 
         var folders: [FileNode] = []
         var files: [FileNode] = []
@@ -33,13 +36,19 @@ struct FileNode: Identifiable, Hashable {
             let hidden = name.hasPrefix(".")
 
             if isDir {
-                let children = buildTree(at: itemURL, showHiddenFiles: showHiddenFiles)
+                if rules.shouldIgnore(url: itemURL, isDirectory: true) { continue }
+                var childRules = rules
+                childRules.loadNestedGitignore(at: itemURL)
+                let children = buildTree(at: itemURL, showHiddenFiles: showHiddenFiles, ignoreRules: childRules)
                 // Only include folders that contain markdown files (directly or nested)
                 if !children.isEmpty {
                     folders.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: children))
                 }
-            } else if markdownExtensions.contains(itemURL.pathExtension.lowercased()) {
-                files.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: nil))
+            } else {
+                if rules.shouldIgnore(url: itemURL, isDirectory: false) { continue }
+                if markdownExtensions.contains(itemURL.pathExtension.lowercased()) {
+                    files.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: nil))
+                }
             }
         }
 

--- a/Clearly/IgnoreRules.swift
+++ b/Clearly/IgnoreRules.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// Consolidates directory ignore logic: hardcoded skip list + .gitignore parsing.
+/// Used by `FileNode.buildTree` and `VaultIndex.collectMarkdownFiles` to skip
+/// heavy directories like node_modules and respect .gitignore rules.
+struct IgnoreRules {
+
+    // MARK: - Hardcoded defaults
+
+    /// Directories that are always skipped regardless of .gitignore.
+    static let defaultIgnoredDirectories: Set<String> = [
+        // Version control
+        ".git", ".svn", ".hg", "CVS",
+        // Dependencies / packages
+        "node_modules", "bower_components", "Pods", ".pub-cache", ".bundle",
+        // Build output
+        "build", "dist", ".build", ".next", ".nuxt", ".output", "out", "target", "_site",
+        // Caches
+        ".cache", ".parcel-cache", ".sass-cache",
+        // Python
+        "__pycache__", ".venv", "venv", ".tox",
+        // Java / Gradle
+        ".gradle",
+        // IDE
+        ".idea", ".vscode", ".vs", "xcuserdata",
+        // Infrastructure
+        ".terraform", ".vagrant", ".docker",
+        // Test coverage
+        "coverage", ".nyc_output",
+        // Misc
+        "vendor",
+    ]
+
+    // MARK: - Gitignore rules
+
+    private struct Rule {
+        let pattern: String
+        let negated: Bool
+        let directoryOnly: Bool
+        /// Anchored rules match from the .gitignore's directory; unanchored match any path component.
+        let anchored: Bool
+        /// The directory containing the .gitignore that defined this rule.
+        let basePath: URL
+    }
+
+    private var rules: [Rule] = []
+    let rootURL: URL
+
+    // MARK: - Init
+
+    init(rootURL: URL) {
+        self.rootURL = rootURL
+        loadGitignore(at: rootURL)
+    }
+
+    // MARK: - Public API
+
+    /// Returns `true` if the item at `url` should be skipped.
+    func shouldIgnore(url: URL, isDirectory: Bool) -> Bool {
+        let name = url.lastPathComponent
+
+        // Fast path: hardcoded directory names
+        if isDirectory && Self.defaultIgnoredDirectories.contains(name) {
+            return true
+        }
+
+        guard !rules.isEmpty else { return false }
+
+        guard let relativePath = Self.relativePath(of: url, from: rootURL) else { return false }
+
+        // Process rules in order — last match wins
+        var ignored = false
+        for rule in rules {
+            if rule.directoryOnly && !isDirectory { continue }
+
+            let pathToMatch: String
+            if rule.basePath == rootURL {
+                pathToMatch = relativePath
+            } else {
+                // Nested .gitignore: match relative to the .gitignore's directory
+                guard let nestedRelative = Self.relativePath(of: url, from: rule.basePath) else { continue }
+                pathToMatch = nestedRelative
+            }
+
+            if matches(pattern: rule.pattern, path: pathToMatch, anchored: rule.anchored) {
+                ignored = !rule.negated
+            }
+        }
+        return ignored
+    }
+
+    /// Load a nested .gitignore when entering a subdirectory.
+    mutating func loadNestedGitignore(at directoryURL: URL) {
+        loadGitignore(at: directoryURL)
+    }
+
+    // MARK: - Parsing
+
+    private mutating func loadGitignore(at directoryURL: URL) {
+        let gitignoreURL = directoryURL.appendingPathComponent(".gitignore")
+        guard let contents = try? String(contentsOf: gitignoreURL, encoding: .utf8) else { return }
+
+        for line in contents.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingTrailingWhitespace()
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+
+            var pattern = trimmed
+            let negated = pattern.hasPrefix("!")
+            if negated { pattern = String(pattern.dropFirst()) }
+
+            let directoryOnly = pattern.hasSuffix("/")
+            if directoryOnly { pattern = String(pattern.dropLast()) }
+
+            // A pattern is anchored if it contains a slash anywhere (other than trailing, already stripped)
+            // or starts with a slash. Leading slash is stripped after setting anchored.
+            let anchored: Bool
+            if pattern.hasPrefix("/") {
+                anchored = true
+                pattern = String(pattern.dropFirst())
+            } else {
+                anchored = pattern.contains("/")
+            }
+
+            guard !pattern.isEmpty else { continue }
+
+            rules.append(Rule(
+                pattern: pattern,
+                negated: negated,
+                directoryOnly: directoryOnly,
+                anchored: anchored,
+                basePath: directoryURL
+            ))
+        }
+    }
+
+    // MARK: - Matching
+
+    /// Match a gitignore pattern against a relative path.
+    private func matches(pattern: String, path: String, anchored: Bool) -> Bool {
+        // Handle leading **/ — match anywhere in path
+        if pattern.hasPrefix("**/") {
+            let rest = String(pattern.dropFirst(3))
+            // Try matching rest against full path and every suffix after a /
+            if fnmatchWrap(rest, path) { return true }
+            var idx = path.startIndex
+            while let slashIdx = path[idx...].firstIndex(of: "/") {
+                let after = path.index(after: slashIdx)
+                if after < path.endIndex && fnmatchWrap(rest, String(path[after...])) {
+                    return true
+                }
+                idx = after
+            }
+            return false
+        }
+
+        // Handle trailing /** — match everything under a directory
+        if pattern.hasSuffix("/**") {
+            let prefix = String(pattern.dropLast(3))
+            return path == prefix || path.hasPrefix(prefix + "/")
+        }
+
+        // Handle infix /**/ — zero-or-more intermediate directories
+        if pattern.contains("/**/") {
+            let parts = pattern.components(separatedBy: "/**/")
+            if parts.count == 2 {
+                let left = parts[0]
+                let right = parts[1]
+                // Must start with left, end matching right, with anything in between
+                guard fnmatchWrap(left, path) || path.hasPrefix(left + "/") else { return false }
+                // Try matching right against every suffix
+                if fnmatchWrap(left + "/" + right, path) { return true }
+                var idx = path.startIndex
+                while let slashIdx = path[idx...].firstIndex(of: "/") {
+                    let after = path.index(after: slashIdx)
+                    if after < path.endIndex && fnmatchWrap(right, String(path[after...])) {
+                        return true
+                    }
+                    idx = after
+                }
+            }
+            return false
+        }
+
+        if anchored {
+            return fnmatchWrap(pattern, path)
+        } else {
+            // Unanchored: match against just the last component
+            let filename = (path as NSString).lastPathComponent
+            return fnmatchWrap(pattern, filename)
+        }
+    }
+
+    /// Wrapper around POSIX fnmatch with FNM_PATHNAME.
+    private func fnmatchWrap(_ pattern: String, _ string: String) -> Bool {
+        Darwin.fnmatch(pattern, string, FNM_PATHNAME) == 0
+    }
+
+    // MARK: - Helpers
+
+    private static func relativePath(of url: URL, from base: URL) -> String? {
+        let filePath = url.standardizedFileURL.path
+        let basePath = base.standardizedFileURL.path
+        if filePath == basePath { return "" }
+        guard filePath.hasPrefix(basePath + "/") else { return nil }
+        return String(filePath.dropFirst(basePath.count + 1))
+    }
+}
+
+// MARK: - String helpers
+
+private extension String {
+    func trimmingTrailingWhitespace() -> String {
+        var s = self
+        while let last = s.last, last == " " || last == "\t" {
+            s.removeLast()
+        }
+        return s
+    }
+}

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -712,14 +712,28 @@ final class VaultIndex: @unchecked Sendable {
     private func collectMarkdownFiles(under rootURL: URL, showHiddenFiles: Bool) -> [URL] {
         let fm = FileManager.default
         let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
-        guard let enumerator = fm.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey], options: options) else {
+        guard let enumerator = fm.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey], options: options) else {
             return []
         }
 
+        var rules = IgnoreRules(rootURL: rootURL)
         var files: [URL] = []
         for case let url as URL in enumerator {
+            let resourceValues = try? url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            let isDir = resourceValues?.isDirectory ?? false
+
+            if isDir {
+                rules.loadNestedGitignore(at: url)
+                if rules.shouldIgnore(url: url, isDirectory: true) {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                continue
+            }
+
+            if rules.shouldIgnore(url: url, isDirectory: false) { continue }
             guard FileNode.markdownExtensions.contains(url.pathExtension.lowercased()) else { continue }
-            guard let isFile = try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile, isFile else { continue }
+            guard resourceValues?.isRegularFile ?? false else { continue }
             files.append(url)
         }
         return files

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -658,14 +658,13 @@ final class WorkspaceManager {
     /// On first-ever location add, creates a Getting Started document and opens it.
     func handleFirstLocationIfNeeded(folderURL: URL) {
         guard !UserDefaults.standard.bool(forKey: Self.hasDeliveredGettingStartedKey) else { return }
-        UserDefaults.standard.set(true, forKey: Self.hasDeliveredGettingStartedKey)
-
         showSidebar()
 
         let fileName = "Getting Started.md"
         let fileURL = folderURL.appendingPathComponent(fileName)
 
         guard !FileManager.default.fileExists(atPath: fileURL.path) else {
+            UserDefaults.standard.set(true, forKey: Self.hasDeliveredGettingStartedKey)
             _ = openFile(at: fileURL)
             return
         }
@@ -678,6 +677,7 @@ final class WorkspaceManager {
 
         do {
             try content.write(to: fileURL, atomically: true, encoding: .utf8)
+            UserDefaults.standard.set(true, forKey: Self.hasDeliveredGettingStartedKey)
             DiagnosticLog.log("Created Getting Started.md in \(folderURL.lastPathComponent)")
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 _ = self?.openFile(at: fileURL)
@@ -739,10 +739,37 @@ final class WorkspaceManager {
     // MARK: - Pinned Files
 
     func togglePin(_ url: URL) {
-        if let idx = pinnedFiles.firstIndex(of: url) {
+        let normalizedURL = url.standardizedFileURL
+
+        if let idx = pinnedFiles.firstIndex(where: { $0.standardizedFileURL == normalizedURL }) {
             pinnedFiles.remove(at: idx)
         } else {
-            pinnedFiles.append(url)
+            guard let bookmarkData = try? normalizedURL.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) else {
+                DiagnosticLog.log("Failed to create bookmark for pinned file: \(normalizedURL.path)")
+                return
+            }
+
+            var isStale = false
+            let pinnedURL = (try? URL(
+                resolvingBookmarkData: bookmarkData,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            ))?.standardizedFileURL ?? normalizedURL
+
+            if !hasExactActiveAccess(to: pinnedURL) {
+                if pinnedURL.startAccessingSecurityScopedResource() {
+                    accessedURLs.insert(pinnedURL)
+                } else if !hasActiveAccess(to: pinnedURL) {
+                    DiagnosticLog.log("Failed to access pinned file: \(pinnedURL.path)")
+                }
+            }
+
+            pinnedFiles.append(pinnedURL)
         }
         persistPinnedFiles()
     }
@@ -1117,13 +1144,18 @@ final class WorkspaceManager {
                 relativeTo: nil,
                 bookmarkDataIsStale: &isStale
             ) {
+                let normalizedURL = url.standardizedFileURL
                 if isStale {
                     shouldPersist = true
                 }
-                if !hasActiveAccess(to: url), url.startAccessingSecurityScopedResource() {
-                    accessedURLs.insert(url)
+                if !hasExactActiveAccess(to: normalizedURL) {
+                    if normalizedURL.startAccessingSecurityScopedResource() {
+                        accessedURLs.insert(normalizedURL)
+                    } else if !hasActiveAccess(to: normalizedURL) {
+                        DiagnosticLog.log("Failed to restore pinned file access: \(normalizedURL.path)")
+                    }
                 }
-                urls.append(url)
+                urls.append(normalizedURL)
             } else {
                 shouldPersist = true
             }
@@ -1390,6 +1422,11 @@ final class WorkspaceManager {
             let scopePath = accessedURL.standardizedFileURL.path
             return targetPath == scopePath || targetPath.hasPrefix(scopePath + "/")
         }
+    }
+
+    private func hasExactActiveAccess(to url: URL) -> Bool {
+        let targetPath = url.standardizedFileURL.path
+        return accessedURLs.contains { $0.standardizedFileURL.path == targetPath }
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -135,6 +135,7 @@ targets:
       - path: Clearly/VaultIndex.swift
       - path: Clearly/FileParser.swift
       - path: Clearly/FileNode.swift
+      - path: Clearly/IgnoreRules.swift
       - path: Clearly/DiagnosticLog.swift
       - path: Shared/FrontmatterSupport.swift
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `IgnoreRules` struct that skips 30+ hardcoded heavy directories (node_modules, .git, build, vendor, __pycache__, etc.) and parses `.gitignore` files — including nested ones — with full pattern support (`**/`, `/**/`, `/**`, negation, directory-only, anchored patterns)
- `FileNode.buildTree` checks ignore rules before recursing into directories, so entire subtrees like node_modules are skipped without listing their contents
- `VaultIndex.collectMarkdownFiles` uses `enumerator.skipDescendants()` to prevent the enumerator from entering ignored directories
- Fixes pinned file bookmark handling to use standardized URLs and proper security-scoped access
- Fixes Getting Started document delivery to only set the "delivered" flag after the file is actually created/opened

Fixes #132