### PR TITLE
Fix MCP config pointing to non-launchable sandboxed binary

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -194,26 +194,6 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         }
     }
 
-    private func installMCPHelperIfNeeded() {
-        #if canImport(Sparkle)
-        guard let source = Bundle.main.url(forResource: "ClearlyMCP", withExtension: nil, subdirectory: "Helpers") else { return }
-        let installDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Clearly")
-        let installed = installDir.appendingPathComponent("ClearlyMCP")
-
-        try? FileManager.default.createDirectory(at: installDir, withIntermediateDirectories: true)
-
-        let shouldCopy = !FileManager.default.fileExists(atPath: installed.path)
-            || (try? Data(contentsOf: source)) != (try? Data(contentsOf: installed))
-
-        if shouldCopy {
-            try? FileManager.default.removeItem(at: installed)
-            try? FileManager.default.copyItem(at: source, to: installed)
-            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installed.path)
-        }
-        #endif
-    }
-
     private func updateWindowAppearance() {
         guard let window = mainWindow else { return }
         let pref = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
@@ -243,7 +223,6 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
-        installMCPHelperIfNeeded()
 
         // A normal Launch Services open activates the app and opens a document window.
         // Login-item launch stays inactive with no document windows, so collapse to

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -89,9 +89,20 @@ struct SettingsView: View {
 
     @State private var mcpCopied = false
 
-    private var mcpBinaryPath: String {
+    private var bundledMCPBinaryPath: String? {
+        Bundle.main.url(forResource: "ClearlyMCP", withExtension: nil, subdirectory: "Helpers")?.path
+    }
+
+    private var installedMCPBinaryPath: String {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport.appendingPathComponent("Clearly/ClearlyMCP").path
+    }
+
+    private var mcpBinaryPath: String {
+        if let bundledMCPBinaryPath, FileManager.default.isExecutableFile(atPath: bundledMCPBinaryPath) {
+            return bundledMCPBinaryPath
+        }
+        return installedMCPBinaryPath
     }
 
     private var mcpBundleIdentifier: String {
@@ -125,6 +136,7 @@ struct SettingsView: View {
             Button(mcpCopied ? "Copied!" : "Copy MCP Config") {
                 copyMCPConfig()
             }
+            .disabled(!mcpBinaryInstalled)
 
             // Help text
             Text("The MCP server lets AI agents search your notes, explore backlinks, and browse tags. It automatically discovers all your vaults. Copy the config and add it to any MCP-compatible app (Claude Desktop, Cursor, Windsurf, etc.).")


### PR DESCRIPTION
## Summary
- **Copy MCP Config** now points to the bundled helper inside the app bundle (`Contents/Resources/Helpers/ClearlyMCP`) instead of the sandboxed Application Support copy that macOS blocks external processes from executing
- Prefers the bundled binary path, falls back to the installed Application Support path
- Disables the Copy MCP Config button when no executable binary is found
- Removes `installMCPHelperIfNeeded()` — no longer needed since we reference the bundle directly

## Test plan
- [ ] Open Settings > MCP, verify "MCP Helper: Installed" status
- [ ] Click Copy MCP Config, verify path contains `.app/Contents/Resources/Helpers/ClearlyMCP`
- [ ] Paste config into an MCP client, verify the server starts without "operation not permitted"

Fixes #174