### PR TITLE
Disable Sparkle update checks in debug builds

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -1016,11 +1016,19 @@ struct ClearlyApp: App {
         DiagnosticLog.trimIfNeeded()
         DiagnosticLog.log("App launched")
         #if canImport(Sparkle)
+        #if DEBUG
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        #else
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        #endif
         #endif
     }
 

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -190,7 +190,7 @@ struct SettingsView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 16) {
-                #if canImport(Sparkle)
+                #if canImport(Sparkle) && !DEBUG
                 Button("Check for Updates") {
                     updater.checkForUpdates()
                 }


### PR DESCRIPTION
## Summary
- Passes `startingUpdater: false` to `SPUStandardUpdaterController` in debug builds so Sparkle never starts its update scheduler — no network requests, no update prompts
- Hides the "Check for Updates" button in Settings for debug builds (it had no disabled guard and would crash calling `checkForUpdates()` on an unstarted updater)
- Release builds are unchanged

Fixes #183