### PR TITLE
fix: refresh sidebar when current file URL changes

### DIFF
--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -352,6 +352,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
         private var lastOpenDocCount = 0
         private var lastLocationTreeHash = 0
         private var lastActiveDocumentID: UUID?
+        private var lastCurrentFileURL: URL?
         private var hasLoadedOnce = false
 
         // Prevent re-entrant selection changes
@@ -461,6 +462,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             let treeHash = workspace.treeRevision
             let activeID = workspace.activeDocumentID
             let vaultRev = workspace.vaultIndexRevision
+            let currentURL = workspace.currentFileURL
 
             let changed = locCount != lastLocationCount
                 || pinCount != lastPinnedCount
@@ -469,6 +471,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                 || treeHash != lastLocationTreeHash
                 || activeID != lastActiveDocumentID
                 || vaultRev != lastVaultRevision
+                || currentURL != lastCurrentFileURL
 
             if vaultRev != lastVaultRevision {
                 refreshCachedTags()
@@ -481,6 +484,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
             lastLocationTreeHash = treeHash
             lastActiveDocumentID = activeID
             lastVaultRevision = vaultRev
+            lastCurrentFileURL = currentURL
 
             return changed
         }


### PR DESCRIPTION
## Summary
- Sidebar's change detection (`dataDidChange`) only checked array counts and `activeDocumentID`, missing when `openFile` replaces the active tab's content in-place (same doc UUID, same counts, different file)
- The stale sidebar caused item 1 (OpenDoc) to no-op via `switchToDocument` and item 2 to no-op once its URL matched the already-open file
- Track `currentFileURL` in change detection so the sidebar reloads when the active tab's file changes

## Test plan
- Open the app with a location containing several markdown files
- Click between items 1, 2, and 3+ in the RECENTS sidebar section
- Verify the viewer updates for all items, including alternating between items 1 and 2

Closes #185