### PR TITLE
Phase 6: docs, error polish, integration tests, CI, release prep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build + Integration + Smoke
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.0
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.0"
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build Clearly (Debug)
+        run: xcodebuild -scheme Clearly -configuration Debug build -quiet
+
+      - name: Integration tests
+        run: |
+          xcodebuild test \
+            -scheme ClearlyCLIIntegrationTests \
+            -destination 'platform=macOS' \
+            -quiet
+
+      - name: CLI smoke test
+        run: ./scripts/cli-smoke.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      - name: Build Clearly (Debug)
-        run: xcodebuild -scheme Clearly -configuration Debug build -quiet
+      - name: Build ClearlyCLI (Debug)
+        run: xcodebuild -scheme ClearlyCLI -configuration Debug build -quiet
 
       - name: Integration tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ concurrency:
 jobs:
   test:
     name: Build + Integration + Smoke
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select latest Xcode 16.x
+      - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: "latest-stable"
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 16.0
+      - name: Select latest Xcode 16.x
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.0"
+          xcode-version: "16.2"
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-04-17
+- `clearly` command-line tool shipped — install from Settings → Command Line for terminal and MCP-client access to your vault
+- MCP server grows from 3 to 9 tools: `read_note`, `list_notes`, `get_headings`, `get_frontmatter` (reads) plus `create_note`, `update_note` (writes)
+- Structured JSON on every tool, input/output schemas published via MCP, stable error identifiers
+- Agent-friendly `--help` with examples on every CLI subcommand
+- XCTest integration suite drives every MCP tool end-to-end on every PR
+- `ClearlyMCP` target renamed to `ClearlyCLI` internally (same bundled binary, new subcommand tree)
+- New Command Line tab in Settings replaces the MCP Config tab
+
 ## [2.2.0] - 2026-04-16
 - Hide frontmatter in preview mode with a new toggle in Settings
 - Empty folders now appear in the sidebar file tree

--- a/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
+++ b/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
@@ -4,7 +4,26 @@ import Foundation
 struct BacklinksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "backlinks",
-        abstract: "List wiki-link references and unlinked mentions pointing to a note."
+        abstract: "List wiki-link references and unlinked mentions pointing to a note.",
+        discussion: """
+        Returns a single structured JSON with two arrays: `linked` (notes
+        that reference the target via [[WikiLinks]], resolved through the
+        index) and `unlinked` (notes that mention the target by filename
+        in plain text, scanned via FTS — useful for "promote to a link").
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → get_backlinks.
+
+        EXAMPLES
+          # Backlinks for a single note
+          clearly backlinks 'Notes/Meeting Notes — Platform Team.md'
+
+          # Just the count of linked references
+          clearly backlinks 'Ideas/graph.md' | jq '.linked | length'
+
+          # Human-readable two-section output
+          clearly backlinks README.md --format text
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -22,7 +41,8 @@ struct BacklinksCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
+++ b/ClearlyCLI/CLI/Commands/BacklinksCommand.swift
@@ -42,7 +42,7 @@ struct BacklinksCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/CreateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/CreateCommand.swift
@@ -68,7 +68,7 @@ struct CreateCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/CreateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/CreateCommand.swift
@@ -4,7 +4,32 @@ import Foundation
 struct CreateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "create",
-        abstract: "Create a new note at the given vault-relative path."
+        abstract: "Create a new note at the given vault-relative path.",
+        discussion: """
+        Parent directories are created automatically. Fails with exit 5 /
+        error note_exists if the note already exists — use `clearly update`
+        to modify existing notes. Path traversal attempts (../, absolute
+        paths, unicode lookalikes) are rejected with exit 4 /
+        error path_outside_vault.
+
+        When multiple vaults are loaded, --in-vault is required. Provide
+        content via --content "<string>" or --from-stdin (mutually
+        exclusive). Content starting with "---" must use --from-stdin
+        (swift-argument-parser parses it as a flag otherwise).
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → create_note.
+
+        EXAMPLES
+          # Inline content
+          clearly create Daily/2026-04-17.md --content "# Today\\n\\nNotes..."
+
+          # Pipe content from stdin (recommended for anything non-trivial)
+          cat draft.md | clearly create Inbox/draft.md --from-stdin
+
+          # Two-vault setup
+          clearly create Notes/idea.md --content "..." --in-vault Work
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -40,7 +65,11 @@ struct CreateCommand: AsyncParsableCommand {
         do {
             vaults = try IndexSet.openIndexes(globals)
         } catch {
-            Emitter.emitError("no_vaults", message: "Unable to open any vault index: \(error.localizedDescription)")
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+            )
             throw ExitCode(Exit.general)
         }
 

--- a/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
+++ b/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
@@ -45,7 +45,7 @@ struct FrontmatterCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
+++ b/ClearlyCLI/CLI/Commands/FrontmatterCommand.swift
@@ -4,7 +4,29 @@ import Foundation
 struct FrontmatterCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "frontmatter",
-        abstract: "Return the parsed YAML frontmatter of a note as a flat key-value map."
+        abstract: "Return the parsed YAML frontmatter of a note as a flat key-value map.",
+        discussion: """
+        Reads directly from disk (not the index) so results always reflect
+        current file state. Duplicate keys are last-write-wins to match the
+        internal flattening behavior.
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → get_frontmatter. Returns
+        {has_frontmatter: false, frontmatter: {}} when the note has no
+        YAML block.
+
+        EXAMPLES
+          # Dump a note's frontmatter
+          clearly frontmatter Projects/2026-plan.md
+
+          # Extract a single tag field
+          clearly frontmatter Projects/plan.md | jq -r '.frontmatter.status'
+
+          # Skip notes without frontmatter
+          clearly list | jq -r '.relative_path' \\
+            | xargs -I{} sh -c 'clearly frontmatter "{}" | jq -e ".has_frontmatter"' \\
+            2>/dev/null
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -22,7 +44,8 @@ struct FrontmatterCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
@@ -4,7 +4,25 @@ import Foundation
 struct HeadingsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "headings",
-        abstract: "Return the heading outline of a note."
+        abstract: "Return the heading outline of a note.",
+        discussion: """
+        Sourced from the vault's index, so the note must have been indexed
+        at least once. Returns an array of {level, text, line_number},
+        level 1–6.
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → get_headings.
+
+        EXAMPLES
+          # Print the outline as JSON
+          clearly headings Strategy/pricing.md
+
+          # Human-readable outline
+          clearly headings Strategy/pricing.md --format text
+
+          # Count H2s in a note
+          clearly headings 'Projects/plan.md' | jq '[.headings[] | select(.level == 2)] | length'
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -22,7 +40,8 @@ struct HeadingsCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/HeadingsCommand.swift
@@ -41,7 +41,7 @@ struct HeadingsCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/IndexCommand.swift
+++ b/ClearlyCLI/CLI/Commands/IndexCommand.swift
@@ -70,7 +70,7 @@ struct IndexRebuildCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/IndexCommand.swift
+++ b/ClearlyCLI/CLI/Commands/IndexCommand.swift
@@ -5,6 +5,15 @@ struct IndexCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "index",
         abstract: "Vault index maintenance.",
+        discussion: """
+        Parent command for index operations. Currently exposes `rebuild`
+        only. Running `clearly index` with no subcommand is equivalent to
+        `clearly index rebuild`.
+
+        EXAMPLES
+          clearly index                        # same as `clearly index rebuild`
+          clearly index rebuild --in-vault Work
+        """,
         subcommands: [IndexRebuildCommand.self],
         defaultSubcommand: IndexRebuildCommand.self
     )
@@ -26,7 +35,23 @@ private struct RebuildResult: Encodable {
 struct IndexRebuildCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "rebuild",
-        abstract: "Rebuild the SQLite index from disk. Pass --in-vault to limit to one vault."
+        abstract: "Rebuild the SQLite index from disk. Pass --in-vault to limit to one vault.",
+        discussion: """
+        Full re-walk of each vault's filesystem, re-hashing every markdown
+        file. Use this to recover from a corrupted index or after
+        out-of-band file operations. One-liner stderr per vault; final
+        JSON summary on stdout with per-vault duration_ms.
+
+        Exits 3 / error no_vault_match if --in-vault doesn't match any
+        loaded vault.
+
+        EXAMPLES
+          # Rebuild every loaded vault
+          clearly index rebuild
+
+          # Rebuild only one (matched on directory name)
+          clearly index rebuild --in-vault Documents
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -44,7 +69,8 @@ struct IndexRebuildCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/ListCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ListCommand.swift
@@ -4,7 +4,32 @@ import Foundation
 struct ListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List notes in loaded vault(s). Emits NDJSON (one record per line)."
+        abstract: "List notes in loaded vault(s). Emits NDJSON (one record per line).",
+        discussion: """
+        Walks the filesystem fresh every call (not the index) so results
+        always reflect current on-disk state. Each record carries vault,
+        relative_path, size_bytes, modified_at.
+
+        Use --under to scope to a subdirectory prefix and --in-vault to
+        scope to a single vault when multiple are loaded.
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → list_notes.
+
+        EXAMPLES
+          # Every note across every vault
+          clearly list
+
+          # Only daily notes
+          clearly list --under Daily/
+
+          # Count notes per vault
+          clearly list | jq -r '.vault' | sort | uniq -c
+
+          # Piping relative paths into another clearly command
+          clearly list --under Projects/ | jq -r '.relative_path' \\
+            | xargs -I{} clearly headings {}
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -22,7 +47,8 @@ struct ListCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/ListCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ListCommand.swift
@@ -48,7 +48,7 @@ struct ListCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/MCPCommand.swift
+++ b/ClearlyCLI/CLI/Commands/MCPCommand.swift
@@ -4,7 +4,25 @@ import Foundation
 struct MCPCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mcp",
-        abstract: "Start the Model Context Protocol stdio server."
+        abstract: "Start the Model Context Protocol stdio server.",
+        discussion: """
+        Runs a JSON-RPC MCP server over stdio, exposing all 9 Clearly tools
+        (search_notes, get_backlinks, get_tags, read_note, list_notes,
+        get_headings, get_frontmatter, create_note, update_note).
+
+        This is the mode invoked by Claude Desktop, Claude Code, Cursor, and
+        other MCP clients. Do not run it interactively — stdout is reserved
+        for JSON-RPC frames; the process ends when stdin closes.
+
+        Client config examples are in README.md, section "ClearlyMCP".
+
+        EXAMPLES
+          # Typical Claude Desktop config entry (in claude_desktop_config.json):
+          #   "clearly": { "command": "/usr/local/bin/clearly", "args": ["mcp"] }
+
+          # Manual smoke test (pipe a JSON-RPC initialize request):
+          echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' | clearly mcp
+        """
     )
 
     @OptionGroup var globals: GlobalOptions

--- a/ClearlyCLI/CLI/Commands/ReadCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ReadCommand.swift
@@ -4,7 +4,33 @@ import Foundation
 struct ReadCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "read",
-        abstract: "Read a note by vault-relative path, with optional line range."
+        abstract: "Read a note by vault-relative path, with optional line range.",
+        discussion: """
+        Returns a single JSON object with content, SHA-256 content_hash,
+        size_bytes, modified_at (ISO-8601 w/ fractional seconds), parsed
+        frontmatter (flat key-value), headings, tags, and an echoed
+        line_range when --start-line / --end-line are used.
+
+        When multiple vaults are loaded and the relative path exists in more
+        than one, pass --in-vault to disambiguate (exit code 5 otherwise).
+        Use exit code 3 to detect "not found".
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → read_note.
+
+        EXAMPLES
+          # Read a whole note
+          clearly read Daily/2026-04-16.md
+
+          # Read only lines 10–30
+          clearly read notes/longer-note.md --start-line 10 --end-line 30
+
+          # Extract the SHA-256 hash for cache invalidation
+          clearly read Projects/plan.md | jq -r '.content_hash'
+
+          # Two-vault setup: scope the lookup
+          clearly read README.md --in-vault Work
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -28,7 +54,8 @@ struct ReadCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/ReadCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ReadCommand.swift
@@ -55,7 +55,7 @@ struct ReadCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/SearchCommand.swift
+++ b/ClearlyCLI/CLI/Commands/SearchCommand.swift
@@ -4,7 +4,29 @@ import Foundation
 struct SearchCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "search",
-        abstract: "Full-text search across loaded vaults. Emits NDJSON hits (one per line) in JSON mode."
+        abstract: "Full-text search across loaded vaults. Emits NDJSON hits (one per line) in JSON mode.",
+        discussion: """
+        Uses the vault's FTS5 index (BM25 ranking). Each hit includes the
+        vault, relative path, filename, a matches_filename flag, and a few
+        context excerpts. Output is NDJSON — one hit per line — which
+        composes well with jq / xargs.
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → search_notes.
+
+        EXAMPLES
+          # Basic search
+          clearly search pricing
+
+          # Cap results and pretty-print one hit:
+          clearly search "API design" --limit 5 | head -1 | jq .
+
+          # Pipeline: list paths of the top 20 matches
+          clearly search rust --limit 20 | jq -r '.relative_path'
+
+          # Combine with --in-vault via read (search searches all vaults):
+          clearly search budget | jq -r '.relative_path' | xargs -I{} clearly read {}
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -22,7 +44,8 @@ struct SearchCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/SearchCommand.swift
+++ b/ClearlyCLI/CLI/Commands/SearchCommand.swift
@@ -45,7 +45,7 @@ struct SearchCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/TagsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/TagsCommand.swift
@@ -44,7 +44,7 @@ struct TagsCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/TagsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/TagsCommand.swift
@@ -4,7 +4,31 @@ import Foundation
 struct TagsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "tags",
-        abstract: "List tags (no argument) or files for a tag (with argument). Emits NDJSON in JSON mode."
+        abstract: "List tags (no argument) or files for a tag (with argument). Emits NDJSON in JSON mode.",
+        discussion: """
+        Two modes, selected by whether a tag argument is provided:
+
+          • No argument  — emits {tag, count} records across all vaults
+            (mode: all).
+          • With a tag   — emits {vault, vault_path, relative_path} records
+            listing every note that carries the tag (mode: by_tag).
+
+        Tags come from both inline #hashtags and YAML frontmatter `tags:`
+        entries. The argument must NOT include the leading "#".
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → get_tags.
+
+        EXAMPLES
+          # Top 20 tags by count
+          clearly tags | jq -s 'sort_by(-.count) | .[:20]'
+
+          # All notes tagged #architecture
+          clearly tags architecture
+
+          # Human-readable count view
+          clearly tags --format text | sort -k2 -nr | head -20
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -19,7 +43,8 @@ struct TagsCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/UpdateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/UpdateCommand.swift
@@ -6,7 +6,37 @@ extension UpdateMode: ExpressibleByArgument {}
 struct UpdateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "update",
-        abstract: "Update an existing note with replace, append, or prepend mode."
+        abstract: "Update an existing note with replace, append, or prepend mode.",
+        discussion: """
+        Modes:
+          • replace  — overwrite the entire file
+          • append   — add content at the end, inserting a leading newline
+                       if the file does not already end with one
+          • prepend  — insert content at the beginning; if the file has
+                       YAML frontmatter, content is inserted AFTER the
+                       closing "---" block, never in front of it
+
+        Fails with exit 3 / error note_not_found if the note doesn't
+        exist — use `clearly create` for new notes. Path traversal checks
+        match `clearly create`.
+
+        Provide content via --content "<string>" or --from-stdin (mutually
+        exclusive).
+
+        Output shape documented in README.md, section "clearly CLI" →
+        "Tool reference" → update_note.
+
+        EXAMPLES
+          # Append a line to today's daily note
+          clearly update Daily/2026-04-17.md --mode append --content $'\\n- New idea'
+
+          # Replace whole file from stdin
+          cat revised.md | clearly update Notes/plan.md --mode replace --from-stdin
+
+          # Prepend a heading to a note with frontmatter — inserted AFTER
+          # the --- block, not in front of it
+          clearly update Strategy/pricing.md --mode prepend --content $'## Summary\\n\\n'
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -45,7 +75,11 @@ struct UpdateCommand: AsyncParsableCommand {
         do {
             vaults = try IndexSet.openIndexes(globals)
         } catch {
-            Emitter.emitError("no_vaults", message: "Unable to open any vault index: \(error.localizedDescription)")
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+            )
             throw ExitCode(Exit.general)
         }
 

--- a/ClearlyCLI/CLI/Commands/UpdateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/UpdateCommand.swift
@@ -78,7 +78,7 @@ struct UpdateCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/VaultsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/VaultsCommand.swift
@@ -55,7 +55,7 @@ struct VaultsListCommand: AsyncParsableCommand {
             Emitter.emitError(
                 "no_vaults",
                 message: "Unable to open any vault index: \(error.localizedDescription)",
-                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
+                extra: ["bundle_id": globals.bundleID]
             )
             throw ExitCode(Exit.general)
         }

--- a/ClearlyCLI/CLI/Commands/VaultsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/VaultsCommand.swift
@@ -5,6 +5,16 @@ struct VaultsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vaults",
         abstract: "List configured vaults.",
+        discussion: """
+        Parent command for vault inspection. Run with no subcommand (or
+        `list`) to emit one NDJSON record per loaded vault. `add` / `remove`
+        are reserved for the sync feature — today they print a pointer to
+        the Clearly app and exit 2.
+
+        EXAMPLES
+          clearly vaults                     # same as `clearly vaults list`
+          clearly vaults list --format text  # vault name, path, file count (tabs)
+        """,
         subcommands: [VaultsListCommand.self, VaultsAddCommand.self, VaultsRemoveCommand.self],
         defaultSubcommand: VaultsListCommand.self
     )
@@ -23,7 +33,16 @@ private struct VaultSummary: Encodable {
 struct VaultsListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List loaded vaults as NDJSON (one record per line)."
+        abstract: "List loaded vaults as NDJSON (one record per line).",
+        discussion: """
+        Emits {name, path, file_count, last_indexed_at, bundle_id} per
+        vault. `last_indexed_at` is an ISO-8601 timestamp (fractional
+        seconds) or null when the index is empty.
+
+        EXAMPLES
+          clearly vaults list
+          clearly vaults list | jq -r '.name + "\\t" + (.file_count|tostring)'
+        """
     )
 
     @OptionGroup var globals: GlobalOptions
@@ -35,7 +54,8 @@ struct VaultsListCommand: AsyncParsableCommand {
         } catch {
             Emitter.emitError(
                 "no_vaults",
-                message: "Unable to open any vault index: \(error.localizedDescription)"
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID, "attempted_count": globals.vault.count]
             )
             throw ExitCode(Exit.general)
         }
@@ -72,7 +92,12 @@ struct VaultsListCommand: AsyncParsableCommand {
 struct VaultsAddCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "add",
-        abstract: "Add a vault. Not available here — use the Clearly app (the sync feature will expose this)."
+        abstract: "Add a vault. Not available here — use the Clearly app (the sync feature will expose this).",
+        discussion: """
+        Placeholder for the sync feature. Today, vault configuration lives
+        in the Clearly Mac app (Settings → Vaults). This command exits 2
+        and prints a pointer.
+        """
     )
 
     @Argument(help: "Vault path (ignored; open Clearly to manage vaults).")
@@ -89,7 +114,12 @@ struct VaultsAddCommand: AsyncParsableCommand {
 struct VaultsRemoveCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "remove",
-        abstract: "Remove a vault. Not available here — use the Clearly app (the sync feature will expose this)."
+        abstract: "Remove a vault. Not available here — use the Clearly app (the sync feature will expose this).",
+        discussion: """
+        Placeholder for the sync feature. Today, vault configuration lives
+        in the Clearly Mac app (Settings → Vaults). This command exits 2
+        and prints a pointer.
+        """
     )
 
     @Argument(help: "Vault path (ignored; open Clearly to manage vaults).")

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -92,7 +92,15 @@ enum Handlers {
             }
 
         default:
-            return .init(content: [.text("Unknown tool: \(params.name)")], isError: true)
+            let payload: [String: Any] = [
+                "error": "unknown_tool",
+                "message": "Unknown tool: \(params.name)",
+                "tool": params.name
+            ]
+            let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)
+            let text = String(data: data, encoding: .utf8) ?? "{}"
+            let structured: Value? = (try? JSONDecoder().decode(Value.self, from: data)) ?? .object([:])
+            return .init(content: [.text(text)], structuredContent: structured, isError: true)
         }
     }
 
@@ -117,7 +125,8 @@ enum Handlers {
         } catch {
             let payload: [String: Any] = [
                 "error": "internal_error",
-                "message": error.localizedDescription
+                "message": error.localizedDescription,
+                "error_type": String(describing: type(of: error))
             ]
             let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)
             let text = String(data: data, encoding: .utf8) ?? "{}"

--- a/ClearlyCLI/MCP/MCPServer.swift
+++ b/ClearlyCLI/MCP/MCPServer.swift
@@ -21,7 +21,11 @@ enum MCPServer {
         let transport = StdioTransport()
         try await server.start(transport: transport)
 
-        // Block until the process is terminated
-        try await Task.sleep(for: .seconds(365 * 24 * 3600))
+        // Block until stdin closes (MCP client disconnects) — the transport
+        // reports EOF which completes the server lifecycle. Previously this
+        // slept for a year regardless of transport state, which made scripted
+        // JSON-RPC smoke tests hang. `waitUntilCompleted` returns promptly on
+        // clean disconnect and keeps blocking during normal client use.
+        await server.waitUntilCompleted()
     }
 }

--- a/ClearlyCLIIntegrationTests/ErrorPathTests.swift
+++ b/ClearlyCLIIntegrationTests/ErrorPathTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MCP
+import XCTest
+
+/// Exercise every ToolError case end-to-end via the MCP path.
+final class ErrorPathTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    func testReadNoteMissing() async throws {
+        let err = try await harness.callToolExpectingError(
+            "read_note",
+            arguments: ["relative_path": .string("does/not/exist.md")]
+        )
+        XCTAssertEqual(err.error, "note_not_found")
+    }
+
+    func testCreateNoteConflict() async throws {
+        struct Ignored: Decodable {}
+        _ = try await harness.callTool(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/dup.md"),
+                "content": .string("first")
+            ],
+            as: Ignored.self
+        )
+        let err = try await harness.callToolExpectingError(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/dup.md"),
+                "content": .string("second")
+            ]
+        )
+        XCTAssertEqual(err.error, "note_exists")
+    }
+
+    func testUpdateNoteInvalidMode() async throws {
+        let err = try await harness.callToolExpectingError(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Daily/2026-04-17.md"),
+                "mode": .string("not-a-mode"),
+                "content": .string("x")
+            ]
+        )
+        XCTAssertEqual(err.error, "invalid_argument")
+    }
+
+    func testUnknownToolReturnsStableError() async throws {
+        let err = try await harness.callToolExpectingError(
+            "not_a_real_tool"
+        )
+        XCTAssertEqual(err.error, "unknown_tool")
+    }
+}

--- a/ClearlyCLIIntegrationTests/FixtureVault/Daily/2026-04-17.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Daily/2026-04-17.md
@@ -1,0 +1,22 @@
+---
+title: 2026-04-17
+status: draft
+tags: daily, fixture
+---
+
+# 2026-04-17
+
+## Morning
+
+- Read [[Link Target]] before standup.
+- Reviewed #architecture notes.
+
+## Afternoon
+
+### Deep work
+
+Wrote integration tests against the fixture vault.
+
+## Evening
+
+Nothing of note.

--- a/ClearlyCLIIntegrationTests/FixtureVault/Notes/Link Target.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Notes/Link Target.md
@@ -1,0 +1,7 @@
+# Link Target
+
+This note is the target of wiki-links from other fixture notes.
+
+## Section A
+
+Body text. #architecture

--- a/ClearlyCLIIntegrationTests/FixtureVault/Notes/Linker.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Notes/Linker.md
@@ -1,0 +1,7 @@
+# Linker
+
+This note has a linked reference to [[Link Target]] on this line.
+
+And another [[Link Target|custom display]] here with a display override.
+
+#fixture

--- a/ClearlyCLIIntegrationTests/FixtureVault/Notes/Unlinked Mention.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Notes/Unlinked Mention.md
@@ -1,0 +1,4 @@
+# Unlinked Mention
+
+This note mentions Link Target by name in plain text, without a wiki-link.
+It should appear in `get_backlinks` under `unlinked`, not `linked`.

--- a/ClearlyCLIIntegrationTests/FixtureVault/Projects/Plan.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Projects/Plan.md
@@ -1,0 +1,16 @@
+---
+title: Project Plan
+tags: architecture, planning
+status: active
+---
+
+# Project Plan
+
+## Goals
+
+- Ship v2.3.
+- Maintain test coverage.
+
+## Timeline
+
+See [[Link Target]] for context.

--- a/ClearlyCLIIntegrationTests/FixtureVault/README.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/README.md
@@ -1,0 +1,18 @@
+---
+title: Fixture README
+tags: fixture, meta
+---
+
+# Fixture Vault
+
+A minimal corpus used by `ClearlyCLIIntegrationTests`. Covers frontmatter,
+headings (H1–H3), `[[wiki-links]]`, unlinked mentions, inline `#fixture`
+tags, a subdirectory, and a non-ASCII filename.
+
+## Structure
+
+- Daily/
+- Notes/
+- Projects/
+
+#fixture

--- a/ClearlyCLIIntegrationTests/FixtureVault/Resume-é.md
+++ b/ClearlyCLIIntegrationTests/FixtureVault/Resume-é.md
@@ -1,0 +1,5 @@
+# Resume-é
+
+Non-ASCII filename — smoke test for unicode path handling.
+
+#resume

--- a/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
+++ b/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
@@ -1,0 +1,311 @@
+import Foundation
+import MCP
+import XCTest
+
+/// End-to-end test of the 9 MCP tools exposed by ClearlyCLI, driving a real
+/// Server over InMemoryTransport with a real Client. Each test exercises the
+/// success path; ErrorPathTests covers ToolError cases.
+final class MCPIntegrationTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    // MARK: - tools/list
+
+    func testListToolsReturnsNine() async throws {
+        let (tools, _) = try await harness.client.listTools()
+        XCTAssertEqual(tools.count, 9)
+        let names = Set(tools.map(\.name))
+        XCTAssertEqual(names, Set([
+            "search_notes", "get_backlinks", "get_tags",
+            "read_note", "list_notes", "get_headings",
+            "get_frontmatter", "create_note", "update_note"
+        ]))
+        // Every tool advertises an outputSchema.
+        for t in tools {
+            XCTAssertNotNil(t.outputSchema, "\(t.name) missing outputSchema")
+            XCTAssertNotNil(t.annotations, "\(t.name) missing annotations")
+        }
+    }
+
+    // MARK: - search_notes
+
+    func testSearchNotesReturnsHits() async throws {
+        struct Hit: Decodable {
+            let relativePath: String
+            let filename: String
+            let vault: String
+            let matchesFilename: Bool
+        }
+        struct Result: Decodable { let results: [Hit]; let totalCount: Int }
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("Link Target"), "limit": .int(10)],
+            as: Result.self
+        )
+        XCTAssertGreaterThan(result.totalCount, 0)
+        XCTAssertTrue(
+            result.results.contains { $0.relativePath.contains("Link Target") },
+            "expected a hit touching 'Link Target'"
+        )
+    }
+
+    // MARK: - read_note
+
+    func testReadNoteReturnsContentAndHash() async throws {
+        struct Result: Decodable {
+            let content: String
+            let contentHash: String
+            let sizeBytes: Int
+            let vault: String
+            let relativePath: String
+        }
+        let result = try await harness.callTool(
+            "read_note",
+            arguments: ["relative_path": .string("Daily/2026-04-17.md")],
+            as: Result.self
+        )
+        XCTAssertTrue(result.content.contains("# 2026-04-17"))
+        XCTAssertEqual(result.contentHash.count, 64) // SHA-256 hex
+        XCTAssertGreaterThan(result.sizeBytes, 0)
+    }
+
+    func testReadNoteLineRangeClampsContent() async throws {
+        struct Range: Decodable { let start: Int; let end: Int }
+        struct Result: Decodable { let content: String; let lineRange: Range? }
+        let result = try await harness.callTool(
+            "read_note",
+            arguments: [
+                "relative_path": .string("Daily/2026-04-17.md"),
+                "start_line": .int(1),
+                "end_line": .int(2)
+            ],
+            as: Result.self
+        )
+        XCTAssertNotNil(result.lineRange)
+        XCTAssertEqual(result.lineRange?.start, 1)
+        XCTAssertEqual(result.lineRange?.end, 2)
+        XCTAssertLessThanOrEqual(
+            result.content.components(separatedBy: "\n").count,
+            3  // up to 2 lines + potential trailing newline
+        )
+    }
+
+    // MARK: - list_notes
+
+    func testListNotesReturnsFixtureCount() async throws {
+        struct Note: Decodable { let relativePath: String }
+        struct Result: Decodable { let notes: [Note] }
+        let result = try await harness.callTool(
+            "list_notes",
+            arguments: [:],
+            as: Result.self
+        )
+        // FixtureVault has 7 markdown files.
+        XCTAssertEqual(result.notes.count, 7, "unexpected fixture size: \(result.notes.map(\.relativePath))")
+    }
+
+    func testListNotesFiltersByUnder() async throws {
+        struct Note: Decodable { let relativePath: String }
+        struct Result: Decodable { let notes: [Note] }
+        let result = try await harness.callTool(
+            "list_notes",
+            arguments: ["under": .string("Notes/")],
+            as: Result.self
+        )
+        XCTAssertEqual(result.notes.count, 3)
+        XCTAssertTrue(result.notes.allSatisfy { $0.relativePath.hasPrefix("Notes/") })
+    }
+
+    // MARK: - get_headings
+
+    func testGetHeadingsReturnsOutline() async throws {
+        struct Heading: Decodable { let level: Int; let text: String; let lineNumber: Int }
+        struct Result: Decodable { let headings: [Heading] }
+        let result = try await harness.callTool(
+            "get_headings",
+            arguments: ["relative_path": .string("Daily/2026-04-17.md")],
+            as: Result.self
+        )
+        XCTAssertFalse(result.headings.isEmpty)
+        XCTAssertTrue(result.headings.contains { $0.level == 1 && $0.text == "2026-04-17" })
+        XCTAssertTrue(result.headings.contains { $0.level == 3 && $0.text == "Deep work" })
+    }
+
+    // MARK: - get_frontmatter
+
+    func testGetFrontmatterFlatMap() async throws {
+        struct Result: Decodable { let hasFrontmatter: Bool; let frontmatter: [String: String] }
+        let result = try await harness.callTool(
+            "get_frontmatter",
+            arguments: ["relative_path": .string("Projects/Plan.md")],
+            as: Result.self
+        )
+        XCTAssertTrue(result.hasFrontmatter)
+        XCTAssertEqual(result.frontmatter["title"], "Project Plan")
+        XCTAssertEqual(result.frontmatter["status"], "active")
+    }
+
+    func testGetFrontmatterAbsent() async throws {
+        struct Result: Decodable { let hasFrontmatter: Bool; let frontmatter: [String: String] }
+        let result = try await harness.callTool(
+            "get_frontmatter",
+            arguments: ["relative_path": .string("Notes/Link Target.md")],
+            as: Result.self
+        )
+        XCTAssertFalse(result.hasFrontmatter)
+        XCTAssertTrue(result.frontmatter.isEmpty)
+    }
+
+    // MARK: - get_backlinks
+
+    func testGetBacklinksSeparatesLinkedAndUnlinked() async throws {
+        struct LinkedEntry: Decodable { let relativePath: String }
+        struct UnlinkedEntry: Decodable { let relativePath: String }
+        struct Result: Decodable {
+            let linked: [LinkedEntry]
+            let unlinked: [UnlinkedEntry]
+            let relativePath: String
+            let vault: String
+        }
+        let result = try await harness.callTool(
+            "get_backlinks",
+            arguments: ["relative_path": .string("Notes/Link Target.md")],
+            as: Result.self
+        )
+        // Linker.md has two [[Link Target]] references; Plan.md has one.
+        XCTAssertGreaterThanOrEqual(result.linked.count, 3)
+        XCTAssertTrue(result.linked.contains { $0.relativePath == "Notes/Linker.md" })
+        XCTAssertTrue(result.linked.contains { $0.relativePath == "Projects/Plan.md" })
+        // Unlinked Mention.md references the target in plain text.
+        XCTAssertTrue(result.unlinked.contains { $0.relativePath == "Notes/Unlinked Mention.md" })
+    }
+
+    // MARK: - get_tags
+
+    func testGetTagsAllMode() async throws {
+        struct TagCount: Decodable { let tag: String; let count: Int }
+        struct Result: Decodable { let mode: String; let allTags: [TagCount]? }
+        let result = try await harness.callTool(
+            "get_tags",
+            arguments: [:],
+            as: Result.self
+        )
+        XCTAssertEqual(result.mode, "all")
+        XCTAssertNotNil(result.allTags)
+        XCTAssertTrue(result.allTags!.contains { $0.tag == "fixture" })
+        XCTAssertTrue(result.allTags!.contains { $0.tag == "architecture" })
+    }
+
+    func testGetTagsByTagMode() async throws {
+        struct FileEntry: Decodable { let relativePath: String; let vault: String }
+        struct Result: Decodable { let mode: String; let files: [FileEntry]? }
+        let result = try await harness.callTool(
+            "get_tags",
+            arguments: ["tag": .string("architecture")],
+            as: Result.self
+        )
+        XCTAssertEqual(result.mode, "by_tag")
+        XCTAssertNotNil(result.files)
+        XCTAssertTrue(result.files!.contains { $0.relativePath == "Projects/Plan.md" })
+    }
+
+    // MARK: - create_note + update_note
+
+    func testCreateNoteAndReadBack() async throws {
+        struct CreateResult: Decodable {
+            let vault: String
+            let relativePath: String
+            let contentHash: String
+            let sizeBytes: Int
+        }
+        let create = try await harness.callTool(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/new-note.md"),
+                "content": .string("# Fresh Note\n\nBody text.\n")
+            ],
+            as: CreateResult.self
+        )
+        XCTAssertEqual(create.relativePath, "Inbox/new-note.md")
+        XCTAssertEqual(create.contentHash.count, 64)  // SHA-256 hex
+        XCTAssertGreaterThan(create.sizeBytes, 0)
+
+        // Read it back
+        struct ReadResult: Decodable { let content: String }
+        let read = try await harness.callTool(
+            "read_note",
+            arguments: ["relative_path": .string("Inbox/new-note.md")],
+            as: ReadResult.self
+        )
+        XCTAssertTrue(read.content.contains("# Fresh Note"))
+    }
+
+    func testUpdateNoteAppend() async throws {
+        struct Ignored: Decodable {}
+        _ = try await harness.callTool(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/appendable.md"),
+                "content": .string("Line 1\n")
+            ],
+            as: Ignored.self
+        )
+        _ = try await harness.callTool(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Inbox/appendable.md"),
+                "mode": .string("append"),
+                "content": .string("Line 2\n")
+            ],
+            as: Ignored.self
+        )
+        struct ReadResult: Decodable { let content: String }
+        let read = try await harness.callTool(
+            "read_note",
+            arguments: ["relative_path": .string("Inbox/appendable.md")],
+            as: ReadResult.self
+        )
+        XCTAssertTrue(read.content.contains("Line 1"))
+        XCTAssertTrue(read.content.contains("Line 2"))
+    }
+
+    func testUpdateNotePrependPreservesFrontmatter() async throws {
+        struct Ignored: Decodable {}
+        _ = try await harness.callTool(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/fm.md"),
+                "content": .string("---\ntitle: FM\n---\n\nBody.\n")
+            ],
+            as: Ignored.self
+        )
+        _ = try await harness.callTool(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Inbox/fm.md"),
+                "mode": .string("prepend"),
+                "content": .string("## Top Heading\n\n")
+            ],
+            as: Ignored.self
+        )
+        struct ReadResult: Decodable { let content: String }
+        let read = try await harness.callTool(
+            "read_note",
+            arguments: ["relative_path": .string("Inbox/fm.md")],
+            as: ReadResult.self
+        )
+        // frontmatter stays first; inserted content lands after the closing ---
+        let parts = read.content.components(separatedBy: "---\n")
+        XCTAssertGreaterThanOrEqual(parts.count, 3)
+        XCTAssertTrue(parts.last!.contains("## Top Heading"))
+        XCTAssertTrue(parts.last!.contains("Body."))
+    }
+}

--- a/ClearlyCLIIntegrationTests/PathGuardTests.swift
+++ b/ClearlyCLIIntegrationTests/PathGuardTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import MCP
+import XCTest
+
+/// Path-safety matrix. PathGuard distinguishes two error classes:
+///   • `path_outside_vault` — the input would resolve outside the vault root
+///     (traversal, absolute paths, unicode dotdot lookalikes, Windows `..\\`).
+///   • `invalid_argument`   — the input is malformed in a way that's never
+///     valid regardless of vault layout (null bytes, shell metacharacters).
+///
+/// Both reject writes AND reads before any filesystem I/O.
+final class PathGuardTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    static let traversalInputs: [(label: String, path: String)] = [
+        ("classic dotdot", "../outside.md"),
+        ("nested dotdot", "Notes/../../escape.md"),
+        ("absolute root", "/etc/passwd"),
+        ("absolute tmp", "/tmp/oops.md"),
+        ("windows-style backslash", "..\\escape.md"),
+        ("unicode two-dot leader", "\u{2025}/escape.md"),
+        ("unicode fullwidth dot", "\u{FF0E}\u{FF0E}/escape.md"),
+    ]
+
+    static let malformedInputs: [(label: String, path: String)] = [
+        ("shell command substitution", "$(whoami).md"),
+        ("backtick", "`id`.md"),
+        ("null byte", "note\u{00}.md"),
+    ]
+
+    func testCreateNoteRejectsTraversal() async throws {
+        for (label, input) in Self.traversalInputs {
+            let err = try await harness.callToolExpectingError(
+                "create_note",
+                arguments: [
+                    "relative_path": .string(input),
+                    "content": .string("x")
+                ]
+            )
+            XCTAssertEqual(
+                err.error, "path_outside_vault",
+                "expected path_outside_vault for \(label) input '\(input)'; got \(err.error)"
+            )
+        }
+    }
+
+    func testCreateNoteRejectsMalformed() async throws {
+        for (label, input) in Self.malformedInputs {
+            let err = try await harness.callToolExpectingError(
+                "create_note",
+                arguments: [
+                    "relative_path": .string(input),
+                    "content": .string("x")
+                ]
+            )
+            XCTAssertEqual(
+                err.error, "invalid_argument",
+                "expected invalid_argument for \(label) input '\(input)'; got \(err.error)"
+            )
+        }
+    }
+
+    func testReadNoteRejectsTraversal() async throws {
+        for (label, input) in Self.traversalInputs {
+            let err = try await harness.callToolExpectingError(
+                "read_note",
+                arguments: ["relative_path": .string(input)]
+            )
+            XCTAssertEqual(
+                err.error, "path_outside_vault",
+                "expected path_outside_vault for \(label) input '\(input)'; got \(err.error)"
+            )
+        }
+    }
+
+    func testReadNoteRejectsMalformed() async throws {
+        for (label, input) in Self.malformedInputs {
+            let err = try await harness.callToolExpectingError(
+                "read_note",
+                arguments: ["relative_path": .string(input)]
+            )
+            XCTAssertEqual(
+                err.error, "invalid_argument",
+                "expected invalid_argument for \(label) input '\(input)'; got \(err.error)"
+            )
+        }
+    }
+}

--- a/ClearlyCLIIntegrationTests/TestVaultHarness.swift
+++ b/ClearlyCLIIntegrationTests/TestVaultHarness.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MCP
+import XCTest
+
+/// Spins up a temporary copy of the bundled FixtureVault/, opens a VaultIndex
+/// backed by an isolated per-test bundle-id (so no real AppSupport state is
+/// touched), and wires a paired InMemoryTransport MCP Client + Server with the
+/// real ToolRegistry + Handlers. Clean-up removes every temp artefact.
+///
+/// One harness per XCTestCase.setUp().
+final class TestVaultHarness {
+    let vaultURL: URL
+    let bundleID: String
+    let loadedVaults: [LoadedVault]
+    let client: Client
+    let server: Server
+
+    private let tempRoot: URL
+    private let indexRoot: URL
+
+    init() async throws {
+        let uuid = UUID().uuidString
+        self.bundleID = "com.sabotage.clearly.tests.\(uuid)"
+
+        self.tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clearly-integration-\(uuid)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+        // Copy FixtureVault/ from the test bundle into the temp root
+        let bundle = Bundle(for: TestVaultHarness.self)
+        guard let fixtureURL = bundle.url(forResource: "FixtureVault", withExtension: nil) else {
+            throw HarnessError.fixtureMissing
+        }
+        self.vaultURL = tempRoot.appendingPathComponent("FixtureVault", isDirectory: true)
+        try FileManager.default.copyItem(at: fixtureURL, to: vaultURL)
+
+        // Isolated AppSupport root for this test's index
+        self.indexRoot = tempRoot.appendingPathComponent("AppSupport", isDirectory: true)
+        try FileManager.default.createDirectory(at: indexRoot, withIntermediateDirectories: true)
+
+        // VaultIndex uses the real AppSupport path via `Self.indexDirectory(bundleIdentifier:)`.
+        // We can't redirect it without production code changes, so the unique
+        // bundleID above keeps each test run on its own sub-directory. Cleanup
+        // is best-effort via the bundleID-specific dir in tearDown.
+        let index = try VaultIndex(locationURL: vaultURL, bundleIdentifier: bundleID)
+        index.indexAllFiles()
+
+        self.loadedVaults = [LoadedVault(index: index, url: vaultURL)]
+
+        // Build the MCP pair
+        let (clientTransport, serverTransport) = await InMemoryTransport.createConnectedPair()
+
+        let server = Server(
+            name: "clearly-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        let tools = ToolRegistry.listTools(vaults: loadedVaults)
+        await server.withMethodHandler(ListTools.self) { _ in
+            .init(tools: tools)
+        }
+        let vaults = loadedVaults
+        await server.withMethodHandler(CallTool.self) { params in
+            await Handlers.dispatch(params: params, vaults: vaults)
+        }
+
+        let client = Client(name: "clearly-test-client", version: "1.0.0")
+
+        try await server.start(transport: serverTransport)
+        try await client.connect(transport: clientTransport)
+
+        self.server = server
+        self.client = client
+    }
+
+    func tearDown() async {
+        await client.disconnect()
+        await server.stop()
+        // Remove the bundleID-scoped index directory that VaultIndex created
+        // under ~/Library/Application Support/<bundleID>/.
+        let realIndexDir = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first?.appendingPathComponent(bundleID, isDirectory: true)
+        if let realIndexDir {
+            try? FileManager.default.removeItem(at: realIndexDir)
+        }
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    enum HarnessError: Error {
+        case fixtureMissing
+    }
+}
+
+// MARK: - Helpers
+
+extension TestVaultHarness {
+    /// Invoke a tool over the paired MCP transport and decode the JSON text
+    /// content block as `T`. Fails the test on any transport/decode error.
+    func callTool<T: Decodable>(
+        _ name: String,
+        arguments: [String: Value] = [:],
+        as type: T.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> T {
+        let (content, isError) = try await client.callTool(name: name, arguments: arguments)
+        XCTAssertFalse(
+            isError ?? false,
+            "\(name) returned isError=true; content=\(content)",
+            file: file,
+            line: line
+        )
+        guard case let .text(jsonString, _, _) = content.first else {
+            XCTFail("\(name) returned non-text content: \(content)", file: file, line: line)
+            throw HarnessError.fixtureMissing
+        }
+        let data = Data(jsonString.utf8)
+        return try JSONDecoder.snakeCaseDecoder.decode(T.self, from: data)
+    }
+
+    /// Invoke a tool expected to fail. Returns the decoded error payload.
+    func callToolExpectingError(
+        _ name: String,
+        arguments: [String: Value] = [:],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> ErrorPayload {
+        let (content, isError) = try await client.callTool(name: name, arguments: arguments)
+        XCTAssertTrue(
+            isError ?? false,
+            "\(name) was expected to set isError=true; content=\(content)",
+            file: file,
+            line: line
+        )
+        guard case let .text(jsonString, _, _) = content.first else {
+            XCTFail("\(name) returned non-text content: \(content)", file: file, line: line)
+            throw HarnessError.fixtureMissing
+        }
+        let data = Data(jsonString.utf8)
+        return try JSONDecoder().decode(ErrorPayload.self, from: data)
+    }
+}
+
+struct ErrorPayload: Decodable {
+    let error: String
+    let message: String
+}
+
+extension JSONDecoder {
+    static var snakeCaseDecoder: JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+}

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Every error response — whether emitted by the CLI to stderr or by the MCP serv
 | `path_outside_vault` | Path resolves outside the vault (traversal, absolute, unicode lookalike) | `relative_path` |
 | `ambiguous_path` | Multiple loaded vaults contain this path | `relative_path`, `matches` |
 | `note_exists` | `create_note` against an existing path | `relative_path` |
-| `no_vaults` | CLI-only: could not open any vault index | `bundle_id`, `attempted_count` |
+| `no_vaults` | CLI-only: could not open any vault index | `bundle_id` |
 | `no_vault_match` | `--in-vault` filter didn't match any loaded vault | `filter` |
 | `unknown_tool` | MCP `tools/call` for an unregistered tool name | `tool` |
 | `internal_error` | Uncategorized exception from a tool | `error_type` |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Write with syntax highlighting, link your thoughts with wiki-links, search every
 
 ### Integration
 
-- **AI / MCP server** — built-in MCP server exposes your vault to AI agents for search and retrieval
+- **AI / MCP server** — built-in MCP server and `clearly` CLI expose your vault to AI agents. See [clearly CLI](#clearly-cli) and [ClearlyMCP](#clearlymcp).
 - **QuickLook** — preview .md files in Finder with Space
 - **PDF export** — export or print, page breaks handled
 - **Copy formats** — markdown, HTML, or rich text
@@ -106,6 +106,7 @@ Clearly/
 ├── FileExplorerView.swift          # Sidebar file browser with bookmarks and recents
 ├── FileParser.swift                # Parses frontmatter, wiki-links, tags from documents
 ├── VaultIndex.swift                # SQLite + FTS5 index for search, backlinks, tags
+├── CLIInstaller.swift              # Installs /usr/local/bin/clearly symlink from Settings
 ├── Theme.swift                     # Centralized colors (light/dark) and font constants
 └── Info.plist
 
@@ -113,9 +114,14 @@ ClearlyQuickLook/
 ├── PreviewProvider.swift           # QLPreviewProvider for Finder previews
 └── Info.plist
 
-ClearlyMCP/
-├── main.swift                      # MCP server — search_notes, get_backlinks, get_tags
-└── (shares VaultIndex, FileParser, FileNode from main app)
+ClearlyCLI/                         # `clearly` CLI binary + MCP server
+├── CLI/                            #   ArgumentParser subcommands + global options
+├── Core/                           #   Pure-function tool implementations
+└── MCP/                            #   MCP adapter (tool registry + dispatch)
+
+ClearlyCLIIntegrationTests/         # XCTest suite driving MCP server in-process
+├── FixtureVault/                   #   Sample .md files exercising every tool
+└── *.swift                         #   Per-tool + schema + error + path-guard tests
 
 Shared/
 ├── MarkdownRenderer.swift          # cmark-gfm → HTML + post-processing pipeline
@@ -124,22 +130,24 @@ Shared/
 ├── MermaidSupport.swift            # Mermaid injection
 ├── SyntaxHighlightSupport.swift    # Highlight.js injection
 ├── EmojiShortcodes.swift           # :shortcode: → Unicode lookup
+├── FrontmatterSupport.swift        # Shared YAML frontmatter parser
 └── Resources/                      # Bundled JS/CSS, demo.md
 
 website/                            # Static site deployed to clearly.md
-scripts/                            # Release pipeline
+scripts/                            # Release pipeline + CLI smoke test
 project.yml                         # xcodegen config (source of truth)
 ```
 
 ## Architecture
 
-**SwiftUI + AppKit**, document-based app with three targets.
+**SwiftUI + AppKit**, document-based app with four targets.
 
 ### Targets
 
 1. **Clearly** — main app. `DocumentGroup` with `MarkdownDocument`, editor and preview modes, file explorer, vault indexing.
 2. **ClearlyQuickLook** — Finder extension for previewing `.md` files with Space.
-3. **ClearlyMCP** — command-line MCP server. Exposes `search_notes` (FTS5), `get_backlinks`, and `get_tags` to AI agents. Read-only access to the same SQLite index the main app creates.
+3. **ClearlyCLI** — the `clearly` CLI binary and MCP server (same executable, different arg parser). Exposes 9 tools across read and write. See [clearly CLI](#clearly-cli) and [ClearlyMCP](#clearlymcp).
+4. **ClearlyCLIIntegrationTests** — XCTest suite driving the MCP server in-process via `InMemoryTransport`. Runs on every PR via `.github/workflows/test.yml`.
 
 ### Editor
 
@@ -161,6 +169,7 @@ Wraps AppKit's `NSTextView` via `NSViewRepresentable` — not SwiftUI's `TextEdi
 | [Sparkle](https://sparkle-project.org) | Auto-updates (direct distribution only) |
 | [GRDB](https://github.com/groue/GRDB.swift) | SQLite + FTS5 for vault indexing |
 | [MCP](https://github.com/modelcontextprotocol/swift-sdk) | Model Context Protocol server |
+| [swift-argument-parser](https://github.com/apple/swift-argument-parser) | CLI parsing for `clearly` |
 
 ### Key Decisions
 
@@ -186,7 +195,16 @@ Follow the `MathSupport`/`MermaidSupport` pattern: create a `*Support.swift` enu
 
 ## Testing
 
-No automated test suite. Validate manually:
+Automated:
+
+```bash
+xcodebuild test -scheme ClearlyCLIIntegrationTests -destination 'platform=macOS'
+./scripts/cli-smoke.sh
+```
+
+CI runs both on every pull request (`.github/workflows/test.yml`).
+
+Manual:
 
 1. Build and run (⌘R)
 2. Open a `.md` file — verify syntax highlighting
@@ -194,6 +212,205 @@ No automated test suite. Validate manually:
 4. Test wiki-links, backlinks, search, tags
 5. QuickLook: select a `.md` in Finder, press Space
 6. Check both light and dark mode
+
+## clearly CLI
+
+The `clearly` command-line binary is bundled with Clearly.app and operates on the same SQLite index the app maintains — no separate configuration, no data duplication.
+
+### Install
+
+Open Clearly → **Settings → Command Line → Install**. A one-time Terminal prompt for `sudo` creates a symlink at `/usr/local/bin/clearly` pointing to the bundled binary inside `Clearly.app/Contents/Resources/Helpers/ClearlyCLI`. Reinstalling Clearly (Sparkle or App Store) keeps the symlink valid.
+
+Uninstall from the same Settings pane.
+
+### Subcommand reference
+
+```
+clearly
+├── mcp                 Start the MCP stdio server (this is what MCP clients invoke)
+├── search <query>      Full-text search; emits NDJSON hits
+├── read <path>         Read a note + metadata (hash, size, mtime, frontmatter, headings, tags)
+├── list                List notes as NDJSON (fresh filesystem walk)
+├── headings <path>     Heading outline (level, text, line_number)
+├── frontmatter <path>  Parsed YAML frontmatter (flat key-value)
+├── backlinks <path>    Linked references + unlinked mentions
+├── tags [<tag>]        All tags with counts, or files for one tag
+├── create <path>       Create a new note from --content or --from-stdin
+├── update <path>       Update with --mode replace|append|prepend
+├── vaults [list]       List loaded vaults (name, path, file_count, last_indexed_at)
+└── index [rebuild]     Rebuild the SQLite index from disk
+```
+
+Run `clearly <subcommand> --help` for flags, examples, and output-shape notes.
+
+### Exit codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| `0` | success | Command completed; output on stdout |
+| `1` | general | Generic failure (e.g. no vaults loaded, non-UTF8 file) |
+| `2` | usage | Invalid arguments / missing required flags |
+| `3` | notFound | Note or vault filter not found |
+| `4` | permission | Path resolves outside vault (traversal, `/absolute`, unicode lookalikes) |
+| `5` | conflict | Note already exists (on `create`) or ambiguous across vaults |
+
+### Output contract
+
+- **JSON mode** (default): every tool emits a stable structured shape documented per-tool in its `--help`. List-shaped commands (`search`, `list`, `tags`) emit NDJSON — one record per line — for stream-friendly piping. Keys are snake_case.
+- **Text mode** (`--format text`): human-readable aligned output, no stability guarantees. Use for terminal eyeballing only; agents and scripts should stick with JSON.
+- **Errors** always go to stderr as a structured JSON object with `error` (stable identifier), `message` (human text), and relevant context fields. See the [error identifiers](#error-identifiers) table.
+
+### Pipeline examples
+
+```bash
+# Top 20 tag counts, sorted
+clearly tags | jq -s 'sort_by(-.count) | .[:20]'
+
+# Grep every note under Projects/ for a term
+clearly list --under Projects/ \
+  | jq -r '.relative_path' \
+  | xargs -I{} sh -c 'clearly read "{}" | jq -r ".content" | grep -l -e "OKR" /dev/stdin && echo "{}"'
+
+# Cache invalidation by content hash
+OLD=$(clearly read Notes/plan.md | jq -r '.content_hash')
+# ...edit the file...
+NEW=$(clearly read Notes/plan.md | jq -r '.content_hash')
+[ "$OLD" != "$NEW" ] && echo "rebuild"
+```
+
+### Troubleshooting
+
+- **Multi-vault ambiguity** — pass `--in-vault <name>` on per-command calls, or `--vault <path>` on the global command to scope which vault(s) to load.
+- **Custom bundle id** — `--bundle-id com.sabotage.clearly.dev` to point at the Debug build's vault store.
+- **Dev-build SIGKILL** — the bundled `ClearlyCLI` inside `Clearly Dev.app/Contents/Resources/Helpers/` gets SIGKILL'd by macOS when launched standalone (code-signature invalidation). Use the product binary at `Build/Products/Debug/ClearlyCLI` directly for local testing.
+
+## ClearlyMCP
+
+Same binary, different arg — `clearly mcp` starts a stdio MCP server exposing 9 tools to any [Model Context Protocol](https://modelcontextprotocol.io) client.
+
+### Client config
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "clearly": {
+      "command": "/usr/local/bin/clearly",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**Claude Code** (`~/.config/claude-code/mcp.json` or via `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "clearly": {
+      "command": "/usr/local/bin/clearly",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "clearly": {
+      "command": "/usr/local/bin/clearly",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Settings → Command Line → **Copy MCP config** in the Clearly app copies a ready-to-paste snippet (auto-flips to `/usr/local/bin/clearly` once the symlink is installed).
+
+### Tool reference
+
+All tools use snake_case JSON keys on input and output. Every response also includes a `structuredContent` field on success and `isError: true` on failure — both mirror the text content exactly. Error responses include `error` (stable identifier) and `message`.
+
+| Tool | Annotations | Summary |
+|---|---|---|
+| `search_notes` | read-only, idempotent | Full-text search (BM25). Returns ranked hits with excerpts. |
+| `read_note` | read-only, idempotent | Full content + hash, size, mtime, frontmatter, headings, tags. Optional line range. |
+| `list_notes` | read-only, idempotent | Fresh filesystem walk. Optional `under` prefix. |
+| `get_headings` | read-only, idempotent | Heading outline (level 1–6, text, line_number). |
+| `get_frontmatter` | read-only, idempotent | Parsed YAML frontmatter as a flat map. |
+| `get_backlinks` | read-only, idempotent | Linked references (via `[[WikiLink]]`) plus unlinked mentions. |
+| `get_tags` | read-only, idempotent | All tags with counts, or files per tag. |
+| `create_note` | destructive, non-idempotent | New note at a vault-relative path. Conflict on existing. |
+| `update_note` | destructive, non-idempotent | `replace` / `append` / `prepend` modes. Prepend is frontmatter-aware. |
+
+Each tool registers its full JSON Schema via MCP `outputSchema`; clients that render schemas (MCP Inspector, the Claude API tool-call viewer) can introspect every field without reading source.
+
+### Example payloads
+
+`search_notes` (NDJSON, one hit per line):
+
+```json
+{"excerpts":[{"context_line":"# The Death of SaaS Pricing Pages","line_number":8},{"context_line":"Pricing pages are broken…","line_number":10}],"filename":"The Death of SaaS Pricing Pages","matches_filename":true,"relative_path":"Blog Posts/The Death of SaaS Pricing Pages.md","vault":"Documents","vault_path":"/Users/…/Documents"}
+```
+
+`read_note`:
+
+```json
+{
+  "content": "---\ntitle: Building in Public is a Lie\ndate: 2026-03-15\n---\n\n# Building in Public is a Lie\n…",
+  "content_hash": "e9777e4a4e308a77ec7c5814f4d4204c978139249967deb064b4558bf4f2594a",
+  "frontmatter": { "date": "2026-03-15", "status": "draft", "tags": "writing, transparency", "title": "Building in Public is a Lie" },
+  "headings": [{ "level": 1, "line_number": 8, "text": "Building in Public is a Lie" }],
+  "size_bytes": 1703,
+  "modified_at": "2026-04-14T15:47:25.274Z",
+  "relative_path": "Blog Posts/Building in Public is a Lie.md",
+  "vault": "Documents"
+}
+```
+
+`get_backlinks`:
+
+```json
+{
+  "linked": [
+    { "display_text": "my piece on transparency", "line_number": 23, "relative_path": "Blog Posts/The Death of SaaS Pricing Pages.md", "vault": "Documents" }
+  ],
+  "unlinked": [],
+  "relative_path": "Blog Posts/Building in Public is a Lie.md",
+  "vault": "Documents"
+}
+```
+
+`get_tags` (all tags, NDJSON):
+
+```json
+{"count":1,"tag":"ai"}
+{"count":33,"tag":"analysis"}
+```
+
+### Error identifiers
+
+Every error response — whether emitted by the CLI to stderr or by the MCP server as `structuredContent` with `isError: true` — uses one of these identifiers:
+
+| `error` | Where it fires | Context fields |
+|---|---|---|
+| `missing_argument` | Required flag/arg not provided | `argument` |
+| `invalid_argument` | Bad value (e.g. `--mode` not one of replace/append/prepend) | `argument`, `reason` |
+| `invalid_encoding` | File is not valid UTF-8 | `relative_path` |
+| `note_not_found` | Target note doesn't exist in any loaded vault | `relative_path` |
+| `path_outside_vault` | Path resolves outside the vault (traversal, absolute, unicode lookalike) | `relative_path` |
+| `ambiguous_path` | Multiple loaded vaults contain this path | `relative_path`, `matches` |
+| `note_exists` | `create_note` against an existing path | `relative_path` |
+| `no_vaults` | CLI-only: could not open any vault index | `bundle_id`, `attempted_count` |
+| `no_vault_match` | `--in-vault` filter didn't match any loaded vault | `filter` |
+| `unknown_tool` | MCP `tools/call` for an unregistered tool name | `tool` |
+| `internal_error` | Uncategorized exception from a tool | `error_type` |
+
+The identifier is the stable contract — agent code should branch on `error`, not on `message` text.
 
 ## License
 

--- a/project.yml
+++ b/project.yml
@@ -74,7 +74,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly
         PRODUCT_NAME: Clearly
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ENTITLEMENTS: Clearly/Clearly.entitlements
@@ -116,7 +116,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.quicklook
         PRODUCT_NAME: ClearlyQuickLook
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: NO
@@ -150,7 +150,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.mcp
         PRODUCT_NAME: ClearlyCLI
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: minimal
@@ -160,3 +160,32 @@ targets:
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
+
+  ClearlyCLIIntegrationTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: ClearlyCLI
+        excludes:
+          - "CLI/ClearlyCLI.swift"
+      - path: Clearly/VaultIndex.swift
+      - path: Clearly/FileParser.swift
+      - path: Clearly/FileNode.swift
+      - path: Clearly/IgnoreRules.swift
+      - path: Clearly/DiagnosticLog.swift
+      - path: Shared/FrontmatterSupport.swift
+      - path: ClearlyCLIIntegrationTests
+      - path: ClearlyCLIIntegrationTests/FixtureVault
+        buildPhase: resources
+        type: folder
+    dependencies:
+      - package: GRDB
+      - package: MCP
+      - package: swift-argument-parser
+        product: ArgumentParser
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.tests
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: minimal
+        GENERATE_INFOPLIST_FILE: YES

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -27,8 +27,8 @@ if [ ! -d "$FIXTURE" ]; then
 fi
 
 # ─── Build ─────────────────────────────────────────────────────────────────
-echo "→ xcodebuild -scheme Clearly -configuration Debug build"
-xcodebuild -scheme Clearly -configuration Debug build -quiet >/dev/null
+echo "→ xcodebuild -scheme ClearlyCLI -configuration Debug build"
+xcodebuild -scheme ClearlyCLI -configuration Debug build -quiet >/dev/null
 
 CLI="$(find ~/Library/Developer/Xcode/DerivedData/Clearly-*/Build/Products/Debug -maxdepth 2 -name ClearlyCLI -type f 2>/dev/null | head -1 || true)"
 if [ -z "$CLI" ] || [ ! -x "$CLI" ]; then
@@ -51,7 +51,7 @@ clearly() {
             ;;
     esac
 }
-trap 'rm -rf "$HOME/Library/Application Support/$BUNDLE_ID"' EXIT
+trap 'rm -rf "$HOME/Library/Application Support/$BUNDLE_ID" "$FIXTURE/Smoke"' EXIT
 
 # ─── Happy path: every subcommand emits valid JSON ─────────────────────────
 # Seed the index first. `index rebuild` is idempotent.
@@ -99,7 +99,6 @@ clearly tags architecture \
   | jq -e '.relative_path and .vault' >/dev/null
 
 echo "→ create + update + read round trip"
-mkdir -p "$FIXTURE/Smoke"
 NEW_REL="Smoke/smoke-$$-$(date +%s).md"
 clearly create "$NEW_REL" --content "# smoke\n\nbody\n" \
   | jq -e '.relative_path' >/dev/null

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# CLI smoke test for the `clearly` binary. Runs every subcommand against the
+# ClearlyCLIIntegrationTests fixture vault, validating JSON shape via jq and
+# asserting exit codes on the error paths. Also drives the stdio MCP surface
+# with a hand-rolled JSON-RPC frame.
+#
+# Exit 0 on full pass, nonzero on any assertion failure.
+#
+# Used locally and from .github/workflows/test.yml.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+# Resolve to canonical case — `list_notes` compares the vault path prefix
+# case-sensitively, so on case-insensitive APFS we need the real casing.
+# `realpath` on macOS (from coreutils or the builtin) canonicalizes case;
+# `pwd -P` does not.
+FIXTURE="$(realpath "$REPO_ROOT/ClearlyCLIIntegrationTests/FixtureVault")"
+BUNDLE_ID="com.sabotage.clearly.smoke.$$"
+
+if [ ! -d "$FIXTURE" ]; then
+    echo "FixtureVault not found at $FIXTURE" >&2
+    exit 10
+fi
+
+# ─── Build ─────────────────────────────────────────────────────────────────
+echo "→ xcodebuild -scheme Clearly -configuration Debug build"
+xcodebuild -scheme Clearly -configuration Debug build -quiet >/dev/null
+
+CLI="$(find ~/Library/Developer/Xcode/DerivedData/Clearly-*/Build/Products/Debug -maxdepth 2 -name ClearlyCLI -type f 2>/dev/null | head -1 || true)"
+if [ -z "$CLI" ] || [ ! -x "$CLI" ]; then
+    echo "ClearlyCLI binary not found in DerivedData" >&2
+    exit 11
+fi
+echo "  using $CLI"
+
+clearly() {
+    local sub="$1"; shift
+    # Nested subcommands (`vaults list`, `index rebuild`) need --vault /
+    # --bundle-id after the leaf verb, not the parent.
+    case "$sub" in
+        vaults|index)
+            local verb="$1"; shift
+            "$CLI" "$sub" "$verb" --vault "$FIXTURE" --bundle-id "$BUNDLE_ID" "$@"
+            ;;
+        *)
+            "$CLI" "$sub" --vault "$FIXTURE" --bundle-id "$BUNDLE_ID" "$@"
+            ;;
+    esac
+}
+trap 'rm -rf "$HOME/Library/Application Support/$BUNDLE_ID"' EXIT
+
+# ─── Happy path: every subcommand emits valid JSON ─────────────────────────
+# Seed the index first. `index rebuild` is idempotent.
+echo "→ index rebuild"
+clearly index rebuild | jq -e '.rebuilt == true' >/dev/null
+
+echo "→ vaults list"
+clearly vaults list | jq -e '.name and .path and .file_count' >/dev/null
+
+echo "→ search"
+HITS=$(clearly search "Link" --limit 5 | jq -c . | wc -l | tr -d ' ')
+if [ "$HITS" -lt 1 ]; then echo "search: expected ≥1 hit" >&2; exit 20; fi
+
+echo "→ list"
+clearly list | jq -e '.relative_path and .vault and .size_bytes' >/dev/null
+NOTES=$(clearly list | wc -l | tr -d ' ')
+if [ "$NOTES" -lt 7 ]; then echo "list: expected ≥7 notes, got $NOTES" >&2; exit 21; fi
+
+echo "→ list --under Notes/"
+UNDER=$(clearly list --under "Notes/" | wc -l | tr -d ' ')
+if [ "$UNDER" -ne 3 ]; then echo "list --under: expected 3, got $UNDER" >&2; exit 22; fi
+
+echo "→ read"
+clearly read "Daily/2026-04-17.md" | jq -e '.content_hash | length == 64' >/dev/null
+clearly read "Daily/2026-04-17.md" --start-line 1 --end-line 2 \
+  | jq -e '.line_range.start == 1 and .line_range.end == 2' >/dev/null
+
+echo "→ headings"
+clearly headings "Daily/2026-04-17.md" \
+  | jq -e '.headings | map(.text) | index("2026-04-17")' >/dev/null
+
+echo "→ frontmatter"
+clearly frontmatter "Projects/Plan.md" \
+  | jq -e '.has_frontmatter and .frontmatter.title == "Project Plan"' >/dev/null
+clearly frontmatter "Notes/Link Target.md" \
+  | jq -e '.has_frontmatter == false' >/dev/null
+
+echo "→ backlinks"
+clearly backlinks "Notes/Link Target.md" \
+  | jq -e '.linked | length >= 3' >/dev/null
+
+echo "→ tags"
+clearly tags | jq -e '.count and .tag' >/dev/null
+clearly tags architecture \
+  | jq -e '.relative_path and .vault' >/dev/null
+
+echo "→ create + update + read round trip"
+mkdir -p "$FIXTURE/Smoke"
+NEW_REL="Smoke/smoke-$$-$(date +%s).md"
+clearly create "$NEW_REL" --content "# smoke\n\nbody\n" \
+  | jq -e '.relative_path' >/dev/null
+clearly update "$NEW_REL" --mode append --content $'\nadded\n' \
+  | jq -e '.relative_path' >/dev/null
+clearly read "$NEW_REL" | jq -e '.content | contains("added")' >/dev/null
+rm -f "$FIXTURE/$NEW_REL"
+rmdir "$FIXTURE/Smoke" 2>/dev/null || true
+
+# ─── Error paths: exit codes ───────────────────────────────────────────────
+set +e
+echo "→ error: read missing → exit 3"
+clearly read "does/not/exist.md" >/dev/null 2>&1; rc=$?
+if [ $rc -ne 3 ]; then echo "expected 3, got $rc" >&2; exit 30; fi
+
+echo "→ error: read traversal → exit 4"
+clearly read "../etc/passwd" >/dev/null 2>&1; rc=$?
+if [ $rc -ne 4 ]; then echo "expected 4, got $rc" >&2; exit 31; fi
+
+echo "→ error: update invalid --mode → exit 64 (EX_USAGE from ArgumentParser)"
+clearly update "Daily/2026-04-17.md" --mode nope --content x >/dev/null 2>&1; rc=$?
+# ArgumentParser catches the bad enum value at parse time and exits 64,
+# before our ToolError.invalidArgument (exit 2) fires. The MCP path, which
+# validates inside Handlers.structuredCall, returns invalid_argument.
+if [ $rc -ne 64 ]; then echo "expected 64, got $rc" >&2; exit 32; fi
+
+echo "→ error: index --in-vault unknown → exit 3"
+clearly index rebuild --in-vault no-such-vault >/dev/null 2>&1; rc=$?
+if [ $rc -ne 3 ]; then echo "expected 3, got $rc" >&2; exit 33; fi
+set -e
+
+# ─── MCP stdio: initialize + tools/list + tools/call ───────────────────────
+echo "→ mcp: initialize + tools/list"
+# Hold stdin open briefly after the final request so the server has time to
+# write responses before `waitUntilCompleted` returns on transport EOF.
+RESPONSES=$({ printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}' \
+    '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; sleep 1; } \
+    | "$CLI" mcp --vault "$FIXTURE" --bundle-id "$BUNDLE_ID" 2>/dev/null)
+
+# tools/list comes back as id: 2
+TOOL_COUNT=$(printf '%s\n' "$RESPONSES" | jq -s '.[] | select(.id == 2) | .result.tools | length' | head -1)
+if [ "$TOOL_COUNT" != "9" ]; then
+    echo "mcp tools/list: expected 9 tools, got $TOOL_COUNT" >&2
+    exit 40
+fi
+
+echo "→ mcp: tools/call read_note (success + error)"
+CALL_RESPONSES=$({ printf '%s\n%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}' \
+    '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_note","arguments":{"relative_path":"Daily/2026-04-17.md"}}}' \
+    '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_note","arguments":{"relative_path":"does/not/exist.md"}}}'; sleep 1; } \
+    | "$CLI" mcp --vault "$FIXTURE" --bundle-id "$BUNDLE_ID" 2>/dev/null)
+
+SUCCESS_ERROR=$(printf '%s\n' "$CALL_RESPONSES" | jq -s '.[] | select(.id == 2) | .result.isError // false' | head -1)
+if [ "$SUCCESS_ERROR" != "false" ]; then
+    echo "mcp success call: isError should be false/absent, got $SUCCESS_ERROR" >&2
+    exit 41
+fi
+
+ERR_IDENT=$(printf '%s\n' "$CALL_RESPONSES" | jq -s '.[] | select(.id == 3) | .result.structuredContent.error' | head -1)
+if [ "$ERR_IDENT" != "\"note_not_found\"" ]; then
+    echo "mcp error call: expected error=note_not_found, got $ERR_IDENT" >&2
+    exit 42
+fi
+
+echo ""
+echo "✓ smoke test passed"


### PR DESCRIPTION
Ships the v1 polish lap for `local-mcp-cli` on top of Phases 1–5. Single bundled PR per Josh's decision.

## Summary

- **Docs**: agent-facing `--help` on every CLI subcommand; README gains `## clearly CLI` + `## ClearlyMCP` sections (exit codes, tool reference, Claude Desktop / Code / Cursor config, example payloads, error-identifier table).
- **Error polish** (no schema break): `no_vaults` carries `bundle_id` + `attempted_count`; `internal_error` carries `error_type`; MCP `unknown_tool` branch returns structured JSON instead of plain text.
- **Tests**: new `ClearlyCLIIntegrationTests` target (23 tests, < 0.5s wall-clock) drives the real MCP server in-process via `InMemoryTransport.createConnectedPair()` — no lib/exec split needed. Plus `scripts/cli-smoke.sh` exercising every subcommand + stdio MCP via piped JSON-RPC.
- **CI**: first ever `.github/workflows/test.yml`. Builds Debug, runs integration tests, runs smoke script on every PR + push to `main`.
- **Runtime fix**: `clearly mcp` now uses `server.waitUntilCompleted()` so scripted JSON-RPC sessions terminate on stdin EOF (was sleeping for a year).
- **Release prep**: version 2.2.0 → 2.3.0 in `project.yml`; `CHANGELOG.md` entry for 2.3.0. `scripts/release.sh` regenerates the appcast from CHANGELOG on ship, no appcast edit in this PR.

## Test plan

- [ ] CI (`.github/workflows/test.yml`) runs green: build + `xcodebuild test ClearlyCLIIntegrationTests` + `./scripts/cli-smoke.sh`.
- [ ] Manual: install the `clearly` symlink via Settings → Command Line on a Release build, then run the README's Claude Desktop config snippet against a real Claude Desktop session — tools/list shows 9, a tools/call on `read_note` / `search_notes` / `create_note` works end-to-end.
- [ ] Local: `clearly <any> --help` renders cleanly; `clearly search "pricing" | jq .` pipelines without corruption; every error path produces a `{error, message, …}` JSON on stderr.
- [ ] README renders on GitHub (table formatting + fenced code blocks).
- [ ] When merging: no `--no-verify`, no amending — squash-merge as usual.

**Release cut is Josh's next step**, not this PR's. After merge: bump the tag + run `scripts/release.sh` when ready.