### PR TITLE
Phase 5: install flow + vaults list + index rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,18 @@ The app ships through two channels from the same codebase:
 
 When adding new Sparkle-dependent code, always wrap it in `#if canImport(Sparkle)`. The App Store build must compile cleanly without the Sparkle module.
 
+### Privileged ops from the sandboxed app
+
+Clearly is sandboxed, so any operation that needs root (`/usr/local/bin/` writes, privileged installs) can't route through `NSAppleScript … with administrator privileges` — that path is silently blocked and surfaces as a misleading **"The administrator user name or password was incorrect"** error with no SecurityAgent dialog ever appearing. Don't use it.
+
+The working pattern (see `Clearly/CLIInstaller.swift`) is `tell application "Terminal" to do script "sudo …"`. Terminal's own inline sudo prompt handles authentication. Required pieces:
+
+- `com.apple.security.temporary-exception.apple-events` with `com.apple.Terminal` as the only target in `Clearly.entitlements`.
+- `NSAppleEventsUsageDescription` in `Info.plist` with a user-visible reason. **Without it, TCC silently auto-denies — the consent prompt never appears.** This was the single most time-consuming debug step during Phase 5 of `local-mcp-cli`.
+- For ad-hoc-signed Debug builds iterating on AppleEvents, TCC can cache stale denials across rebuilds. Reset with `tccutil reset AppleEvents com.sabotage.clearly.dev`.
+
+**Cross-channel warning:** the apple-events exception lives in `Clearly.entitlements` (direct/Sparkle) but **not** in `Clearly-AppStore.entitlements`, which strips temporary-exceptions to pass MAS review. That means the CLI install flow (and anything else that drives Terminal) won't work in the App Store build as-is. Either mirror the entitlement into the MAS file (review-risk) or gate the Install UI behind `#if canImport(Sparkle)` and ship a copy-paste fallback for MAS.
+
 ## Conventions
 
 - All colors go through `Theme` with dynamic light/dark resolution — don't hardcode colors

--- a/Clearly/CLIInstaller.swift
+++ b/Clearly/CLIInstaller.swift
@@ -11,7 +11,7 @@ enum CLIInstaller {
 
     enum CLIInstallerError: LocalizedError {
         case notBundled
-        case cancelled
+        case terminalUnavailable
         case scriptFailed(code: Int, message: String)
         case wrongOwner
 
@@ -19,10 +19,10 @@ enum CLIInstaller {
             switch self {
             case .notBundled:
                 return "The clearly binary isn't bundled with this build."
-            case .cancelled:
-                return "Installation was cancelled."
+            case .terminalUnavailable:
+                return "Couldn't open Terminal. Check Privacy & Security → Automation and allow Clearly to control Terminal."
             case .scriptFailed(let code, let message):
-                return "Install script failed (code \(code)): \(message)"
+                return "Couldn't open Terminal (code \(code)): \(message)"
             case .wrongOwner:
                 return "/usr/local/bin/clearly points at a different tool — remove it manually first."
             }
@@ -72,24 +72,35 @@ enum CLIInstaller {
         if case .installedElsewhere = symlinkState() {
             throw CLIInstallerError.wrongOwner
         }
-        let sourcePath = source.path
-        try await runPrivileged(
-            shellCommand: "mkdir -p /usr/local/bin && ln -sf '\(escape(sourcePath))' '\(symlinkPath)'"
-        )
+        let shellCommand =
+            "sudo mkdir -p /usr/local/bin && " +
+            "sudo ln -sf '\(shellEscape(source.path))' '\(symlinkPath)' && " +
+            "echo '' && " +
+            "echo '✓ Installed. You can close this window — clearly is on your PATH.'"
+        try await runInTerminal(shellCommand)
     }
 
     static func uninstall() async throws {
         guard symlinkState() == .installed else {
             throw CLIInstallerError.wrongOwner
         }
-        try await runPrivileged(shellCommand: "rm -f '\(symlinkPath)'")
+        let shellCommand =
+            "sudo rm -f '\(symlinkPath)' && " +
+            "echo '' && " +
+            "echo '✓ Uninstalled. You can close this window.'"
+        try await runInTerminal(shellCommand)
     }
 
-    private static func runPrivileged(shellCommand: String) async throws {
-        let escaped = shellCommand
+    private static func runInTerminal(_ shellCommand: String) async throws {
+        let escapedForAS = shellCommand
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        let script = "do shell script \"\(escaped)\" with administrator privileges"
+        let script = """
+        tell application "Terminal"
+            activate
+            do script "\(escapedForAS)"
+        end tell
+        """
         try await Task.detached(priority: .userInitiated) {
             var errorDict: NSDictionary?
             guard let apple = NSAppleScript(source: script) else {
@@ -98,16 +109,16 @@ enum CLIInstaller {
             _ = apple.executeAndReturnError(&errorDict)
             if let err = errorDict {
                 let code = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
-                if code == -128 {
-                    throw CLIInstallerError.cancelled
-                }
                 let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "Unknown error"
+                if code == -1743 || code == -600 {
+                    throw CLIInstallerError.terminalUnavailable
+                }
                 throw CLIInstallerError.scriptFailed(code: code, message: msg)
             }
         }.value
     }
 
-    private static func escape(_ path: String) -> String {
+    private static func shellEscape(_ path: String) -> String {
         path.replacingOccurrences(of: "'", with: "'\\''")
     }
 }

--- a/Clearly/CLIInstaller.swift
+++ b/Clearly/CLIInstaller.swift
@@ -86,7 +86,10 @@ enum CLIInstaller {
     }
 
     private static func runPrivileged(shellCommand: String) async throws {
-        let script = "do shell script \"\(shellCommand.replacingOccurrences(of: "\"", with: "\\\""))\" with administrator privileges"
+        let escaped = shellCommand
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = "do shell script \"\(escaped)\" with administrator privileges"
         try await Task.detached(priority: .userInitiated) {
             var errorDict: NSDictionary?
             guard let apple = NSAppleScript(source: script) else {

--- a/Clearly/CLIInstaller.swift
+++ b/Clearly/CLIInstaller.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+enum CLIInstaller {
+    static let symlinkPath = "/usr/local/bin/clearly"
+
+    enum State: Equatable {
+        case notInstalled
+        case installed
+        case installedElsewhere(URL)
+    }
+
+    enum CLIInstallerError: LocalizedError {
+        case notBundled
+        case cancelled
+        case scriptFailed(code: Int, message: String)
+        case wrongOwner
+
+        var errorDescription: String? {
+            switch self {
+            case .notBundled:
+                return "The clearly binary isn't bundled with this build."
+            case .cancelled:
+                return "Installation was cancelled."
+            case .scriptFailed(let code, let message):
+                return "Install script failed (code \(code)): \(message)"
+            case .wrongOwner:
+                return "/usr/local/bin/clearly points at a different tool — remove it manually first."
+            }
+        }
+    }
+
+    static func bundledBinaryURL() -> URL? {
+        Bundle.main.url(forResource: "ClearlyCLI", withExtension: nil, subdirectory: "Helpers")
+    }
+
+    static func symlinkState() -> State {
+        let fm = FileManager.default
+        guard let bundled = bundledBinaryURL() else {
+            if fm.fileExists(atPath: symlinkPath) {
+                return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
+            }
+            return .notInstalled
+        }
+        let bundledResolved = bundled.resolvingSymlinksInPath().path
+
+        do {
+            let target = try fm.destinationOfSymbolicLink(atPath: symlinkPath)
+            let targetURL: URL
+            if target.hasPrefix("/") {
+                targetURL = URL(fileURLWithPath: target, isDirectory: false)
+            } else {
+                let parent = (symlinkPath as NSString).deletingLastPathComponent
+                targetURL = URL(fileURLWithPath: parent).appendingPathComponent(target)
+            }
+            let targetResolved = targetURL.resolvingSymlinksInPath().path
+            if targetResolved == bundledResolved {
+                return .installed
+            }
+            return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
+        } catch {
+            if fm.fileExists(atPath: symlinkPath) {
+                return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
+            }
+            return .notInstalled
+        }
+    }
+
+    static func install() async throws {
+        guard let source = bundledBinaryURL() else {
+            throw CLIInstallerError.notBundled
+        }
+        if case .installedElsewhere = symlinkState() {
+            throw CLIInstallerError.wrongOwner
+        }
+        let sourcePath = source.path
+        try await runPrivileged(
+            shellCommand: "mkdir -p /usr/local/bin && ln -sf '\(escape(sourcePath))' '\(symlinkPath)'"
+        )
+    }
+
+    static func uninstall() async throws {
+        guard symlinkState() == .installed else {
+            throw CLIInstallerError.wrongOwner
+        }
+        try await runPrivileged(shellCommand: "rm -f '\(symlinkPath)'")
+    }
+
+    private static func runPrivileged(shellCommand: String) async throws {
+        let script = "do shell script \"\(shellCommand.replacingOccurrences(of: "\"", with: "\\\""))\" with administrator privileges"
+        try await Task.detached(priority: .userInitiated) {
+            var errorDict: NSDictionary?
+            guard let apple = NSAppleScript(source: script) else {
+                throw CLIInstallerError.scriptFailed(code: -1, message: "Could not compile AppleScript")
+            }
+            _ = apple.executeAndReturnError(&errorDict)
+            if let err = errorDict {
+                let code = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
+                if code == -128 {
+                    throw CLIInstallerError.cancelled
+                }
+                let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "Unknown error"
+                throw CLIInstallerError.scriptFailed(code: code, message: msg)
+            }
+        }.value
+    }
+
+    private static func escape(_ path: String) -> String {
+        path.replacingOccurrences(of: "'", with: "'\\''")
+    }
+}

--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -21,5 +21,9 @@
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
 	</array>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<array>
+		<string>com.apple.Terminal</string>
+	</array>
 </dict>
 </plist>

--- a/Clearly/Info.plist
+++ b/Clearly/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleIconFile</key>
-	<string>AppIcon</string>
-	<key>CFBundleIconName</key>
-	<string>AppIcon</string>
 	<key>CFBundleDisplayName</key>
 	<string>Clearly</string>
 	<key>CFBundleDocumentTypes</key>
@@ -37,6 +33,10 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
@@ -51,12 +51,14 @@
 	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Clearly uses Terminal to install the clearly command-line tool on your PATH.</string>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://clearly.md/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>I1gi82QlV84mZZXMzxJyVMFKpDCmcatBYVSGcq1nJgE=</string>
-	<key>SUEnableInstallerLauncherService</key>
-	<true/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -181,7 +181,7 @@ struct SettingsView: View {
                         .foregroundStyle(.red)
                 }
 
-                Text("Symlinks `/usr/local/bin/clearly` to the helper inside Clearly.app so `clearly` resolves on your shell PATH. Requires your admin password.")
+                Text("Opens Terminal and runs `sudo ln -sf` so `clearly` resolves on your shell PATH. Enter your admin password in Terminal when prompted, then switch back here — Clearly detects the install automatically.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -202,6 +202,9 @@ struct SettingsView: View {
         .onAppear {
             cliSymlinkState = CLIInstaller.symlinkState()
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            cliSymlinkState = CLIInstaller.symlinkState()
+        }
     }
 
     private func runInstall() async {
@@ -211,8 +214,6 @@ struct SettingsView: View {
         do {
             try await CLIInstaller.install()
             cliSymlinkState = CLIInstaller.symlinkState()
-        } catch CLIInstaller.CLIInstallerError.cancelled {
-            // User cancelled; no-op
         } catch {
             cliInstallError = error.localizedDescription
         }
@@ -225,8 +226,6 @@ struct SettingsView: View {
         do {
             try await CLIInstaller.uninstall()
             cliSymlinkState = CLIInstaller.symlinkState()
-        } catch CLIInstaller.CLIInstallerError.cancelled {
-            // User cancelled; no-op
         } catch {
             cliInstallError = error.localizedDescription
         }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -23,9 +23,9 @@ struct SettingsView: View {
                     Label("General", systemImage: "gearshape")
                 }
 
-            mcpSettings
+            commandLineSettings
                 .tabItem {
-                    Label("MCP", systemImage: "network")
+                    Label("Command Line", systemImage: "terminal")
                 }
 
             aboutView
@@ -33,7 +33,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 420)
+        .frame(width: 460)
         .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -87,74 +87,166 @@ struct SettingsView: View {
         .formStyle(.grouped)
     }
 
-    // MARK: - MCP Settings
+    // MARK: - Command Line Settings
 
     @State private var mcpCopied = false
+    @State private var cliSymlinkState: CLIInstaller.State = CLIInstaller.symlinkState()
+    @State private var cliInstallBusy = false
+    @State private var cliInstallError: String?
 
-    private var bundledMCPBinaryPath: String? {
-        Bundle.main.url(forResource: "ClearlyMCP", withExtension: nil, subdirectory: "Helpers")?.path
+    private var bundledCLIBinaryPath: String? {
+        CLIInstaller.bundledBinaryURL()?.path
     }
 
-    private var installedMCPBinaryPath: String {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("Clearly/ClearlyMCP").path
-    }
-
-    private var mcpBinaryPath: String {
-        if let bundledMCPBinaryPath, FileManager.default.isExecutableFile(atPath: bundledMCPBinaryPath) {
-            return bundledMCPBinaryPath
-        }
-        return installedMCPBinaryPath
-    }
-
-    private var mcpBundleIdentifier: String {
+    private var cliBundleIdentifier: String {
         Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
     }
 
-    private var mcpBinaryInstalled: Bool {
-        FileManager.default.isExecutableFile(atPath: mcpBinaryPath)
+    private var cliBundledExecutable: Bool {
+        guard let path = bundledCLIBinaryPath else { return false }
+        return FileManager.default.isExecutableFile(atPath: path)
     }
 
-    private var mcpSettings: some View {
+    private var commandLineSettings: some View {
         Form {
-            // Status
+            // Row 1 — bundled binary status
             HStack {
-                Text("MCP Helper")
+                Text("Helper binary")
                 Spacer()
-                if mcpBinaryInstalled {
+                if cliBundledExecutable {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
-                    Text("Installed")
+                    Text("Bundled")
                         .foregroundStyle(.secondary)
                 } else {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(.red)
-                    Text("Not Installed")
+                    Text("Missing — reinstall Clearly")
                         .foregroundStyle(.secondary)
                 }
             }
 
-            // Copy config
-            Button(mcpCopied ? "Copied!" : "Copy MCP Config") {
-                copyMCPConfig()
-            }
-            .disabled(!mcpBinaryInstalled)
+            // Row 2 — terminal install
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Terminal command")
+                    Spacer()
+                    switch cliSymlinkState {
+                    case .installed:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("Installed at \(CLIInstaller.symlinkPath)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    case .installedElsewhere:
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Different `clearly` on PATH")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    case .notInstalled:
+                        Image(systemName: "circle")
+                            .foregroundStyle(.secondary)
+                        Text("Not installed")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
-            // Help text
-            Text("The MCP server lets AI agents search your notes, explore backlinks, and browse tags. It automatically discovers all your vaults. Copy the config and add it to any MCP-compatible app (Claude Desktop, Cursor, Windsurf, etc.).")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+                HStack {
+                    switch cliSymlinkState {
+                    case .installed:
+                        Button("Uninstall") {
+                            Task { await runUninstall() }
+                        }
+                        .disabled(cliInstallBusy)
+                    case .installedElsewhere:
+                        Button("Install \u{2026}") {}
+                            .disabled(true)
+                        Text("Remove the existing `clearly` from /usr/local/bin manually before installing.")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    case .notInstalled:
+                        Button("Install \u{2026}") {
+                            Task { await runInstall() }
+                        }
+                        .disabled(cliInstallBusy || !cliBundledExecutable)
+                    }
+                    Spacer()
+                }
+
+                if let errorText = cliInstallError {
+                    Text(errorText)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                Text("Symlinks `/usr/local/bin/clearly` to the helper inside Clearly.app so `clearly` resolves on your shell PATH. Requires your admin password.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            // Row 3 — MCP config copy
+            VStack(alignment: .leading, spacing: 8) {
+                Button(mcpCopied ? "Copied!" : "Copy MCP Config") {
+                    copyMCPConfig()
+                }
+                .disabled(!cliBundledExecutable)
+
+                Text("The MCP server lets AI agents search your notes, explore backlinks, and browse tags. Copy this config into any MCP-compatible app (Claude Desktop, Cursor, Windsurf, etc.).")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .formStyle(.grouped)
+        .onAppear {
+            cliSymlinkState = CLIInstaller.symlinkState()
+        }
+    }
+
+    private func runInstall() async {
+        cliInstallBusy = true
+        cliInstallError = nil
+        defer { cliInstallBusy = false }
+        do {
+            try await CLIInstaller.install()
+            cliSymlinkState = CLIInstaller.symlinkState()
+        } catch CLIInstaller.CLIInstallerError.cancelled {
+            // User cancelled; no-op
+        } catch {
+            cliInstallError = error.localizedDescription
+        }
+    }
+
+    private func runUninstall() async {
+        cliInstallBusy = true
+        cliInstallError = nil
+        defer { cliInstallBusy = false }
+        do {
+            try await CLIInstaller.uninstall()
+            cliSymlinkState = CLIInstaller.symlinkState()
+        } catch CLIInstaller.CLIInstallerError.cancelled {
+            // User cancelled; no-op
+        } catch {
+            cliInstallError = error.localizedDescription
+        }
     }
 
     private func copyMCPConfig() {
+        let command: String
+        if case .installed = cliSymlinkState {
+            command = CLIInstaller.symlinkPath
+        } else if let path = bundledCLIBinaryPath {
+            command = path
+        } else {
+            return
+        }
         let config = """
         {
           "mcpServers": {
             "clearly": {
-              "command": "\(mcpBinaryPath)",
-              "args": ["--bundle-id", "\(mcpBundleIdentifier)"]
+              "command": "\(command)",
+              "args": ["mcp", "--bundle-id", "\(cliBundleIdentifier)"]
             }
           }
         }

--- a/Clearly/VaultIndex.swift
+++ b/Clearly/VaultIndex.swift
@@ -758,6 +758,31 @@ final class VaultIndex: @unchecked Sendable {
         }
     }
 
+    // MARK: Read — Vault Summary
+
+    func fileCount() -> Int {
+        do {
+            return try dbPool.read { db in
+                let row = try Row.fetchOne(db, sql: "SELECT COUNT(*) AS c FROM files")
+                return Int(row?["c"] as Int64? ?? 0)
+            }
+        } catch {
+            return 0
+        }
+    }
+
+    func lastIndexedAt() -> Date? {
+        do {
+            return try dbPool.read { db in
+                let row = try Row.fetchOne(db, sql: "SELECT MAX(indexed_at) AS m FROM files")
+                guard let ts = row?["m"] as Double? else { return nil }
+                return Date(timeIntervalSince1970: ts)
+            }
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: Read — File by URL
 
     func file(forURL url: URL) -> IndexedFile? {

--- a/ClearlyCLI/CLI/Commands/IndexCommand.swift
+++ b/ClearlyCLI/CLI/Commands/IndexCommand.swift
@@ -4,13 +4,86 @@ import Foundation
 struct IndexCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "index",
-        abstract: "Vault index maintenance (arrives in Phase 5)."
+        abstract: "Vault index maintenance.",
+        subcommands: [IndexRebuildCommand.self],
+        defaultSubcommand: IndexRebuildCommand.self
+    )
+}
+
+// MARK: - index rebuild
+
+private struct RebuiltVault: Encodable {
+    let name: String
+    let path: String
+    let durationMs: Int
+}
+
+private struct RebuildResult: Encodable {
+    let rebuilt: Bool
+    let vaults: [RebuiltVault]
+}
+
+struct IndexRebuildCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rebuild",
+        abstract: "Rebuild the SQLite index from disk. Pass --in-vault to limit to one vault."
     )
 
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(
+        name: .customLong("in-vault"),
+        help: "Restrict rebuild to the vault whose directory name matches."
+    )
+    var inVault: String?
+
     func run() async throws {
-        FileHandle.standardError.write(
-            Data("clearly index — not yet implemented (Phase 5)\n".utf8)
-        )
-        throw ExitCode(Exit.usage)
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        let targets: [LoadedVault]
+        if let filter = inVault {
+            targets = vaults.filter { $0.url.lastPathComponent == filter }
+            if targets.isEmpty {
+                Emitter.emitError(
+                    "no_vault_match",
+                    message: "No loaded vault matches --in-vault \(filter).",
+                    extra: ["filter": filter]
+                )
+                throw ExitCode(Exit.notFound)
+            }
+        } else {
+            targets = vaults
+        }
+
+        var rebuilt: [RebuiltVault] = []
+        for vault in targets {
+            let name = vault.url.lastPathComponent
+            FileHandle.standardError.write(
+                Data("Rebuilding \(name)\u{2026}\n".utf8)
+            )
+            let start = Date()
+            vault.index.indexAllFiles()
+            let elapsedMs = Int((Date().timeIntervalSince(start) * 1000).rounded())
+            rebuilt.append(RebuiltVault(name: name, path: vault.url.path, durationMs: elapsedMs))
+        }
+
+        let result = RebuildResult(rebuilt: true, vaults: rebuilt)
+        switch globals.format {
+        case .json:
+            try Emitter.emit(result, format: .json)
+        case .text:
+            for entry in rebuilt {
+                Emitter.emitLine("\(entry.name)\t\(entry.durationMs)ms")
+            }
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/VaultsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/VaultsCommand.swift
@@ -4,12 +4,100 @@ import Foundation
 struct VaultsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vaults",
-        abstract: "List configured vaults (arrives in Phase 5)."
+        abstract: "List configured vaults.",
+        subcommands: [VaultsListCommand.self, VaultsAddCommand.self, VaultsRemoveCommand.self],
+        defaultSubcommand: VaultsListCommand.self
     )
+}
+
+// MARK: - vaults list
+
+private struct VaultSummary: Encodable {
+    let name: String
+    let path: String
+    let fileCount: Int
+    let lastIndexedAt: String?
+    let bundleId: String
+}
+
+struct VaultsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List loaded vaults as NDJSON (one record per line)."
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    func run() async throws {
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)"
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let summaries: [VaultSummary] = vaults.map { vault in
+            let lastIndexed = vault.index.lastIndexedAt().map { formatter.string(from: $0) }
+            return VaultSummary(
+                name: vault.url.lastPathComponent,
+                path: vault.url.path,
+                fileCount: vault.index.fileCount(),
+                lastIndexedAt: lastIndexed,
+                bundleId: globals.bundleID
+            )
+        }
+
+        switch globals.format {
+        case .json:
+            for summary in summaries {
+                try Emitter.emitNDJSONRecord(summary)
+            }
+        case .text:
+            for summary in summaries {
+                Emitter.emitLine("\(summary.name)\t\(summary.path)\t\(summary.fileCount)")
+            }
+        }
+    }
+}
+
+// MARK: - vaults add / remove (deferred to sync feature)
+
+struct VaultsAddCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "Add a vault. Not available here — use the Clearly app (the sync feature will expose this)."
+    )
+
+    @Argument(help: "Vault path (ignored; open Clearly to manage vaults).")
+    var path: String?
 
     func run() async throws {
         FileHandle.standardError.write(
-            Data("clearly vaults — not yet implemented (Phase 5)\n".utf8)
+            Data("Open Clearly to manage vaults.\n".utf8)
+        )
+        throw ExitCode(Exit.usage)
+    }
+}
+
+struct VaultsRemoveCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remove",
+        abstract: "Remove a vault. Not available here — use the Clearly app (the sync feature will expose this)."
+    )
+
+    @Argument(help: "Vault path (ignored; open Clearly to manage vaults).")
+    var path: String?
+
+    func run() async throws {
+        FileHandle.standardError.write(
+            Data("Open Clearly to manage vaults.\n".utf8)
         )
         throw ExitCode(Exit.usage)
     }


### PR DESCRIPTION
## Summary

Phase 5 of `local-mcp-cli` — ships the distribution affordance and the two diagnostic subcommands that were still Phase-1 stubs.

- **Settings → new "Command Line" tab.** Replaces the half-broken MCP tab. Three rows over one bundled binary: bundled-binary status, terminal install (Install/Uninstall), MCP config copy. When the symlink is installed, the MCP config points at `clearly mcp` instead of the absolute bundle path so it survives `.app` moves.
- **Install flow: `tell application "Terminal" to do script "sudo ln -sf …"`.** Click Install → TCC consent prompt (first time) → Terminal opens with the command → user enters admin password in Terminal's own inline sudo prompt → symlink lands → user cmd-tabs back to Clearly and the Settings row auto-refreshes via an `NSApplication.didBecomeActiveNotification` observer. No refresh button; no separate SecurityAgent dialog to fail; works under the existing app sandbox.
- **Phase-1 regression fix (folded in).** SettingsView was still looking up a bundle resource named `"ClearlyMCP"` renamed in Phase 1 — the old "MCP Helper" row always read "Not Installed" and the copy button was disabled. All references now point at `"ClearlyCLI"`; the stale `~/Library/Application Support/Clearly/ClearlyMCP` fallback removed.
- **`clearly vaults` (list + add/remove).** `list` → NDJSON of `{name, path, file_count, last_indexed_at, bundle_id}`. `add`/`remove` → stderr `Open Clearly to manage vaults`, exit 2 (sync feature owns programmatic vault editing).
- **`clearly index rebuild [--in-vault <name>]`.** Per-vault stderr "Rebuilding X…", final stdout JSON `{rebuilt: true, vaults: [{name, path, duration_ms}]}`. No match → stderr `no_vault_match`, exit 3.
- **Two small VaultIndex helpers.** `fileCount() -> Int`, `lastIndexedAt() -> Date?`.
- **New CLAUDE.md section** "Privileged ops from the sandboxed app" captures the three things the next agent would otherwise rediscover: (1) `NSAppleScript … with administrator privileges` is silently blocked in sandbox and masquerades as "password incorrect", (2) `NSAppleEventsUsageDescription` must be in Info.plist or TCC silently auto-denies, (3) `tccutil reset AppleEvents com.sabotage.clearly.dev` for iterating on AppleEvents in Debug builds.

Refs `docs/local-mcp-cli/IMPLEMENTATION.md` §Phase 5.

## ⚠️ App Store channel — known gap

`com.apple.security.temporary-exception.apple-events` lives only in `Clearly.entitlements` (direct/Sparkle), **not** in `Clearly-AppStore.entitlements`. The MAS build will ship without the Install button's required entitlement. Two options, neither blocks this PR:

- Mirror the entitlement into `Clearly-AppStore.entitlements` (MAS review risk since temporary-exceptions are discouraged, though `apple-events` scoped to a single target is commonly approved).
- Gate the Install UI behind `#if canImport(Sparkle)` and ship a copy-paste fallback in MAS.

Either is a follow-up PR; Phase 5's stated deliverable is the Sparkle/direct install flow, which now works.

## Test plan

Automated / done:

- [x] `xcodegen && xcodebuild -scheme Clearly -configuration Debug build` — build succeeded; zero new warnings.
- [x] `grep -rn 'print(' ClearlyCLI/` — empty.
- [x] `clearly vaults list` → NDJSON with 5 expected snake_case keys; `file_count` matches vault state.
- [x] `clearly vaults` (no subcommand) → runs `list` via defaultSubcommand.
- [x] `clearly vaults add` / `clearly vaults remove` → stderr message, exit 2.
- [x] `clearly index rebuild` → stderr `Rebuilding Documents…`, stdout rebuild summary JSON, exit 0. Duration ~3.6s on a 456-note vault.
- [x] `clearly index rebuild --in-vault Documents` → filter applied.
- [x] `clearly index rebuild --in-vault nonexistent` → stderr `no_vault_match`, exit 3.
- [x] MCP regression: `tools/list` still returns all 9 tools with Phase-4 schemas intact.

Live sandboxed Debug build verification (done by Josh):

- [x] Settings Command Line tab renders; bundled binary green; install row shows "Not installed".
- [x] **Install** click → TCC consent ("Clearly would like to control Terminal") → approved → Terminal opened with the sudo command → entered admin password → "✓ Installed" echo → cmd-tabbed back to Clearly → row auto-flipped to "Installed at /usr/local/bin/clearly" + Uninstall button appeared without manual refresh.
- [x] **Uninstall** click → Terminal opened with sudo rm → entered password → "✓ Uninstalled" → row returned to "Not installed".

Accepted without explicit verification (low-risk polish):

- [x] Wrong-owner guard — logic was reviewed during the self-review pass; rare edge case.
- [x] Copy MCP Config before vs after install — code path is trivially inspectable in `SettingsView.copyMCPConfig()`.
