### PR TITLE
Add setting to hide frontmatter in preview mode

### DIFF
--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -35,6 +35,7 @@ struct PreviewView: NSViewRepresentable {
     var wikiFileNames: Set<String>?
     var contentWidthEm: CGFloat? = nil
     var extraTopInset: CGFloat = 0
+    @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
     @Environment(\.colorScheme) private var colorScheme
 
     private var bodyMaxWidthCSS: String {
@@ -44,7 +45,7 @@ struct PreviewView: NSViewRepresentable {
     }
 
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")"
+        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")__\(hideFrontmatterInPreview)"
     }
 
     private var wikiFilesKey: String {
@@ -154,7 +155,7 @@ struct PreviewView: NSViewRepresentable {
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
         context.coordinator.isLoadingContent = true
-        let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true)
+        let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true, includeFrontmatter: !hideFrontmatterInPreview)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
         let wikiFilesJSON: String = {
             guard let names = wikiFileNames, !names.isEmpty else { return "[]" }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @AppStorage("themePreference") private var themePreference = "system"
     @AppStorage("launchBehavior") private var launchBehavior = "lastFile"
     @AppStorage("contentWidth") private var contentWidth = "off"
+    @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
 
     var body: some View {
         TabView {
@@ -68,6 +69,7 @@ struct SettingsView: View {
                 Text("Medium").tag("medium")
                 Text("Wide").tag("wide")
             }
+            Toggle("Hide frontmatter in Preview", isOn: $hideFrontmatterInPreview)
             KeyboardShortcuts.Recorder("New Scratchpad:", name: .newScratchpad)
             Toggle("Launch at Login", isOn: $launchAtLogin)
                 .onChange(of: launchAtLogin) { _, newValue in

--- a/Shared/MarkdownRenderer.swift
+++ b/Shared/MarkdownRenderer.swift
@@ -2,7 +2,7 @@ import Foundation
 import cmark
 
 enum MarkdownRenderer {
-    static func renderHTML(_ markdown: String, appLinkURLs: Bool = false) -> String {
+    static func renderHTML(_ markdown: String, appLinkURLs: Bool = false, includeFrontmatter: Bool = true) -> String {
         guard !markdown.isEmpty else { return "" }
 
         let frontmatter = FrontmatterSupport.extract(from: markdown)
@@ -40,7 +40,7 @@ enum MarkdownRenderer {
         }
 
         // Prepend frontmatter HTML
-        if let frontmatter {
+        if includeFrontmatter, let frontmatter {
             html = frontmatterHTML(from: frontmatter) + html
         }
 


### PR DESCRIPTION
## Summary
- Adds a "Hide frontmatter in Preview" toggle in Settings > General
- When enabled, strips the frontmatter HTML block from preview rendering while preserving sourcepos adjustments for click-to-source accuracy
- Only affects in-app preview — PDF export, QuickLook, and editor mode are unchanged

## Test plan
- [ ] Open a markdown file with YAML frontmatter
- [ ] Verify frontmatter renders in preview by default
- [ ] Toggle "Hide frontmatter in Preview" in Settings > General
- [ ] Confirm preview immediately re-renders without frontmatter
- [ ] Double-click body text in preview to verify click-to-source still jumps to correct line
- [ ] Switch Edit ↔ Preview to verify scroll position sync still works

Fixes #170