### PR TITLE
Phase 2: read tools + structured MCP output

### DIFF
--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -634,6 +634,46 @@ final class VaultIndex: @unchecked Sendable {
         }
     }
 
+    // MARK: Read — Headings by File
+
+    func headings(forFileId fileId: Int64) -> [ParsedHeading] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT text, level, line_number FROM headings
+                    WHERE file_id = ?
+                    ORDER BY line_number
+                    """, arguments: [fileId])
+                    .map { row in
+                        ParsedHeading(
+                            text: row["text"],
+                            level: Int(row["level"] as Int64),
+                            lineNumber: Int(row["line_number"] as Int64)
+                        )
+                    }
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: Read — Tags by File
+
+    func tags(forFileId fileId: Int64) -> [String] {
+        do {
+            return try dbPool.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT DISTINCT tag FROM tags
+                    WHERE file_id = ?
+                    ORDER BY tag
+                    """, arguments: [fileId])
+                    .map { $0["tag"] as String }
+            }
+        } catch {
+            return []
+        }
+    }
+
     // MARK: Read — File by URL
 
     func file(forURL url: URL) -> IndexedFile? {

--- a/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
+++ b/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
@@ -4,13 +4,49 @@ import Foundation
 struct FrontmatterCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "frontmatter",
-        abstract: "Read YAML frontmatter from a note (arrives in Phase 2)."
+        abstract: "Return the parsed YAML frontmatter of a note as a flat key-value map."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path, e.g. 'Projects/2026-plan.md'.")
+    var relativePath: String
+
+    @Option(name: .customLong("in-vault"), help: "Optional vault disambiguator (name or path) when multiple vaults are loaded.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly frontmatter — not yet implemented (Phase 2)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await getFrontmatter(
+                GetFrontmatterArgs(relativePath: relativePath, vault: inVault),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                try Emitter.emit(result, format: .json)
+            case .text:
+                if !result.hasFrontmatter {
+                    Emitter.emitLine("(no frontmatter)")
+                } else {
+                    for key in result.frontmatter.keys.sorted() {
+                        Emitter.emitLine("\(key): \(result.frontmatter[key] ?? "")")
+                    }
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
@@ -4,13 +4,46 @@ import Foundation
 struct HeadingsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "headings",
-        abstract: "Extract headings from a note (arrives in Phase 2)."
+        abstract: "Return the heading outline of a note."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path, e.g. 'Strategy/pricing.md'.")
+    var relativePath: String
+
+    @Option(name: .customLong("in-vault"), help: "Optional vault disambiguator (name or path) when multiple vaults are loaded.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly headings — not yet implemented (Phase 2)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await getHeadings(
+                GetHeadingsArgs(relativePath: relativePath, vault: inVault),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                try Emitter.emit(result, format: .json)
+            case .text:
+                for h in result.headings {
+                    let prefix = String(repeating: "#", count: h.level)
+                    Emitter.emitLine("\(prefix) \(h.text)\t(line \(h.lineNumber))")
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/ListCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ListCommand.swift
@@ -4,13 +4,47 @@ import Foundation
 struct ListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List notes in a vault (arrives in Phase 2)."
+        abstract: "List notes in loaded vault(s). Emits NDJSON (one record per line)."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(help: "Vault-relative directory prefix to filter by, e.g. 'Daily/'.")
+    var under: String?
+
+    @Option(name: .customLong("in-vault"), help: "Optional vault disambiguator (name or path) when multiple vaults are loaded.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly list — not yet implemented (Phase 2)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await listNotes(
+                ListNotesArgs(under: under, vault: inVault),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                for note in result.notes {
+                    try Emitter.emitNDJSONRecord(note)
+                }
+            case .text:
+                for note in result.notes {
+                    Emitter.emitLine("\(note.relativePath)\t\(note.sizeBytes)\t\(note.modifiedAt)")
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/ReadCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ReadCommand.swift
@@ -4,13 +4,54 @@ import Foundation
 struct ReadCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "read",
-        abstract: "Read a note by relative path (arrives in Phase 2)."
+        abstract: "Read a note by vault-relative path, with optional line range."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path, e.g. 'Daily/2026-04-16.md'.")
+    var relativePath: String
+
+    @Option(name: .customLong("start-line"), help: "1-based line number to start reading from.")
+    var startLine: Int?
+
+    @Option(name: .customLong("end-line"), help: "1-based line number to stop reading at (inclusive).")
+    var endLine: Int?
+
+    @Option(name: .customLong("in-vault"), help: "Optional vault disambiguator (name or path) when multiple vaults are loaded.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly read — not yet implemented (Phase 2)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await readNote(
+                ReadNoteArgs(
+                    relativePath: relativePath,
+                    startLine: startLine,
+                    endLine: endLine,
+                    vault: inVault
+                ),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                try Emitter.emit(result, format: .json)
+            case .text:
+                Emitter.emitLine(result.content)
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Emitters.swift
+++ b/ClearlyCLI/CLI/Emitters.swift
@@ -1,27 +1,57 @@
 import Foundation
+import ArgumentParser
 
 enum Emitter {
+    /// Emit a single Encodable value. JSON mode uses snake_case keys + sorted
+    /// keys to match the MCP structured output contract. Newline-terminated.
     static func emit<T: Encodable>(_ value: T, format: OutputFormat) throws {
         switch format {
         case .json:
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
-            let data = try encoder.encode(value)
+            let data = try jsonEncoder().encode(value)
             FileHandle.standardOutput.write(data)
             FileHandle.standardOutput.write(Data("\n".utf8))
         case .text:
-            // Phase 2 fills in text emitters alongside the read tools that need them.
             throw CLIError.textFormatUnavailable
         }
     }
 
-    static func emitError(_ error: String, message: String, extra: [String: String] = [:]) {
-        var payload: [String: String] = ["error": error, "message": message]
+    /// Emit a pre-rendered text line to stdout with a trailing newline.
+    static func emitLine(_ line: String) {
+        FileHandle.standardOutput.write(Data(line.utf8))
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+
+    /// Emit an NDJSON record: one JSON object per line, flushed immediately.
+    /// Matches RESEARCH.md §5.6 pipeline contract for list-shaped commands.
+    static func emitNDJSONRecord<T: Encodable>(_ value: T) throws {
+        let data = try jsonEncoder().encode(value)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+
+    static func emitError(_ error: String, message: String, extra: [String: Any] = [:]) {
+        var payload: [String: Any] = ["error": error, "message": message]
         for (k, v) in extra { payload[k] = v }
         let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data()
         FileHandle.standardError.write(data)
         FileHandle.standardError.write(Data("\n".utf8))
+    }
+
+    /// Write the structured JSON error for a ToolError to stderr and return
+    /// the CLI exit code. Every command's catch block calls this.
+    @discardableResult
+    static func emitToolError(_ error: ToolError) -> Int32 {
+        let (code, data) = error.renderStructured()
+        FileHandle.standardError.write(data)
+        FileHandle.standardError.write(Data("\n".utf8))
+        return code
+    }
+
+    private static func jsonEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
     }
 }
 

--- a/ClearlyCLI/Core/PathGuard.swift
+++ b/ClearlyCLI/Core/PathGuard.swift
@@ -1,41 +1,30 @@
 import Foundation
 
-enum PathGuardError: Error, LocalizedError {
-    case pathOutsideVault(String)
-    case invalidPath(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .pathOutsideVault(let path):
-            return "Path resolves outside the vault: \(path)"
-        case .invalidPath(let reason):
-            return "Invalid path: \(reason)"
-        }
-    }
-}
-
 enum PathGuard {
     /// Resolve a vault-relative path to an absolute URL inside the vault.
     ///
-    /// Rejects paths that are absolute, contain `..` segments, contain null bytes,
-    /// or resolve (after symlink resolution) outside the vault root.
+    /// Rejects paths that are absolute, contain `..` segments, contain null
+    /// bytes, or resolve (after symlink resolution) outside the vault root.
     /// Phase 2 implements the baseline safety net; Phase 3 extends the matrix
     /// (APFS case canonicalization, unicode lookalikes, symlink-to-/, etc.).
+    ///
+    /// Throws `ToolError` directly so callers in CLI and MCP share a single
+    /// error surface — no intermediate error type.
     static func resolve(relativePath: String, in vaultURL: URL) throws -> URL {
         if relativePath.isEmpty {
-            throw PathGuardError.invalidPath("empty path")
+            throw ToolError.invalidArgument(name: "relative_path", reason: "must not be empty")
         }
         if relativePath.contains("\0") {
-            throw PathGuardError.invalidPath("null byte in path")
+            throw ToolError.invalidArgument(name: "relative_path", reason: "must not contain null bytes")
         }
         if relativePath.hasPrefix("/") {
-            throw PathGuardError.invalidPath("absolute paths are not allowed: \(relativePath)")
+            throw ToolError.pathOutsideVault(relativePath)
         }
 
         let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
         for component in components {
             if component == ".." {
-                throw PathGuardError.invalidPath("parent traversal (..) is not allowed: \(relativePath)")
+                throw ToolError.pathOutsideVault(relativePath)
             }
         }
 
@@ -48,7 +37,7 @@ enum PathGuard {
         guard resolvedComponents.count >= rootComponents.count,
               Array(resolvedComponents.prefix(rootComponents.count)) == rootComponents
         else {
-            throw PathGuardError.pathOutsideVault(relativePath)
+            throw ToolError.pathOutsideVault(relativePath)
         }
 
         return resolved

--- a/ClearlyCLI/Core/PathGuard.swift
+++ b/ClearlyCLI/Core/PathGuard.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+enum PathGuardError: Error, LocalizedError {
+    case pathOutsideVault(String)
+    case invalidPath(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .pathOutsideVault(let path):
+            return "Path resolves outside the vault: \(path)"
+        case .invalidPath(let reason):
+            return "Invalid path: \(reason)"
+        }
+    }
+}
+
+enum PathGuard {
+    /// Resolve a vault-relative path to an absolute URL inside the vault.
+    ///
+    /// Rejects paths that are absolute, contain `..` segments, contain null bytes,
+    /// or resolve (after symlink resolution) outside the vault root.
+    /// Phase 2 implements the baseline safety net; Phase 3 extends the matrix
+    /// (APFS case canonicalization, unicode lookalikes, symlink-to-/, etc.).
+    static func resolve(relativePath: String, in vaultURL: URL) throws -> URL {
+        if relativePath.isEmpty {
+            throw PathGuardError.invalidPath("empty path")
+        }
+        if relativePath.contains("\0") {
+            throw PathGuardError.invalidPath("null byte in path")
+        }
+        if relativePath.hasPrefix("/") {
+            throw PathGuardError.invalidPath("absolute paths are not allowed: \(relativePath)")
+        }
+
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        for component in components {
+            if component == ".." {
+                throw PathGuardError.invalidPath("parent traversal (..) is not allowed: \(relativePath)")
+            }
+        }
+
+        let vaultRoot = vaultURL.standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = vaultRoot.appendingPathComponent(relativePath)
+        let resolved = candidate.standardizedFileURL.resolvingSymlinksInPath()
+
+        let rootComponents = vaultRoot.pathComponents
+        let resolvedComponents = resolved.pathComponents
+        guard resolvedComponents.count >= rootComponents.count,
+              Array(resolvedComponents.prefix(rootComponents.count)) == rootComponents
+        else {
+            throw PathGuardError.pathOutsideVault(relativePath)
+        }
+
+        return resolved
+    }
+}

--- a/ClearlyCLI/Core/ToolError.swift
+++ b/ClearlyCLI/Core/ToolError.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ToolError: Error, LocalizedError {
     case missingArgument(String)
     case invalidArgument(name: String, reason: String)
+    case invalidEncoding(String)
     case noteNotFound(String)
     case pathOutsideVault(String)
     case ambiguousVault(relativePath: String, matches: [String])
@@ -16,6 +17,8 @@ enum ToolError: Error, LocalizedError {
             return "Error: '\(name)' parameter is required"
         case .invalidArgument(let name, let reason):
             return "Error: '\(name)' \(reason)"
+        case .invalidEncoding(let path):
+            return "File is not valid UTF-8: \(path)"
         case .noteNotFound(let path):
             return "Note not found: \(path)\nMake sure the note exists and has been indexed by Clearly."
         case .pathOutsideVault(let path):
@@ -45,6 +48,11 @@ extension ToolError {
             payload["message"] = errorDescription ?? ""
             payload["argument"] = name
             payload["reason"] = reason
+        case .invalidEncoding(let path):
+            code = 1
+            payload["error"] = "invalid_encoding"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
         case .noteNotFound(let path):
             code = 3
             payload["error"] = "note_not_found"

--- a/ClearlyCLI/Core/ToolError.swift
+++ b/ClearlyCLI/Core/ToolError.swift
@@ -4,6 +4,8 @@ enum ToolError: Error, LocalizedError {
     case missingArgument(String)
     case invalidArgument(name: String, reason: String)
     case noteNotFound(String)
+    case pathOutsideVault(String)
+    case ambiguousVault(relativePath: String, matches: [String])
 
     // Exact text the MCP adapter emits in the `.text` content block. Preserves
     // byte-for-byte parity with the pre-refactor handler output — notably,
@@ -16,6 +18,52 @@ enum ToolError: Error, LocalizedError {
             return "Error: '\(name)' \(reason)"
         case .noteNotFound(let path):
             return "Note not found: \(path)\nMake sure the note exists and has been indexed by Clearly."
+        case .pathOutsideVault(let path):
+            return "Path resolves outside the vault: \(path)"
+        case .ambiguousVault(let path, let matches):
+            return "Ambiguous path '\(path)': matches \(matches.count) vaults (\(matches.joined(separator: ", "))). Specify --vault or the vault field."
         }
+    }
+}
+
+extension ToolError {
+    /// Maps a ToolError to a CLI exit code and a stable structured JSON payload.
+    /// Keys are snake_case to match the broader JSON contract.
+    func renderStructured() -> (exitCode: Int32, json: Data) {
+        let code: Int32
+        var payload: [String: Any] = [:]
+
+        switch self {
+        case .missingArgument(let name):
+            code = 2
+            payload["error"] = "missing_argument"
+            payload["message"] = errorDescription ?? ""
+            payload["argument"] = name
+        case .invalidArgument(let name, let reason):
+            code = 2
+            payload["error"] = "invalid_argument"
+            payload["message"] = errorDescription ?? ""
+            payload["argument"] = name
+            payload["reason"] = reason
+        case .noteNotFound(let path):
+            code = 3
+            payload["error"] = "note_not_found"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
+        case .pathOutsideVault(let path):
+            code = 4
+            payload["error"] = "path_outside_vault"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
+        case .ambiguousVault(let path, let matches):
+            code = 5
+            payload["error"] = "ambiguous_path"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
+            payload["matches"] = matches
+        }
+
+        let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)
+        return (code, data)
     }
 }

--- a/ClearlyCLI/Core/Tools/GetFrontmatter.swift
+++ b/ClearlyCLI/Core/Tools/GetFrontmatter.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct GetFrontmatterArgs: Codable {
+    let relativePath: String
+    let vault: String?
+}
+
+struct GetFrontmatterResult: Codable {
+    let vault: String
+    let relativePath: String
+    /// Flat dict of YAML frontmatter fields. Duplicate keys resolve
+    /// last-write-wins, matching FileParser's single-logical-value convention.
+    let frontmatter: [String: String]
+    let hasFrontmatter: Bool
+}
+
+func getFrontmatter(_ args: GetFrontmatterArgs, vaults: [LoadedVault]) async throws -> GetFrontmatterResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+
+    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.relativePath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let loaded):
+        let fileURL = try PathGuard.resolve(relativePath: args.relativePath, in: loaded.url)
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            throw ToolError.noteNotFound(args.relativePath)
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw ToolError.invalidArgument(name: "relative_path", reason: "file is not valid UTF-8")
+        }
+
+        guard let block = FrontmatterSupport.extract(from: text) else {
+            return GetFrontmatterResult(
+                vault: loaded.url.lastPathComponent,
+                relativePath: args.relativePath,
+                frontmatter: [:],
+                hasFrontmatter: false
+            )
+        }
+        var dict: [String: String] = [:]
+        for field in block.fields {
+            dict[field.key] = field.value
+        }
+        return GetFrontmatterResult(
+            vault: loaded.url.lastPathComponent,
+            relativePath: args.relativePath,
+            frontmatter: dict,
+            hasFrontmatter: true
+        )
+    }
+}

--- a/ClearlyCLI/Core/Tools/GetFrontmatter.swift
+++ b/ClearlyCLI/Core/Tools/GetFrontmatter.swift
@@ -19,7 +19,7 @@ func getFrontmatter(_ args: GetFrontmatterArgs, vaults: [LoadedVault]) async thr
         throw ToolError.missingArgument("relative_path")
     }
 
-    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    switch try VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
     case .notFound:
         throw ToolError.noteNotFound(args.relativePath)
     case .ambiguous(let matches):
@@ -36,7 +36,7 @@ func getFrontmatter(_ args: GetFrontmatterArgs, vaults: [LoadedVault]) async thr
             throw ToolError.noteNotFound(args.relativePath)
         }
         guard let text = String(data: data, encoding: .utf8) else {
-            throw ToolError.invalidArgument(name: "relative_path", reason: "file is not valid UTF-8")
+            throw ToolError.invalidEncoding(args.relativePath)
         }
 
         guard let block = FrontmatterSupport.extract(from: text) else {

--- a/ClearlyCLI/Core/Tools/GetHeadings.swift
+++ b/ClearlyCLI/Core/Tools/GetHeadings.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct GetHeadingsArgs: Codable {
+    let relativePath: String
+    let vault: String?
+}
+
+struct GetHeadingsResult: Codable {
+    struct HeadingEntry: Codable {
+        let text: String
+        let level: Int
+        let lineNumber: Int
+    }
+    let vault: String
+    let relativePath: String
+    let headings: [HeadingEntry]
+}
+
+func getHeadings(_ args: GetHeadingsArgs, vaults: [LoadedVault]) async throws -> GetHeadingsResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+
+    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.relativePath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let loaded):
+        guard let indexed = loaded.index.file(forRelativePath: args.relativePath) else {
+            throw ToolError.noteNotFound(args.relativePath)
+        }
+        let headings = loaded.index.headings(forFileId: indexed.id).map {
+            GetHeadingsResult.HeadingEntry(text: $0.text, level: $0.level, lineNumber: $0.lineNumber)
+        }
+        return GetHeadingsResult(
+            vault: loaded.url.lastPathComponent,
+            relativePath: args.relativePath,
+            headings: headings
+        )
+    }
+}

--- a/ClearlyCLI/Core/Tools/GetHeadings.swift
+++ b/ClearlyCLI/Core/Tools/GetHeadings.swift
@@ -21,7 +21,7 @@ func getHeadings(_ args: GetHeadingsArgs, vaults: [LoadedVault]) async throws ->
         throw ToolError.missingArgument("relative_path")
     }
 
-    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    switch try VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
     case .notFound:
         throw ToolError.noteNotFound(args.relativePath)
     case .ambiguous(let matches):
@@ -30,11 +30,17 @@ func getHeadings(_ args: GetHeadingsArgs, vaults: [LoadedVault]) async throws ->
             matches: matches.map { $0.url.lastPathComponent }
         )
     case .resolved(let loaded):
-        guard let indexed = loaded.index.file(forRelativePath: args.relativePath) else {
-            throw ToolError.noteNotFound(args.relativePath)
-        }
-        let headings = loaded.index.headings(forFileId: indexed.id).map {
-            GetHeadingsResult.HeadingEntry(text: $0.text, level: $0.level, lineNumber: $0.lineNumber)
+        // File exists on disk (VaultResolver confirmed). If it's not yet in
+        // the index, return empty headings rather than note_not_found —
+        // matches ReadNote's behavior and avoids a misleading error when the
+        // index is just behind.
+        let headings: [GetHeadingsResult.HeadingEntry]
+        if let indexed = loaded.index.file(forRelativePath: args.relativePath) {
+            headings = loaded.index.headings(forFileId: indexed.id).map {
+                GetHeadingsResult.HeadingEntry(text: $0.text, level: $0.level, lineNumber: $0.lineNumber)
+            }
+        } else {
+            headings = []
         }
         return GetHeadingsResult(
             vault: loaded.url.lastPathComponent,

--- a/ClearlyCLI/Core/Tools/ListNotes.swift
+++ b/ClearlyCLI/Core/Tools/ListNotes.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+struct ListNotesArgs: Codable {
+    let under: String?
+    let vault: String?
+}
+
+struct ListNotesResult: Codable {
+    struct NoteSummary: Codable {
+        let vault: String
+        let relativePath: String
+        let filename: String
+        let modifiedAt: String
+        let sizeBytes: Int
+    }
+    let notes: [NoteSummary]
+}
+
+func listNotes(_ args: ListNotesArgs, vaults: [LoadedVault]) async throws -> ListNotesResult {
+    let targetVaults: [LoadedVault]
+    if let hint = args.vault, !hint.isEmpty {
+        let hintPath = URL(fileURLWithPath: hint).standardizedFileURL.path
+        targetVaults = vaults.filter { vault in
+            vault.url.lastPathComponent == hint ||
+            vault.url.standardizedFileURL.path == hintPath
+        }
+        if targetVaults.isEmpty {
+            throw ToolError.invalidArgument(
+                name: "vault",
+                reason: "no loaded vault named or located at '\(hint)'"
+            )
+        }
+    } else {
+        targetVaults = vaults
+    }
+
+    let underPrefix: String?
+    if let raw = args.under, !raw.isEmpty {
+        underPrefix = raw.hasSuffix("/") ? raw : raw + "/"
+    } else {
+        underPrefix = nil
+    }
+
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    var notes: [ListNotesResult.NoteSummary] = []
+    for loaded in targetVaults {
+        let tree = FileNode.buildTree(at: loaded.url, showHiddenFiles: false, ignoreRules: nil)
+        collectFiles(tree, vaultURL: loaded.url, vaultName: loaded.url.lastPathComponent, iso: iso, under: underPrefix, into: &notes)
+    }
+    return ListNotesResult(notes: notes)
+}
+
+private func collectFiles(
+    _ nodes: [FileNode],
+    vaultURL: URL,
+    vaultName: String,
+    iso: ISO8601DateFormatter,
+    under: String?,
+    into notes: inout [ListNotesResult.NoteSummary]
+) {
+    for node in nodes {
+        if let children = node.children {
+            collectFiles(children, vaultURL: vaultURL, vaultName: vaultName, iso: iso, under: under, into: &notes)
+            continue
+        }
+        let relativePath = relativePath(of: node.url, from: vaultURL)
+        if let under, !relativePath.hasPrefix(under) {
+            continue
+        }
+        let attrs = try? FileManager.default.attributesOfItem(atPath: node.url.path)
+        let modified = (attrs?[.modificationDate] as? Date) ?? Date()
+        let size = (attrs?[.size] as? Int) ?? 0
+
+        notes.append(ListNotesResult.NoteSummary(
+            vault: vaultName,
+            relativePath: relativePath,
+            filename: node.name,
+            modifiedAt: iso.string(from: modified),
+            sizeBytes: size
+        ))
+    }
+}
+
+private func relativePath(of fileURL: URL, from vaultURL: URL) -> String {
+    let root = vaultURL.standardizedFileURL.path
+    let full = fileURL.standardizedFileURL.path
+    if full.hasPrefix(root + "/") {
+        return String(full.dropFirst(root.count + 1))
+    }
+    return full
+}

--- a/ClearlyCLI/Core/Tools/ReadNote.swift
+++ b/ClearlyCLI/Core/Tools/ReadNote.swift
@@ -1,0 +1,141 @@
+import Foundation
+import CryptoKit
+
+struct ReadNoteArgs: Codable {
+    let relativePath: String
+    let startLine: Int?
+    let endLine: Int?
+    let vault: String?
+}
+
+struct ReadNoteResult: Codable {
+    struct HeadingEntry: Codable {
+        let text: String
+        let level: Int
+        let lineNumber: Int
+    }
+    struct LineRange: Codable {
+        let start: Int
+        let end: Int
+    }
+
+    let vault: String
+    let relativePath: String
+    let content: String
+    let contentHash: String
+    let sizeBytes: Int
+    let modifiedAt: String
+    /// Flattened from FrontmatterSupport.Block.fields. Duplicate keys resolve
+    /// last-write-wins — same convention FileParser uses when reading a single
+    /// logical value per key.
+    let frontmatter: [String: String]
+    let headings: [HeadingEntry]
+    let tags: [String]
+    let lineRange: LineRange?
+}
+
+func readNote(_ args: ReadNoteArgs, vaults: [LoadedVault]) async throws -> ReadNoteResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+
+    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.relativePath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let loaded):
+        let fileURL = try PathGuard.resolve(relativePath: args.relativePath, in: loaded.url)
+        let rawData: Data
+        do {
+            rawData = try Data(contentsOf: fileURL)
+        } catch {
+            throw ToolError.noteNotFound(args.relativePath)
+        }
+        guard let fullContent = String(data: rawData, encoding: .utf8) else {
+            throw ToolError.invalidArgument(name: "relative_path", reason: "file is not valid UTF-8")
+        }
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let modifiedAt = (attrs?[.modificationDate] as? Date) ?? Date()
+        let sizeBytes = rawData.count
+
+        let hash = SHA256.hash(data: rawData)
+        let contentHash = hash.map { String(format: "%02x", $0) }.joined()
+
+        let (slice, lineRange) = applyLineRange(
+            fullContent,
+            start: args.startLine,
+            end: args.endLine
+        )
+
+        let frontmatter: [String: String]
+        if let block = FrontmatterSupport.extract(from: fullContent) {
+            var dict: [String: String] = [:]
+            for field in block.fields {
+                dict[field.key] = field.value
+            }
+            frontmatter = dict
+        } else {
+            frontmatter = [:]
+        }
+
+        let indexed = loaded.index.file(forRelativePath: args.relativePath)
+        let headings: [ReadNoteResult.HeadingEntry]
+        let tags: [String]
+        if let indexed {
+            headings = loaded.index.headings(forFileId: indexed.id).map {
+                ReadNoteResult.HeadingEntry(text: $0.text, level: $0.level, lineNumber: $0.lineNumber)
+            }
+            tags = loaded.index.tags(forFileId: indexed.id)
+        } else {
+            headings = []
+            tags = []
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        return ReadNoteResult(
+            vault: loaded.url.lastPathComponent,
+            relativePath: args.relativePath,
+            content: slice,
+            contentHash: contentHash,
+            sizeBytes: sizeBytes,
+            modifiedAt: iso.string(from: modifiedAt),
+            frontmatter: frontmatter,
+            headings: headings,
+            tags: tags,
+            lineRange: lineRange
+        )
+    }
+}
+
+/// Slice the content by 1-based inclusive line numbers, clamping to file bounds.
+/// Returns the slice plus the echoed LineRange reflecting the actual clamp.
+/// If neither start nor end is provided, returns full content and `nil`.
+private func applyLineRange(
+    _ content: String,
+    start: Int?,
+    end: Int?
+) -> (String, ReadNoteResult.LineRange?) {
+    if start == nil, end == nil {
+        return (content, nil)
+    }
+
+    let lines = content.components(separatedBy: "\n")
+    let total = lines.count
+
+    let rawStart = max(1, start ?? 1)
+    let rawEnd = min(total, end ?? total)
+
+    if rawStart > rawEnd || rawStart > total {
+        return ("", ReadNoteResult.LineRange(start: rawStart, end: rawEnd))
+    }
+
+    let slice = lines[(rawStart - 1)..<rawEnd].joined(separator: "\n")
+    return (slice, ReadNoteResult.LineRange(start: rawStart, end: rawEnd))
+}

--- a/ClearlyCLI/Core/Tools/ReadNote.swift
+++ b/ClearlyCLI/Core/Tools/ReadNote.swift
@@ -39,7 +39,7 @@ func readNote(_ args: ReadNoteArgs, vaults: [LoadedVault]) async throws -> ReadN
         throw ToolError.missingArgument("relative_path")
     }
 
-    switch VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    switch try VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
     case .notFound:
         throw ToolError.noteNotFound(args.relativePath)
     case .ambiguous(let matches):
@@ -53,10 +53,14 @@ func readNote(_ args: ReadNoteArgs, vaults: [LoadedVault]) async throws -> ReadN
         do {
             rawData = try Data(contentsOf: fileURL)
         } catch {
+            // VaultResolver confirmed the file exists, so a read failure here
+            // is either a TOCTOU race (file was deleted between check and
+            // read) or a permission denial. noteNotFound is the closest stable
+            // identifier for both; Phase 3 may split out an io_error surface.
             throw ToolError.noteNotFound(args.relativePath)
         }
         guard let fullContent = String(data: rawData, encoding: .utf8) else {
-            throw ToolError.invalidArgument(name: "relative_path", reason: "file is not valid UTF-8")
+            throw ToolError.invalidEncoding(args.relativePath)
         }
 
         let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)

--- a/ClearlyCLI/Core/VaultResolver.swift
+++ b/ClearlyCLI/Core/VaultResolver.swift
@@ -7,16 +7,35 @@ enum VaultResolver {
         case ambiguous([LoadedVault])
     }
 
-    static func resolve(path: String, in vaults: [LoadedVault]) -> Resolution {
-        let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
-        let matches = vaults.filter { vault in
-            let root = vault.url.standardizedFileURL.path
-            return root == normalized || normalized.hasPrefix(root + "/")
+    /// Resolve which loaded vault owns a vault-relative path.
+    ///
+    /// Semantics:
+    /// - `hint` matches a vault by its basename (`lastPathComponent`) or by its full standardized path.
+    /// - Among vaults matching the hint (or all vaults if no hint), the file at `<vault>/<relativePath>` is checked.
+    /// - Exactly one hit → `.resolved`. Zero hits → `.notFound`. More than one → `.ambiguous`.
+    static func resolve(relativePath: String, hint: String?, in vaults: [LoadedVault]) -> Resolution {
+        let filtered: [LoadedVault]
+        if let hint = hint, !hint.isEmpty {
+            let hintPath = URL(fileURLWithPath: hint).standardizedFileURL.path
+            filtered = vaults.filter { vault in
+                vault.url.lastPathComponent == hint ||
+                vault.url.standardizedFileURL.path == hintPath
+            }
+            if filtered.isEmpty {
+                return .notFound
+            }
+        } else {
+            filtered = vaults
         }
-        switch matches.count {
+
+        let hits = filtered.filter { vault in
+            let target = vault.url.appendingPathComponent(relativePath).path
+            return FileManager.default.fileExists(atPath: target)
+        }
+        switch hits.count {
         case 0: return .notFound
-        case 1: return .resolved(matches[0])
-        default: return .ambiguous(matches)
+        case 1: return .resolved(hits[0])
+        default: return .ambiguous(hits)
         }
     }
 }

--- a/ClearlyCLI/Core/VaultResolver.swift
+++ b/ClearlyCLI/Core/VaultResolver.swift
@@ -10,10 +10,14 @@ enum VaultResolver {
     /// Resolve which loaded vault owns a vault-relative path.
     ///
     /// Semantics:
-    /// - `hint` matches a vault by its basename (`lastPathComponent`) or by its full standardized path.
-    /// - Among vaults matching the hint (or all vaults if no hint), the file at `<vault>/<relativePath>` is checked.
-    /// - Exactly one hit → `.resolved`. Zero hits → `.notFound`. More than one → `.ambiguous`.
-    static func resolve(relativePath: String, hint: String?, in vaults: [LoadedVault]) -> Resolution {
+    /// - `hint` matches a vault by its basename (`lastPathComponent`) or by its
+    ///   full standardized path.
+    /// - For each candidate vault, `PathGuard.resolve` runs — this throws
+    ///   `ToolError.pathOutsideVault` / `.invalidArgument` for unsafe paths
+    ///   (absolute, `..`, null bytes, symlink escape) *before* any file-system
+    ///   existence check. Callers get a consistent error identifier.
+    /// - Exactly one hit on disk → `.resolved`. Zero → `.notFound`. >1 → `.ambiguous`.
+    static func resolve(relativePath: String, hint: String?, in vaults: [LoadedVault]) throws -> Resolution {
         let filtered: [LoadedVault]
         if let hint = hint, !hint.isEmpty {
             let hintPath = URL(fileURLWithPath: hint).standardizedFileURL.path
@@ -28,9 +32,12 @@ enum VaultResolver {
             filtered = vaults
         }
 
-        let hits = filtered.filter { vault in
-            let target = vault.url.appendingPathComponent(relativePath).path
-            return FileManager.default.fileExists(atPath: target)
+        var hits: [LoadedVault] = []
+        for vault in filtered {
+            let resolvedURL = try PathGuard.resolve(relativePath: relativePath, in: vault.url)
+            if FileManager.default.fileExists(atPath: resolvedURL.path) {
+                hits.append(vault)
+            }
         }
         switch hits.count {
         case 0: return .notFound

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -26,15 +26,89 @@ enum Handlers {
                 let result = try await getTags(args, vaults: vaults)
                 return .init(content: [.text(renderTagsText(result, multiVault: multiVault))])
 
+            case "read_note":
+                let args = ReadNoteArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    startLine: params.arguments?["start_line"]?.intValue,
+                    endLine: params.arguments?["end_line"]?.intValue,
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return await structuredCall { try await readNote(args, vaults: vaults) }
+
+            case "list_notes":
+                let args = ListNotesArgs(
+                    under: params.arguments?["under"]?.stringValue,
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return await structuredCall { try await listNotes(args, vaults: vaults) }
+
+            case "get_headings":
+                let args = GetHeadingsArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return await structuredCall { try await getHeadings(args, vaults: vaults) }
+
+            case "get_frontmatter":
+                let args = GetFrontmatterArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return await structuredCall { try await getFrontmatter(args, vaults: vaults) }
+
             default:
                 return .init(content: [.text("Unknown tool: \(params.name)")], isError: false)
             }
         } catch let error as ToolError {
+            // Legacy text-only path — covers the Phase-1 tools (search_notes,
+            // get_backlinks, get_tags). Phase 4 ports them to structured output.
             return .init(content: [.text(error.localizedDescription)], isError: true)
         } catch {
             return .init(content: [.text("Error: \(error.localizedDescription)")], isError: true)
         }
     }
+
+    /// Run a new structured-output tool and return a CallTool.Result with both
+    /// `content: [.text(json)]` (for older clients) and `structuredContent`
+    /// (for clients following the 2025-11-25 MCP spec).
+    /// Errors are rendered as structured JSON with `isError: true` so the shape
+    /// is stable across the success and error paths.
+    private static func structuredCall<T: Encodable>(
+        _ work: () async throws -> T
+    ) async -> CallTool.Result {
+        do {
+            let value = try await work()
+            let (text, structured) = try encodeStructured(value)
+            let boxed: Value? = structured
+            return .init(content: [.text(text)], structuredContent: boxed, isError: false)
+        } catch let error as ToolError {
+            let (_, data) = error.renderStructured()
+            let text = String(data: data, encoding: .utf8) ?? "{}"
+            let structured: Value? = (try? JSONDecoder().decode(Value.self, from: data)) ?? .object([:])
+            return .init(content: [.text(text)], structuredContent: structured, isError: true)
+        } catch {
+            let payload: [String: Any] = [
+                "error": "internal_error",
+                "message": error.localizedDescription
+            ]
+            let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)
+            let text = String(data: data, encoding: .utf8) ?? "{}"
+            let structured: Value? = (try? JSONDecoder().decode(Value.self, from: data)) ?? .object([:])
+            return .init(content: [.text(text)], structuredContent: structured, isError: true)
+        }
+    }
+}
+
+/// Encode an `Encodable` value to both a JSON string (for `content: [.text]`)
+/// and a `Value` (for `structuredContent`). Snake_case keys on output.
+func encodeStructured<T: Encodable>(_ value: T) throws -> (text: String, structured: Value) {
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(value)
+    let text = String(data: data, encoding: .utf8) ?? "{}"
+    let structured = try JSONDecoder().decode(Value.self, from: data)
+    return (text, structured)
 }
 
 private func renderSearchText(_ r: SearchNotesResult, multiVault: Bool) -> String {

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -6,6 +6,13 @@ enum ToolRegistry {
         let vaultPaths = vaults.map { $0.url.path }
         let vaultDescription = vaultPaths.joined(separator: ", ")
 
+        let readAnnotations = Tool.Annotations(
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false
+        )
+
         return [
             Tool(
                 name: "search_notes",
@@ -50,6 +57,140 @@ enum ToolRegistry {
                             "description": .string("Specific tag to look up (without # prefix). Omit to list all tags.")
                         ])
                     ])
+                ])
+            ),
+            Tool(
+                name: "read_note",
+                description: "Read the full content of a note in a vault, optionally restricted to a line range. Returns content plus metadata (content hash, size, modification time, parsed frontmatter, headings, tags).",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path, e.g. 'Daily/2026-04-16.md'. Must not start with '/' or contain '..'.")
+                        ]),
+                        "start_line": .object([
+                            "type": .string("integer"),
+                            "minimum": .int(1),
+                            "description": .string("Optional. 1-based line number to start reading from. Omit to read from the beginning.")
+                        ]),
+                        "end_line": .object([
+                            "type": .string("integer"),
+                            "minimum": .int(1),
+                            "description": .string("Optional. 1-based line number to stop at (inclusive). Omit to read to end of file.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name disambiguator. Required only when multiple vaults are loaded and 'relative_path' is ambiguous.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":          .object(["type": .string("string")]),
+                        "relative_path":  .object(["type": .string("string")]),
+                        "content":        .object(["type": .string("string")]),
+                        "content_hash":   .object(["type": .string("string")]),
+                        "size_bytes":     .object(["type": .string("integer")]),
+                        "modified_at":    .object(["type": .string("string"), "format": .string("date-time")]),
+                        "frontmatter":    .object(["type": .string("object"), "additionalProperties": .object(["type": .string("string")])]),
+                        "headings":       .object(["type": .string("array"), "items": .object(["type": .string("object")])]),
+                        "tags":           .object(["type": .string("array"), "items": .object(["type": .string("string")])]),
+                        "line_range":     .object(["type": .string("object"), "description": .string("Present when start_line / end_line were specified.")])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("content"), .string("content_hash")])
+                ])
+            ),
+            Tool(
+                name: "list_notes",
+                description: "List notes in loaded vault(s). Uses a fresh filesystem walk (always current) rather than the index. Optionally restricted to a subpath prefix.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "under": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault-relative directory prefix, e.g. 'Daily/'. Only notes whose path starts with this prefix are returned.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name. When omitted, notes across all loaded vaults are returned.")
+                        ])
+                    ])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "notes": .object([
+                            "type": .string("array"),
+                            "items": .object(["type": .string("object")])
+                        ])
+                    ]),
+                    "required": .array([.string("notes")])
+                ])
+            ),
+            Tool(
+                name: "get_headings",
+                description: "Return the heading outline (H1–H6) of a note, including heading text, level, and 1-based line number. Sourced from the index.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path, e.g. 'Strategy/pricing.md'.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name disambiguator.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":         .object(["type": .string("string")]),
+                        "relative_path": .object(["type": .string("string")]),
+                        "headings":      .object(["type": .string("array"), "items": .object(["type": .string("object")])])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("headings")])
+                ])
+            ),
+            Tool(
+                name: "get_frontmatter",
+                description: "Return the parsed YAML frontmatter of a note as a flat key-value map. Returns an empty map when the note has no frontmatter block.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path, e.g. 'Projects/2026-plan.md'.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name disambiguator.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":           .object(["type": .string("string")]),
+                        "relative_path":   .object(["type": .string("string")]),
+                        "frontmatter":     .object(["type": .string("object"), "additionalProperties": .object(["type": .string("string")])]),
+                        "has_frontmatter": .object(["type": .string("boolean")])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("frontmatter"), .string("has_frontmatter")])
                 ])
             )
         ]


### PR DESCRIPTION
## Summary

Phase 2 of the `local-mcp-cli` feature. Ships 4 new read tools on MCP and CLI surfaces, plus the `structuredContent` + `outputSchema` pattern on the MCP side. Exit-code-parity error envelopes on the CLI side.

New tools: `read_note`, `list_notes`, `get_headings`, `get_frontmatter`.

Read annotations: `readOnlyHint: true`, `idempotentHint: true`, `destructiveHint: false`, `openWorldHint: false`.

Frozen schema shapes — see `Core/Tools/*.swift` `Result` types. These become the public contract that `cloud-api` (feature #3) will mirror.

## Implementation notes

- **`VaultIndex` extensions** (`Clearly/VaultIndex.swift`): `headings(forFileId:) -> [ParsedHeading]` and `tags(forFileId:) -> [String]` (SELECT DISTINCT). Mirror the sync, return-empty-on-error pattern of existing `linksTo/linksFrom`.
- **`PathGuard`** (`ClearlyCLI/Core/PathGuard.swift`): baseline safety — rejects `/`-prefix, `..` components, null bytes, symlink escapes. Phase 3 extends the matrix (APFS case, unicode lookalikes, symlink-to-/).
- **`VaultResolver`** repurposed: takes a vault-relative path + optional name/path hint, returns `.resolved | .notFound | .ambiguous`.
- **`ToolError`** gains `.pathOutsideVault` and `.ambiguousVault`. New `renderStructured()` helper produces stable `{error, message, relative_path, matches}` payloads used by both CLI (via `Emitter.emitToolError`) and MCP (inside `structuredCall`).
- **`Handlers.structuredCall`**: single wrapper that emits `content: [.text(json)] + structuredContent: Value` on success and the same shape with `isError: true` on failure. Legacy Phase-1 tools keep their text-only output.
- **CLI `--in-vault`** (not `--vault`): avoids collision with the global `--vault` flag that selects which vaults to load.
- **Frontmatter flattening**: `FrontmatterSupport.Block.fields` is `[Field]` (key/value pairs; duplicates possible). Flattened to `[String: String]` last-write-wins, matching `FileParser`'s single-logical-value convention. Documented inline.

## Deferred from Phase 2

- **`ClearlyCLITests` target**: `@testable import ClearlyCLI` requires a library module; `ClearlyCLI` is currently a Swift executable. The lib + exec wrapper split is larger than Phase 2 scope and is forced by Phase 3's write-tool path-traversal test matrix — doing it there avoids landing the split twice. Integration-style tests that shell out to the binary are a viable middle-ground if preferred sooner.

## Test plan

- [x] `xcodebuild -scheme Clearly -configuration Debug build` — zero errors, zero new warnings (only pre-existing warnings documented in PR #187).
- [x] `rg -n 'print\(' ClearlyCLI/Core ClearlyCLI/MCP` — no matches (stdout hygiene).
- [x] `clearly list | wc -l` — 456 notes in dev vault. `clearly list --under 'Blog Posts/' | wc -l` — 3. NDJSON, one record per line.
- [x] `clearly read <note>` — single-line JSON on stdout with content, content_hash, size_bytes, modified_at, frontmatter, headings, tags.
- [x] `clearly read <note> --start-line 1 --end-line 2` — content clamped to 47 bytes, `line_range: {start:1, end:2}` echoed.
- [x] `clearly read missing.md` — stderr JSON `{"error":"note_not_found", ...}`, stdout empty, exit 3.
- [x] `clearly headings <note>` — outline JSON with `text/level/line_number` per heading.
- [x] `clearly frontmatter <yaml-note>` — `has_frontmatter: true`, flat keys dict.
- [x] MCP `initialize` + `tools/list` — returns 7 tools (3 Phase-1 + 4 Phase-2). All 4 new tools have `outputSchema`.
- [x] MCP `read_note` tools/call — response has both `content: [.text(json)]` AND `structuredContent` with snake_case keys. `content_hash` matches CLI output byte-for-byte.
- [x] MCP `read_note` on missing file — `isError: true`, `structuredContent.error == "note_not_found"`.
- [x] MCP `search_notes` tools/call — still emits text-only "Found N file(s) ..." (no regression from Phase 1 behavior).
- [ ] **Reviewer to run**: live smoke test via Claude Desktop / Claude Code / MCP Inspector against PR build on a real vault.

Docs update in seoul lands separately.