### PR TITLE
Phase 4: port legacy tools to structured MCP output + CLI subcommands

### DIFF
--- a/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
+++ b/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
@@ -4,13 +4,62 @@ import Foundation
 struct BacklinksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "backlinks",
-        abstract: "List backlinks for a note (arrives in Phase 4)."
+        abstract: "List wiki-link references and unlinked mentions pointing to a note."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Vault-relative path (e.g. 'folder/My Note.md') or bare filename.")
+    var relativePath: String
+
+    @Option(name: .customLong("in-vault"), help: "Optional vault disambiguator (name or path) when multiple vaults are loaded.")
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly backlinks — not yet implemented (Phase 4)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await getBacklinks(
+                GetBacklinksArgs(relativePath: relativePath, vault: inVault),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                try Emitter.emit(result, format: .json)
+            case .text:
+                Emitter.emitLine("# Backlinks for: \(result.relativePath) (\(result.vault))")
+                Emitter.emitLine("")
+                Emitter.emitLine("## Linked (\(result.linked.count))")
+                if result.linked.isEmpty {
+                    Emitter.emitLine("  (none)")
+                } else {
+                    for link in result.linked {
+                        let line = link.lineNumber.map { " L\($0)" } ?? ""
+                        Emitter.emitLine("  \(link.relativePath)\(line)")
+                    }
+                }
+                Emitter.emitLine("")
+                Emitter.emitLine("## Unlinked (\(result.unlinked.count))")
+                if result.unlinked.isEmpty {
+                    Emitter.emitLine("  (none)")
+                } else {
+                    for mention in result.unlinked {
+                        Emitter.emitLine("  \(mention.relativePath) L\(mention.lineNumber): \(mention.contextLine)")
+                    }
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/SearchCommand.swift
+++ b/ClearlyCLI/CLI/Commands/SearchCommand.swift
@@ -4,13 +4,51 @@ import Foundation
 struct SearchCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "search",
-        abstract: "Search notes by query (arrives in Phase 4)."
+        abstract: "Full-text search across loaded vaults. Emits NDJSON hits (one per line) in JSON mode."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Search query. Supports quoted phrases for exact match.")
+    var query: String
+
+    @Option(help: "Max results to return. Default 20, capped at 100.")
+    var limit: Int?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly search — not yet implemented (Phase 4)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await searchNotes(
+                SearchNotesArgs(query: query, limit: limit),
+                vaults: vaults
+            )
+            switch globals.format {
+            case .json:
+                for hit in result.results {
+                    try Emitter.emitNDJSONRecord(hit)
+                }
+            case .text:
+                for hit in result.results {
+                    let tag = hit.matchesFilename ? " [filename]" : ""
+                    Emitter.emitLine("\(hit.relativePath)\t\(hit.filename)\(tag)")
+                    for excerpt in hit.excerpts {
+                        Emitter.emitLine("  L\(excerpt.lineNumber): \(excerpt.contextLine)")
+                    }
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/TagsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/TagsCommand.swift
@@ -4,13 +4,55 @@ import Foundation
 struct TagsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "tags",
-        abstract: "List tags or files for a tag (arrives in Phase 4)."
+        abstract: "List tags (no argument) or files for a tag (with argument). Emits NDJSON in JSON mode."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Optional specific tag (without '#' prefix). Omit to list all tags.")
+    var tag: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly tags — not yet implemented (Phase 4)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await getTags(GetTagsArgs(tag: tag), vaults: vaults)
+            switch globals.format {
+            case .json:
+                switch result.mode {
+                case .all:
+                    for entry in result.allTags ?? [] {
+                        try Emitter.emitNDJSONRecord(entry)
+                    }
+                case .byTag:
+                    for file in result.files ?? [] {
+                        try Emitter.emitNDJSONRecord(file)
+                    }
+                }
+            case .text:
+                switch result.mode {
+                case .all:
+                    for entry in result.allTags ?? [] {
+                        Emitter.emitLine("#\(entry.tag)\t\(entry.count)")
+                    }
+                case .byTag:
+                    for file in result.files ?? [] {
+                        Emitter.emitLine("\(file.vault)\t\(file.relativePath)")
+                    }
+                }
+            }
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
     }
 }

--- a/ClearlyCLI/Core/Tools/GetBacklinks.swift
+++ b/ClearlyCLI/Core/Tools/GetBacklinks.swift
@@ -1,66 +1,92 @@
 import Foundation
 
 struct GetBacklinksArgs: Codable {
-    let notePath: String
+    let relativePath: String
+    let vault: String?
 }
 
 struct GetBacklinksResult: Codable {
     struct Linked: Codable {
-        let source: String
+        let vault: String
+        let relativePath: String
         let lineNumber: Int?
+        let displayText: String?
+        let context: String?
     }
     struct Unlinked: Codable {
-        let path: String
+        let vault: String
+        let relativePath: String
         let lineNumber: Int
         let contextLine: String
     }
-    let vaultPath: String
-    let notePath: String
+    let vault: String
+    let relativePath: String
     let linked: [Linked]
     let unlinked: [Unlinked]
 }
 
 func getBacklinks(_ args: GetBacklinksArgs, vaults: [LoadedVault]) async throws -> GetBacklinksResult {
-    guard !args.notePath.isEmpty else {
-        throw ToolError.missingArgument("note_path")
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
     }
 
-    for vault in vaults {
+    // Honor optional `vault` hint to scope lookup in a multi-vault setup.
+    let searchSpace: [LoadedVault]
+    if let hint = args.vault, !hint.isEmpty {
+        searchSpace = vaults.filter {
+            $0.url.lastPathComponent == hint || $0.url.path == hint
+        }
+        if searchSpace.isEmpty {
+            throw ToolError.noteNotFound(args.relativePath)
+        }
+    } else {
+        searchSpace = vaults
+    }
+
+    for loaded in searchSpace {
         let file: IndexedFile?
-        if let f = vault.index.file(forRelativePath: args.notePath) {
+        if let f = loaded.index.file(forRelativePath: args.relativePath) {
             file = f
-        } else if let f = vault.index.resolveWikiLink(name: args.notePath) {
+        } else if let f = loaded.index.resolveWikiLink(name: args.relativePath) {
             file = f
         } else {
-            let withoutExt = args.notePath.hasSuffix(".md")
-                ? String(args.notePath.dropLast(3))
-                : args.notePath
-            file = vault.index.resolveWikiLink(name: withoutExt)
+            let withoutExt = args.relativePath.hasSuffix(".md")
+                ? String(args.relativePath.dropLast(3))
+                : args.relativePath
+            file = loaded.index.resolveWikiLink(name: withoutExt)
         }
 
         guard let file = file else { continue }
+        let vaultName = loaded.url.lastPathComponent
 
-        let linked = vault.index.linksTo(fileId: file.id)
-        let unlinked = vault.index.unlinkedMentions(for: file.filename, excludingFileId: file.id)
+        let linked = loaded.index.linksTo(fileId: file.id).map { link in
+            GetBacklinksResult.Linked(
+                vault: vaultName,
+                relativePath: link.sourcePath ?? link.sourceFilename ?? "unknown",
+                lineNumber: link.lineNumber,
+                displayText: link.displayText,
+                context: link.context
+            )
+        }
+        let unlinked = loaded.index.unlinkedMentions(
+            for: file.filename,
+            excludingFileId: file.id
+        ).map { mention in
+            GetBacklinksResult.Unlinked(
+                vault: vaultName,
+                relativePath: mention.file.path,
+                lineNumber: mention.lineNumber,
+                contextLine: mention.contextLine
+            )
+        }
 
         return GetBacklinksResult(
-            vaultPath: vault.url.path,
-            notePath: file.path,
-            linked: linked.map {
-                GetBacklinksResult.Linked(
-                    source: $0.sourcePath ?? $0.sourceFilename ?? "unknown",
-                    lineNumber: $0.lineNumber
-                )
-            },
-            unlinked: unlinked.map {
-                GetBacklinksResult.Unlinked(
-                    path: $0.file.path,
-                    lineNumber: $0.lineNumber,
-                    contextLine: $0.contextLine
-                )
-            }
+            vault: vaultName,
+            relativePath: file.path,
+            linked: linked,
+            unlinked: unlinked
         )
     }
 
-    throw ToolError.noteNotFound(args.notePath)
+    throw ToolError.noteNotFound(args.relativePath)
 }

--- a/ClearlyCLI/Core/Tools/GetTags.swift
+++ b/ClearlyCLI/Core/Tools/GetTags.swift
@@ -5,30 +5,39 @@ struct GetTagsArgs: Codable {
 }
 
 struct GetTagsResult: Codable {
-    struct TagEntry: Codable {
+    enum Mode: String, Codable {
+        case all
+        case byTag = "by_tag"
+    }
+    struct TagSummary: Codable {
         let tag: String
         let count: Int
     }
-    struct FileEntry: Codable {
+    struct TagFile: Codable {
+        let vault: String
         let vaultPath: String
-        let path: String
-    }
-    enum Mode: String, Codable {
-        case all
-        case byTag
+        let relativePath: String
     }
     let mode: Mode
     let tag: String?
-    let allTags: [TagEntry]?
-    let files: [FileEntry]?
+    let allTags: [TagSummary]?
+    let files: [TagFile]?
 }
 
 func getTags(_ args: GetTagsArgs, vaults: [LoadedVault]) async throws -> GetTagsResult {
     if let tag = args.tag, !tag.isEmpty {
-        var files: [GetTagsResult.FileEntry] = []
+        var files: [GetTagsResult.TagFile] = []
         for vault in vaults {
+            let vaultName = vault.url.lastPathComponent
+            let vaultPath = vault.url.path
             for f in vault.index.filesForTag(tag: tag) {
-                files.append(GetTagsResult.FileEntry(vaultPath: vault.url.path, path: f.path))
+                files.append(
+                    GetTagsResult.TagFile(
+                        vault: vaultName,
+                        vaultPath: vaultPath,
+                        relativePath: f.path
+                    )
+                )
             }
         }
         return GetTagsResult(mode: .byTag, tag: tag, allTags: nil, files: files)
@@ -43,7 +52,7 @@ func getTags(_ args: GetTagsArgs, vaults: [LoadedVault]) async throws -> GetTags
         return GetTagsResult(
             mode: .all,
             tag: nil,
-            allTags: sorted.map { GetTagsResult.TagEntry(tag: $0.key, count: $0.value) },
+            allTags: sorted.map { GetTagsResult.TagSummary(tag: $0.key, count: $0.value) },
             files: nil
         )
     }

--- a/ClearlyCLI/Core/Tools/SearchNotes.swift
+++ b/ClearlyCLI/Core/Tools/SearchNotes.swift
@@ -10,16 +10,18 @@ struct SearchNotesResult: Codable {
         let lineNumber: Int
         let contextLine: String
     }
-    struct Match: Codable {
+    struct Hit: Codable {
+        let vault: String
         let vaultPath: String
-        let path: String
+        let relativePath: String
+        let filename: String
         let matchesFilename: Bool
         let excerpts: [Excerpt]
     }
     let query: String
     let totalCount: Int
     let returnedCount: Int
-    let results: [Match]
+    let results: [Hit]
 }
 
 func searchNotes(_ args: SearchNotesArgs, vaults: [LoadedVault]) async throws -> SearchNotesResult {
@@ -31,19 +33,21 @@ func searchNotes(_ args: SearchNotesArgs, vaults: [LoadedVault]) async throws ->
     }
     let limit = min(args.limit ?? 20, 100)
 
-    var all: [(vaultPath: String, group: SearchFileGroup)] = []
+    var all: [(vault: LoadedVault, group: SearchFileGroup)] = []
     for vault in vaults {
         for group in vault.index.searchFilesGrouped(query: args.query) {
-            all.append((vault.url.path, group))
+            all.append((vault, group))
         }
     }
     all.sort(by: isHigherPrioritySearchResult)
 
     let capped = Array(all.prefix(limit))
-    let matches = capped.map { item in
-        SearchNotesResult.Match(
-            vaultPath: item.vaultPath,
-            path: item.group.file.path,
+    let hits = capped.map { item in
+        SearchNotesResult.Hit(
+            vault: item.vault.url.lastPathComponent,
+            vaultPath: item.vault.url.path,
+            relativePath: item.group.file.path,
+            filename: item.group.file.filename,
             matchesFilename: item.group.matchesFilename,
             excerpts: item.group.excerpts.map {
                 SearchNotesResult.Excerpt(lineNumber: $0.lineNumber, contextLine: $0.contextLine)
@@ -54,13 +58,13 @@ func searchNotes(_ args: SearchNotesArgs, vaults: [LoadedVault]) async throws ->
         query: args.query,
         totalCount: all.count,
         returnedCount: capped.count,
-        results: matches
+        results: hits
     )
 }
 
 private func isHigherPrioritySearchResult(
-    _ lhs: (vaultPath: String, group: SearchFileGroup),
-    _ rhs: (vaultPath: String, group: SearchFileGroup)
+    _ lhs: (vault: LoadedVault, group: SearchFileGroup),
+    _ rhs: (vault: LoadedVault, group: SearchFileGroup)
 ) -> Bool {
     if lhs.group.matchesFilename != rhs.group.matchesFilename {
         return lhs.group.matchesFilename
@@ -68,8 +72,8 @@ private func isHigherPrioritySearchResult(
     if lhs.group.relevanceRank != rhs.group.relevanceRank {
         return lhs.group.relevanceRank < rhs.group.relevanceRank
     }
-    if lhs.vaultPath != rhs.vaultPath {
-        return lhs.vaultPath.localizedCaseInsensitiveCompare(rhs.vaultPath) == .orderedAscending
+    if lhs.vault.url.path != rhs.vault.url.path {
+        return lhs.vault.url.path.localizedCaseInsensitiveCompare(rhs.vault.url.path) == .orderedAscending
     }
     return lhs.group.file.path.localizedCaseInsensitiveCompare(rhs.group.file.path) == .orderedAscending
 }

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -3,94 +3,96 @@ import MCP
 
 enum Handlers {
     static func dispatch(params: CallTool.Parameters, vaults: [LoadedVault]) async -> CallTool.Result {
-        let multiVault = vaults.count > 1
-        do {
-            switch params.name {
-            case "search_notes":
+        switch params.name {
+        case "search_notes":
+            return await structuredCall {
                 let args = SearchNotesArgs(
                     query: params.arguments?["query"]?.stringValue ?? "",
                     limit: params.arguments?["limit"]?.intValue
                 )
-                let result = try await searchNotes(args, vaults: vaults)
-                return .init(content: [.text(renderSearchText(result, multiVault: multiVault))])
+                return try await searchNotes(args, vaults: vaults)
+            }
 
-            case "get_backlinks":
+        case "get_backlinks":
+            return await structuredCall {
                 let args = GetBacklinksArgs(
-                    notePath: params.arguments?["note_path"]?.stringValue ?? ""
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    vault: params.arguments?["vault"]?.stringValue
                 )
-                let result = try await getBacklinks(args, vaults: vaults)
-                return .init(content: [.text(renderBacklinksText(result, multiVault: multiVault))])
+                return try await getBacklinks(args, vaults: vaults)
+            }
 
-            case "get_tags":
+        case "get_tags":
+            return await structuredCall {
                 let args = GetTagsArgs(tag: params.arguments?["tag"]?.stringValue)
-                let result = try await getTags(args, vaults: vaults)
-                return .init(content: [.text(renderTagsText(result, multiVault: multiVault))])
+                return try await getTags(args, vaults: vaults)
+            }
 
-            case "read_note":
+        case "read_note":
+            return await structuredCall {
                 let args = ReadNoteArgs(
                     relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
                     startLine: params.arguments?["start_line"]?.intValue,
                     endLine: params.arguments?["end_line"]?.intValue,
                     vault: params.arguments?["vault"]?.stringValue
                 )
-                return await structuredCall { try await readNote(args, vaults: vaults) }
+                return try await readNote(args, vaults: vaults)
+            }
 
-            case "list_notes":
+        case "list_notes":
+            return await structuredCall {
                 let args = ListNotesArgs(
                     under: params.arguments?["under"]?.stringValue,
                     vault: params.arguments?["vault"]?.stringValue
                 )
-                return await structuredCall { try await listNotes(args, vaults: vaults) }
+                return try await listNotes(args, vaults: vaults)
+            }
 
-            case "get_headings":
+        case "get_headings":
+            return await structuredCall {
                 let args = GetHeadingsArgs(
                     relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
                     vault: params.arguments?["vault"]?.stringValue
                 )
-                return await structuredCall { try await getHeadings(args, vaults: vaults) }
+                return try await getHeadings(args, vaults: vaults)
+            }
 
-            case "get_frontmatter":
+        case "get_frontmatter":
+            return await structuredCall {
                 let args = GetFrontmatterArgs(
                     relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
                     vault: params.arguments?["vault"]?.stringValue
                 )
-                return await structuredCall { try await getFrontmatter(args, vaults: vaults) }
-
-
-            case "create_note":
-                return await structuredCall {
-                    let args = CreateNoteArgs(
-                        relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
-                        content: params.arguments?["content"]?.stringValue ?? "",
-                        vault: params.arguments?["vault"]?.stringValue
-                    )
-                    return try await createNote(args, vaults: vaults)
-                }
-
-            case "update_note":
-                return await structuredCall {
-                    guard let modeStr = params.arguments?["mode"]?.stringValue,
-                          let mode = UpdateMode(rawValue: modeStr) else {
-                        throw ToolError.invalidArgument(name: "mode", reason: "must be one of: replace, append, prepend")
-                    }
-                    let args = UpdateNoteArgs(
-                        relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
-                        content: params.arguments?["content"]?.stringValue ?? "",
-                        mode: mode,
-                        vault: params.arguments?["vault"]?.stringValue
-                    )
-                    return try await updateNote(args, vaults: vaults)
-                }
-
-            default:
-                return .init(content: [.text("Unknown tool: \(params.name)")], isError: false)
+                return try await getFrontmatter(args, vaults: vaults)
             }
-        } catch let error as ToolError {
-            // Legacy text-only path — covers the Phase-1 tools (search_notes,
-            // get_backlinks, get_tags). Phase 4 ports them to structured output.
-            return .init(content: [.text(error.localizedDescription)], isError: true)
-        } catch {
-            return .init(content: [.text("Error: \(error.localizedDescription)")], isError: true)
+
+        case "create_note":
+            return await structuredCall {
+                let args = CreateNoteArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    content: params.arguments?["content"]?.stringValue ?? "",
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return try await createNote(args, vaults: vaults)
+            }
+
+        case "update_note":
+            return await structuredCall {
+                guard let modeStr = params.arguments?["mode"]?.stringValue,
+                      let mode = UpdateMode(rawValue: modeStr) else {
+                    throw ToolError.invalidArgument(name: "mode", reason: "must be one of: replace, append, prepend")
+                }
+                let args = UpdateNoteArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    content: params.arguments?["content"]?.stringValue ?? "",
+                    mode: mode,
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return try await updateNote(args, vaults: vaults)
+            }
+
+        default:
+            return .init(content: [.text("Unknown tool: \(params.name)")], isError: true)
         }
     }
 
@@ -135,78 +137,6 @@ func encodeStructured<T: Encodable>(_ value: T) throws -> (text: String, structu
     let text = String(data: data, encoding: .utf8) ?? "{}"
     let structured = try JSONDecoder().decode(Value.self, from: data)
     return (text, structured)
-}
-
-private func renderSearchText(_ r: SearchNotesResult, multiVault: Bool) -> String {
-    if r.totalCount == 0 {
-        return "No results found for: \(r.query)"
-    }
-    var output = "Found \(r.totalCount) file(s) matching \"\(r.query)\""
-    if r.totalCount > r.returnedCount {
-        output += " (showing first \(r.returnedCount))"
-    }
-    output += "\n"
-    for match in r.results {
-        let matchType = match.matchesFilename ? " (filename match)" : ""
-        let fullPath = multiVault ? "\(match.vaultPath)/\(match.path)" : match.path
-        output += "\n## \(fullPath)\(matchType)\n"
-        for excerpt in match.excerpts {
-            output += "- Line \(excerpt.lineNumber): \(excerpt.contextLine)\n"
-        }
-    }
-    return output
-}
-
-private func renderBacklinksText(_ r: GetBacklinksResult, multiVault: Bool) -> String {
-    let displayPath = multiVault ? "\(r.vaultPath)/\(r.notePath)" : r.notePath
-    var output = "# Backlinks for: \(displayPath)\n"
-
-    output += "\n## Linked Mentions (\(r.linked.count))\n"
-    if r.linked.isEmpty {
-        output += "No notes link to this file via [[wiki-links]].\n"
-    } else {
-        for link in r.linked {
-            let line = link.lineNumber.map { " (line \($0))" } ?? ""
-            output += "- \(link.source)\(line)\n"
-        }
-    }
-
-    output += "\n## Unlinked Mentions (\(r.unlinked.count))\n"
-    if r.unlinked.isEmpty {
-        output += "No unlinked text mentions found.\n"
-    } else {
-        for mention in r.unlinked {
-            output += "- \(mention.path) (line \(mention.lineNumber)): \(mention.contextLine)\n"
-        }
-    }
-    return output
-}
-
-private func renderTagsText(_ r: GetTagsResult, multiVault: Bool) -> String {
-    switch r.mode {
-    case .byTag:
-        let tag = r.tag ?? ""
-        let files = r.files ?? []
-        if files.isEmpty {
-            return "No files found with tag #\(tag)"
-        }
-        var output = "## Files tagged #\(tag) (\(files.count) file(s))\n"
-        for f in files {
-            let path = multiVault ? "\(f.vaultPath)/\(f.path)" : f.path
-            output += "- \(path)\n"
-        }
-        return output
-    case .all:
-        let allTags = r.allTags ?? []
-        if allTags.isEmpty {
-            return "No tags found in the vault."
-        }
-        var output = "## All Tags (\(allTags.count) tag(s))\n"
-        for t in allTags {
-            output += "- #\(t.tag) (\(t.count) file(s))\n"
-        }
-        return output
-    }
 }
 
 private extension Value {

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -26,6 +26,7 @@ enum ToolRegistry {
                 description: "Full-text search across all notes in Clearly. Searches \(vaults.count) vault(s): \(vaultDescription). Returns relevance-ranked results with context snippets. Uses BM25 ranking and stemming. Results include the vault path and relative file path — use standard file access to read full content.",
                 inputSchema: .object([
                     "type": .string("object"),
+                    "additionalProperties": .bool(false),
                     "properties": .object([
                         "query": .object([
                             "type": .string("string"),
@@ -33,37 +34,77 @@ enum ToolRegistry {
                         ]),
                         "limit": .object([
                             "type": .string("integer"),
-                            "description": .string("Max results to return (default 20)")
+                            "minimum": .int(1),
+                            "description": .string("Max results to return. Default 20, capped at 100.")
                         ])
                     ]),
                     "required": .array([.string("query")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query":          .object(["type": .string("string")]),
+                        "total_count":    .object(["type": .string("integer"), "description": .string("Unclamped total match count across all vaults.")]),
+                        "returned_count": .object(["type": .string("integer"), "description": .string("Number of hits included in the results array after applying limit.")]),
+                        "results":        .object(["type": .string("array"), "items": .object(["type": .string("object")])])
+                    ]),
+                    "required": .array([.string("query"), .string("total_count"), .string("returned_count"), .string("results")])
                 ])
             ),
             Tool(
                 name: "get_backlinks",
-                description: "Get all notes that link to a given note via [[wiki-links]], plus unlinked text mentions (places the note is referenced by name but not yet linked). Searches across all vaults.",
+                description: "Get all notes that link to a given note via [[wiki-links]], plus unlinked text mentions (places the note is referenced by name but not yet linked). Searches across all loaded vaults by default; pass 'vault' to scope.",
                 inputSchema: .object([
                     "type": .string("object"),
+                    "additionalProperties": .bool(false),
                     "properties": .object([
-                        "note_path": .object([
+                        "relative_path": .object([
                             "type": .string("string"),
-                            "description": .string("Note filename (e.g. 'My Note') or relative path within a vault (e.g. 'folder/My Note.md')")
+                            "description": .string("Vault-relative path (e.g. 'folder/My Note.md') or bare filename (e.g. 'My Note') of the target note.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name or path. When set, only this vault is searched.")
                         ])
                     ]),
-                    "required": .array([.string("note_path")])
+                    "required": .array([.string("relative_path")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":         .object(["type": .string("string")]),
+                        "relative_path": .object(["type": .string("string"), "description": .string("Resolved vault-relative path of the target note.")]),
+                        "linked":        .object(["type": .string("array"), "items": .object(["type": .string("object")]), "description": .string("Wiki-link references from other notes.")]),
+                        "unlinked":      .object(["type": .string("array"), "items": .object(["type": .string("object")]), "description": .string("Text mentions of the note's filename not wrapped in [[...]].")])
+                    ]),
+                    "required": .array([.string("vault"), .string("relative_path"), .string("linked"), .string("unlinked")])
                 ])
             ),
             Tool(
                 name: "get_tags",
-                description: "Without arguments: list all tags across all vaults with file counts. With a tag argument: list all files with that tag. Tags come from both inline #hashtags and YAML frontmatter.",
+                description: "Without arguments: list all tags across all vaults with file counts (mode='all'). With a tag argument: list all files with that tag (mode='by_tag'). Tags come from both inline #hashtags and YAML frontmatter.",
                 inputSchema: .object([
                     "type": .string("object"),
+                    "additionalProperties": .bool(false),
                     "properties": .object([
                         "tag": .object([
                             "type": .string("string"),
-                            "description": .string("Specific tag to look up (without # prefix). Omit to list all tags.")
+                            "description": .string("Optional specific tag (without '#' prefix) to look up. Omit to list all tags.")
                         ])
                     ])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "mode":     .object(["type": .string("string"), "enum": .array([.string("all"), .string("by_tag")])]),
+                        "tag":      .object(["type": .string("string"), "description": .string("Echoes the input tag when mode='by_tag'; absent (not emitted) otherwise.")]),
+                        "all_tags": .object(["type": .string("array"), "items": .object(["type": .string("object")]), "description": .string("Populated only when mode='all'. Each entry has 'tag' and 'count'.")]),
+                        "files":    .object(["type": .string("array"), "items": .object(["type": .string("object")]), "description": .string("Populated only when mode='by_tag'. Each entry has 'vault', 'vault_path', 'relative_path'.")])
+                    ]),
+                    "required": .array([.string("mode")])
                 ])
             ),
             Tool(


### PR DESCRIPTION
## Summary

Phase 4 of \`local-mcp-cli\` — ports \`search_notes\`, \`get_backlinks\`, \`get_tags\` to structured MCP output (\`outputSchema\` + \`structuredContent\`) and lands \`clearly search|backlinks|tags\` CLI subcommands. All 9 tools are now end-to-end structured.

- Result Codables redesigned to final snake_case schemas with \`vault\` slug on every entry. \`get_backlinks\` arg renamed \`note_path\` → \`relative_path\` for consistency.
- MCP dispatch unified on the \`structuredCall\` wrapper from Phase 2; three custom text renderers and \`multiVault\` plumbing removed.
- All 3 legacy tools now carry \`readAnnotations\` so Claude Desktop auto-approves reads.
- CLI subcommands follow Phase-2 conventions: NDJSON on list-shaped output (search, tags), single structured JSON for backlinks, \`--in-vault\` disambiguator.

Refs docs/local-mcp-cli/IMPLEMENTATION.md §Phase 4.

## Test plan

- [x] \`xcodebuild -scheme Clearly -configuration Debug build\` — zero errors, zero new warnings
- [x] \`grep -rn 'print(' ClearlyCLI/MCP ClearlyCLI/Core ClearlyCLI/CLI\` — empty
- [x] \`clearly search 'pricing' --limit 3 | jq -c '{rp: .relative_path, n: (.excerpts | length)}'\` — 3 valid NDJSON hits
- [x] \`clearly tags | head -5\` — 5 NDJSON \`{tag, count}\` records
- [x] \`clearly tags architecture | head -3\` — NDJSON \`TagFile\` records
- [x] \`clearly backlinks 'Notes/Meeting Notes — Platform Team.md'\` — structured JSON with 4 linked entries, 0 unlinked
- [x] \`clearly backlinks nonexistent.md\` — stderr \`note_not_found\`, exit 3
- [x] \`clearly backlinks ''\` — stderr \`missing_argument\`, exit 2
- [x] MCP JSON-RPC \`tools/list\` — all 9 tools have \`outputSchema\` + \`annotations\`, input schemas have \`additionalProperties: false\`
- [x] MCP \`tools/call search_notes\` / \`get_tags\` / \`get_backlinks\` — both \`content: [.text(json)]\` AND \`structuredContent\` arrive, text decodes to equal structured payload
- [x] Error path MCP: \`tools/call get_backlinks {"relative_path":"nonexistent.md"}\` → \`isError: true\` with \`structuredContent.error = "note_not_found"\`

### Needs live client verification (before merge)

- [ ] Launch against Claude Desktop / Claude Code — confirm reads auto-approve (readOnlyHint:true) and writes still prompt (destructiveHint:true)
- [ ] MCP Inspector — \`outputSchema\` renders for all 9 tools
- [ ] Trigger a real structured tool call from an MCP-aware agent against the dev vault and confirm the agent consumes \`structuredContent\`