### PR TITLE
Phase 3: write tools (create_note, update_note)

### DIFF
--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -148,6 +148,90 @@ final class VaultIndex: @unchecked Sendable {
         try migrator.migrate(dbPool)
     }
 
+
+    // MARK: Write — Single File
+
+    @discardableResult
+    func updateFile(at relativePath: String) throws -> IndexedFile? {
+        let fileURL = rootURL.appendingPathComponent(relativePath)
+
+        return try dbPool.write { db in
+            let existingRow = try Row.fetchOne(db, sql: "SELECT id, content_hash FROM files WHERE path = ?", arguments: [relativePath])
+
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                if let id: Int64 = existingRow?["id"] {
+                    try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [id])
+                    try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [id])
+                    try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [id])
+                    try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [id])
+                    try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [id])
+                }
+                return nil
+            }
+
+            guard let data = try? Data(contentsOf: fileURL),
+                  let content = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+
+            let hash = Self.contentHash(data)
+            if let existingHash: String = existingRow?["content_hash"], existingHash == hash {
+                let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE path = ?", arguments: [relativePath])
+                return row.map(Self.indexedFile(from:))
+            }
+
+            let filename = fileURL.deletingPathExtension().lastPathComponent
+            let modDate = Self.fileModDate(fileURL)
+            let now = Date()
+
+            if let existingId: Int64 = existingRow?["id"] {
+                try db.execute(sql: """
+                    UPDATE files SET filename = ?, content_hash = ?, modified_at = ?, indexed_at = ?
+                    WHERE id = ?
+                    """, arguments: [filename, hash, modDate.timeIntervalSince1970, now.timeIntervalSince1970, existingId])
+
+                try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existingId])
+                try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                               arguments: [existingId, filename, content])
+
+                try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [existingId])
+                try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [existingId])
+                try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existingId])
+
+                self.insertParsedData(db: db, fileId: existingId, content: content)
+
+                let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE id = ?", arguments: [existingId])
+                return row.map(Self.indexedFile(from:))
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO files (path, filename, content_hash, modified_at, indexed_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """, arguments: [relativePath, filename, hash, modDate.timeIntervalSince1970, now.timeIntervalSince1970])
+
+                let fileId = db.lastInsertedRowID
+
+                try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                               arguments: [fileId, filename, content])
+
+                self.insertParsedData(db: db, fileId: fileId, content: content)
+
+                let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE id = ?", arguments: [fileId])
+                return row.map(Self.indexedFile(from:))
+            }
+        }
+    }
+
+    func resolveLinksToFile(named filename: String) throws {
+        try dbPool.write { db in
+            let lower = filename.lowercased()
+            try db.execute(sql: """
+                UPDATE links SET target_file_id = (
+                    SELECT id FROM files WHERE LOWER(filename) = ? LIMIT 1
+                ) WHERE LOWER(target_name) = ? AND target_file_id IS NULL
+                """, arguments: [lower, lower])
+        }
+    }
+
     // MARK: Write — Full Index
 
     func indexAllFiles(showHiddenFiles: Bool = false) {

--- a/ClearlyCLI/CLI/Commands/CreateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/CreateCommand.swift
@@ -4,13 +4,55 @@ import Foundation
 struct CreateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "create",
-        abstract: "Create a new note (arrives in Phase 3)."
+        abstract: "Create a new note at the given vault-relative path."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path, e.g. 'Daily/2026-04-17.md'.")
+    var relativePath: String
+
+    @Option(name: .long, help: "Note content as a string. Mutually exclusive with --from-stdin.")
+    var content: String?
+
+    @Flag(name: .customLong("from-stdin"), help: "Read content from stdin.")
+    var fromStdin: Bool = false
+
+    @Option(name: .customLong("in-vault"), help: "Vault name or path (required when multiple vaults are loaded).")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly create — not yet implemented (Phase 3)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let body: String
+        if let c = content {
+            guard !fromStdin else {
+                Emitter.emitError("invalid_argument", message: "--content and --from-stdin are mutually exclusive")
+                throw ExitCode(Exit.usage)
+            }
+            body = c
+        } else if fromStdin {
+            body = readAllStdin()
+        } else {
+            Emitter.emitError("missing_argument", message: "Provide --content or --from-stdin")
+            throw ExitCode(Exit.usage)
+        }
+
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError("no_vaults", message: "Unable to open any vault index: \(error.localizedDescription)")
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await createNote(
+                CreateNoteArgs(relativePath: relativePath, content: body, vault: inVault),
+                vaults: vaults
+            )
+            try Emitter.emit(result, format: globals.format)
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/UpdateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/UpdateCommand.swift
@@ -1,16 +1,63 @@
 import ArgumentParser
 import Foundation
 
+extension UpdateMode: ExpressibleByArgument {}
+
 struct UpdateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "update",
-        abstract: "Update an existing note (arrives in Phase 3)."
+        abstract: "Update an existing note with replace, append, or prepend mode."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path, e.g. 'Daily/2026-04-17.md'.")
+    var relativePath: String
+
+    @Option(name: .long, help: "Update mode: replace, append, or prepend.")
+    var mode: UpdateMode
+
+    @Option(name: .long, help: "New content as a string. Mutually exclusive with --from-stdin.")
+    var content: String?
+
+    @Flag(name: .customLong("from-stdin"), help: "Read content from stdin.")
+    var fromStdin: Bool = false
+
+    @Option(name: .customLong("in-vault"), help: "Vault name or path.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly update — not yet implemented (Phase 3)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let body: String
+        if let c = content {
+            guard !fromStdin else {
+                Emitter.emitError("invalid_argument", message: "--content and --from-stdin are mutually exclusive")
+                throw ExitCode(Exit.usage)
+            }
+            body = c
+        } else if fromStdin {
+            body = readAllStdin()
+        } else {
+            Emitter.emitError("missing_argument", message: "Provide --content or --from-stdin")
+            throw ExitCode(Exit.usage)
+        }
+
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError("no_vaults", message: "Unable to open any vault index: \(error.localizedDescription)")
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await updateNote(
+                UpdateNoteArgs(relativePath: relativePath, content: body, mode: mode, vault: inVault),
+                vaults: vaults
+            )
+            try Emitter.emit(result, format: globals.format)
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Emitters.swift
+++ b/ClearlyCLI/CLI/Emitters.swift
@@ -58,3 +58,9 @@ enum Emitter {
 enum CLIError: Error {
     case textFormatUnavailable
 }
+
+func readAllStdin() -> String {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
+}
+

--- a/ClearlyCLI/Core/PathGuard.swift
+++ b/ClearlyCLI/Core/PathGuard.swift
@@ -21,9 +21,25 @@ enum PathGuard {
             throw ToolError.pathOutsideVault(relativePath)
         }
 
+        // Unicode traversal lookalikes
+        if relativePath.contains("\u{2025}") ||
+           relativePath.contains("\u{FF0E}\u{FF0E}") {
+            throw ToolError.pathOutsideVault(relativePath)
+        }
+
+        // Windows-style traversal
+        if relativePath.contains("..\\") {
+            throw ToolError.pathOutsideVault(relativePath)
+        }
+
+        // Shell metacharacters
+        if relativePath.contains("$(") || relativePath.contains("`") {
+            throw ToolError.invalidArgument(name: "relative_path", reason: "must not contain shell metacharacters")
+        }
+
         let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
         for component in components {
-            if component == ".." {
+            if component == ".." || component == "\u{2025}" {
                 throw ToolError.pathOutsideVault(relativePath)
             }
         }

--- a/ClearlyCLI/Core/ToolError.swift
+++ b/ClearlyCLI/Core/ToolError.swift
@@ -7,6 +7,7 @@ enum ToolError: Error, LocalizedError {
     case noteNotFound(String)
     case pathOutsideVault(String)
     case ambiguousVault(relativePath: String, matches: [String])
+    case conflict(existingPath: String)
 
     // Exact text the MCP adapter emits in the `.text` content block. Preserves
     // byte-for-byte parity with the pre-refactor handler output — notably,
@@ -25,6 +26,8 @@ enum ToolError: Error, LocalizedError {
             return "Path resolves outside the vault: \(path)"
         case .ambiguousVault(let path, let matches):
             return "Ambiguous path '\(path)': matches \(matches.count) vaults (\(matches.joined(separator: ", "))). Specify --vault or the vault field."
+        case .conflict(let path):
+            return "Note already exists: \(path)\nUse update_note to modify existing notes."
         }
     }
 }
@@ -69,6 +72,11 @@ extension ToolError {
             payload["message"] = errorDescription ?? ""
             payload["relative_path"] = path
             payload["matches"] = matches
+        case .conflict(let path):
+            code = 5
+            payload["error"] = "note_exists"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
         }
 
         let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)

--- a/ClearlyCLI/Core/Tools/CreateNote.swift
+++ b/ClearlyCLI/Core/Tools/CreateNote.swift
@@ -1,0 +1,65 @@
+import Foundation
+import CryptoKit
+
+struct CreateNoteArgs: Codable {
+    let relativePath: String
+    let content: String
+    let vault: String?
+}
+
+struct CreateNoteResult: Codable {
+    let vault: String
+    let relativePath: String
+    let contentHash: String
+    let sizeBytes: Int
+    let createdAt: String
+}
+
+func createNote(_ args: CreateNoteArgs, vaults: [LoadedVault]) async throws -> CreateNoteResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+
+    let loaded: LoadedVault
+    switch try VaultResolver.resolveForWrite(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.invalidArgument(name: "vault", reason: "no loaded vault matches '\(args.vault ?? "")'")
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let v):
+        loaded = v
+    }
+
+    let fileURL = try PathGuard.resolve(relativePath: args.relativePath, in: loaded.url)
+
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        throw ToolError.conflict(existingPath: args.relativePath)
+    }
+
+    let parentDir = fileURL.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+
+    let data = Data(args.content.utf8)
+    try data.write(to: fileURL, options: .atomic)
+
+    try loaded.index.updateFile(at: args.relativePath)
+
+    let filename = fileURL.deletingPathExtension().lastPathComponent
+    try loaded.index.resolveLinksToFile(named: filename)
+
+    let hash = SHA256.hash(data: data)
+    let contentHash = hash.map { String(format: "%02x", $0) }.joined()
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    return CreateNoteResult(
+        vault: loaded.url.lastPathComponent,
+        relativePath: args.relativePath,
+        contentHash: contentHash,
+        sizeBytes: data.count,
+        createdAt: iso.string(from: Date())
+    )
+}

--- a/ClearlyCLI/Core/Tools/UpdateNote.swift
+++ b/ClearlyCLI/Core/Tools/UpdateNote.swift
@@ -1,0 +1,87 @@
+import Foundation
+import CryptoKit
+
+enum UpdateMode: String, CaseIterable, Codable {
+    case replace
+    case append
+    case prepend
+}
+
+struct UpdateNoteArgs: Codable {
+    let relativePath: String
+    let content: String
+    let mode: UpdateMode
+    let vault: String?
+}
+
+struct UpdateNoteResult: Codable {
+    let vault: String
+    let relativePath: String
+    let mode: String
+    let contentHash: String
+    let sizeBytes: Int
+    let modifiedAt: String
+}
+
+func updateNote(_ args: UpdateNoteArgs, vaults: [LoadedVault]) async throws -> UpdateNoteResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+
+    let loaded: LoadedVault
+    switch try VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.relativePath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let v):
+        loaded = v
+    }
+
+    let fileURL = try PathGuard.resolve(relativePath: args.relativePath, in: loaded.url)
+
+    let rawData = try Data(contentsOf: fileURL)
+    guard let existing = String(data: rawData, encoding: .utf8) else {
+        throw ToolError.invalidEncoding(args.relativePath)
+    }
+
+    let composed: String
+    switch args.mode {
+    case .replace:
+        composed = args.content
+    case .append:
+        let separator = existing.hasSuffix("\n") ? "" : "\n"
+        composed = existing + separator + args.content
+    case .prepend:
+        if let block = FrontmatterSupport.extract(from: existing) {
+            composed = "---\n" + block.rawText + "\n---\n" + args.content + "\n" + block.body
+        } else {
+            composed = args.content + "\n" + existing
+        }
+    }
+
+    let newData = Data(composed.utf8)
+    try newData.write(to: fileURL, options: .atomic)
+
+    try loaded.index.updateFile(at: args.relativePath)
+
+    let hash = SHA256.hash(data: newData)
+    let contentHash = hash.map { String(format: "%02x", $0) }.joined()
+
+    let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+    let modifiedAt = (attrs?[.modificationDate] as? Date) ?? Date()
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    return UpdateNoteResult(
+        vault: loaded.url.lastPathComponent,
+        relativePath: args.relativePath,
+        mode: args.mode.rawValue,
+        contentHash: contentHash,
+        sizeBytes: newData.count,
+        modifiedAt: iso.string(from: modifiedAt)
+    )
+}

--- a/ClearlyCLI/Core/VaultResolver.swift
+++ b/ClearlyCLI/Core/VaultResolver.swift
@@ -45,4 +45,26 @@ enum VaultResolver {
         default: return .ambiguous(hits)
         }
     }
+
+    static func resolveForWrite(relativePath: String, hint: String?, in vaults: [LoadedVault]) throws -> Resolution {
+        let filtered: [LoadedVault]
+        if let hint = hint, !hint.isEmpty {
+            let hintPath = URL(fileURLWithPath: hint).standardizedFileURL.path
+            filtered = vaults.filter { vault in
+                vault.url.lastPathComponent == hint ||
+                vault.url.standardizedFileURL.path == hintPath
+            }
+            if filtered.isEmpty { return .notFound }
+        } else {
+            filtered = vaults
+        }
+
+        guard filtered.count == 1 else {
+            return .ambiguous(filtered)
+        }
+
+        let _ = try PathGuard.resolve(relativePath: relativePath, in: filtered[0].url)
+        return .resolved(filtered[0])
+    }
+
 }

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -56,6 +56,32 @@ enum Handlers {
                 )
                 return await structuredCall { try await getFrontmatter(args, vaults: vaults) }
 
+
+            case "create_note":
+                return await structuredCall {
+                    let args = CreateNoteArgs(
+                        relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                        content: params.arguments?["content"]?.stringValue ?? "",
+                        vault: params.arguments?["vault"]?.stringValue
+                    )
+                    return try await createNote(args, vaults: vaults)
+                }
+
+            case "update_note":
+                return await structuredCall {
+                    guard let modeStr = params.arguments?["mode"]?.stringValue,
+                          let mode = UpdateMode(rawValue: modeStr) else {
+                        throw ToolError.invalidArgument(name: "mode", reason: "must be one of: replace, append, prepend")
+                    }
+                    let args = UpdateNoteArgs(
+                        relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                        content: params.arguments?["content"]?.stringValue ?? "",
+                        mode: mode,
+                        vault: params.arguments?["vault"]?.stringValue
+                    )
+                    return try await updateNote(args, vaults: vaults)
+                }
+
             default:
                 return .init(content: [.text("Unknown tool: \(params.name)")], isError: false)
             }

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -13,6 +13,13 @@ enum ToolRegistry {
             openWorldHint: false
         )
 
+        let writeAnnotations = Tool.Annotations(
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: false
+        )
+
         return [
             Tool(
                 name: "search_notes",
@@ -191,6 +198,82 @@ enum ToolRegistry {
                         "has_frontmatter": .object(["type": .string("boolean")])
                     ]),
                     "required": .array([.string("vault"), .string("relative_path"), .string("frontmatter"), .string("has_frontmatter")])
+                ])
+            ),
+            Tool(
+                name: "create_note",
+                description: "Create a new markdown note at the specified vault-relative path. Parent directories are created automatically. Fails with a conflict error if the note already exists — use update_note to modify existing notes.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path for the new note, e.g. 'Daily/2026-04-17.md'. Must not start with '/' or contain '..'. Parent folders are created automatically.")
+                        ]),
+                        "content": .object([
+                            "type": .string("string"),
+                            "description": .string("Full markdown content, including optional YAML frontmatter delimited by '---'.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional. Name of the vault to write to. Required only when multiple vaults are loaded.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path"), .string("content")])
+                ]),
+                annotations: writeAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":         .object(["type": .string("string")]),
+                        "relative_path": .object(["type": .string("string")]),
+                        "content_hash":  .object(["type": .string("string")]),
+                        "size_bytes":    .object(["type": .string("integer")]),
+                        "created_at":    .object(["type": .string("string"), "format": .string("date-time")])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("content_hash"), .string("size_bytes"), .string("created_at")])
+                ])
+            ),
+            Tool(
+                name: "update_note",
+                description: "Update an existing note. Mode 'replace' overwrites the entire file. Mode 'append' adds content to the end (with a leading newline if the file does not end in one). Mode 'prepend' inserts content after YAML frontmatter if present, or at the beginning of the file.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path of an existing note.")
+                        ]),
+                        "content": .object([
+                            "type": .string("string"),
+                            "description": .string("Markdown content to write.")
+                        ]),
+                        "mode": .object([
+                            "type": .string("string"),
+                            "enum": .array([.string("replace"), .string("append"), .string("prepend")]),
+                            "description": .string("Write mode. 'replace' overwrites the full note. 'append' adds content to the end. 'prepend' adds content to the start (after any YAML frontmatter block, if present).")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name; required only when 'relative_path' is ambiguous across multiple loaded vaults.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path"), .string("content"), .string("mode")])
+                ]),
+                annotations: writeAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":         .object(["type": .string("string")]),
+                        "relative_path": .object(["type": .string("string")]),
+                        "mode":          .object(["type": .string("string")]),
+                        "content_hash":  .object(["type": .string("string")]),
+                        "size_bytes":    .object(["type": .string("integer")]),
+                        "modified_at":   .object(["type": .string("string"), "format": .string("date-time")])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("mode"), .string("content_hash"), .string("size_bytes"), .string("modified_at")])
                 ])
             )
         ]


### PR DESCRIPTION
## Summary

- Add `create_note` and `update_note(mode: replace|append|prepend)` to both MCP and CLI
- New `VaultIndex.updateFile(at:)` for targeted re-index after writes (~10ms vs full vault rebuild)
- New `VaultIndex.resolveLinksToFile(named:)` for wiki-link resolution on creates
- PathGuard extended: unicode lookalikes (U+2025, U+FF0E), Windows `..\\`, shell metacharacters
- MCP annotations: `destructiveHint: true` on both write tools
- CLI: `clearly create <path> (--content | --from-stdin)`, `clearly update <path> --mode <mode> (--content | --from-stdin)`
- ToolError: new `.conflict` case (exit 5, `note_exists`)
- VaultResolver: new `resolveForWrite` for create path (no file-exists requirement)

## Test plan

- [ ] `clearly create "Test/note.md" --content "hello"` → exit 0, JSON with content_hash
- [ ] `clearly create "Test/note.md" --content "dup"` → exit 5, `note_exists` error
- [ ] `clearly update "Test/note.md" --mode append --content "appended"` → exit 0
- [ ] `clearly update "Test/note.md" --mode prepend --content "prepended"` → exit 0
- [ ] `printf '---\ntags: [t]\n---\nbody' | clearly update "Test/note.md" --mode replace --from-stdin` → exit 0
- [ ] Prepend on file with frontmatter → content inserted AFTER `---` block
- [ ] `clearly create "../escape.md" --content x` → exit 4, `path_outside_vault`
- [ ] `clearly update "missing.md" --mode replace --content x` → exit 3, `note_not_found`
- [ ] Live app with vault open picks up CLI-created files via FSEventStream
- [ ] MCP: `tools/list` returns 9 tools, write tools have `destructiveHint: true`
- [ ] MCP: `create_note` and `update_note` return both `structuredContent` and `.text`