### PR TITLE
Phase 1 sync: Accounts UI + Sign in with Apple + Keychain

### DIFF
--- a/Clearly/Accounts/AccountManager.swift
+++ b/Clearly/Accounts/AccountManager.swift
@@ -1,0 +1,119 @@
+import AuthenticationServices
+import Foundation
+import Observation
+import CryptoKit
+
+@Observable
+@MainActor
+final class AccountManager {
+    static let shared = AccountManager()
+
+    var currentUser: SyncAPIUser?
+    var isAuthenticating: Bool = false
+    var lastError: String?
+
+    private let api: SyncAPI
+    private var pendingAppleNonce: String?
+
+    init(api: SyncAPI = SyncAPI(baseURL: SyncAPI.defaultBaseURL)) {
+        self.api = api
+    }
+
+    var isSignedIn: Bool { currentUser != nil }
+
+    func bootstrap() async {
+        guard let token = KeychainStore.read(.sessionToken) else { return }
+        do {
+            currentUser = try await api.me(token: token)
+        } catch let error as SyncAPIError where error.status == 401 {
+            KeychainStore.delete(.sessionToken)
+        } catch {
+            // Leave the stored token in place on transient network failures;
+            // `bootstrap` will retry next launch.
+        }
+    }
+
+    func signUpEmail(email: String, password: String) async {
+        await perform {
+            let response = try await self.api.signUpEmail(email: email, password: password)
+            try self.store(response)
+        }
+    }
+
+    func signInEmail(email: String, password: String) async {
+        await perform {
+            let response = try await self.api.signInEmail(email: email, password: password)
+            try self.store(response)
+        }
+    }
+
+    // Called from AccountsSettingsView after SIWA completes with an
+    // ASAuthorizationAppleIDCredential.
+    func signInWithApple(credential: ASAuthorizationAppleIDCredential) async {
+        guard let tokenData = credential.identityToken,
+              let identityToken = String(data: tokenData, encoding: .utf8),
+              let nonce = pendingAppleNonce else {
+            lastError = "Apple sign-in returned no identity token."
+            return
+        }
+        defer { pendingAppleNonce = nil }
+
+        await perform {
+            let response = try await self.api.signInApple(
+                identityToken: identityToken,
+                nonce: nonce,
+                email: credential.email,
+                fullName: credential.fullName
+            )
+            try self.store(response)
+        }
+    }
+
+    // Call this before presenting the SIWA request. Returns the SHA-256 hashed
+    // nonce to set on ASAuthorizationAppleIDRequest.
+    func prepareAppleRequest(on request: ASAuthorizationAppleIDRequest) {
+        let raw = UUID().uuidString
+        pendingAppleNonce = raw
+        request.requestedScopes = [.email, .fullName]
+        request.nonce = sha256(raw)
+    }
+
+    func signOut() async {
+        guard let token = KeychainStore.read(.sessionToken) else {
+            reset()
+            return
+        }
+        try? await api.signOut(token: token)
+        reset()
+    }
+
+    // MARK: - Private
+
+    private func perform(_ block: @escaping () async throws -> Void) async {
+        isAuthenticating = true
+        lastError = nil
+        defer { isAuthenticating = false }
+        do {
+            try await block()
+        } catch let error as SyncAPIError {
+            lastError = error.errorDescription ?? "Sign-in failed."
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    private func store(_ response: SignInResponse) throws {
+        try KeychainStore.save(response.token, for: .sessionToken)
+        currentUser = response.user
+    }
+
+    private func reset() {
+        KeychainStore.delete(.sessionToken)
+        currentUser = nil
+    }
+
+    private func sha256(_ value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Clearly/Accounts/AccountsSettingsView.swift
+++ b/Clearly/Accounts/AccountsSettingsView.swift
@@ -1,0 +1,101 @@
+import AuthenticationServices
+import SwiftUI
+
+struct AccountsSettingsView: View {
+    @Environment(AccountManager.self) private var account
+    @State private var mode: Mode = .signIn
+    @State private var email: String = ""
+    @State private var password: String = ""
+
+    private enum Mode: String, CaseIterable, Identifiable {
+        case signIn = "Sign In"
+        case signUp = "Create Account"
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        Form {
+            if let user = account.currentUser {
+                signedInSection(user: user)
+            } else {
+                signedOutSection
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private func signedInSection(user: SyncAPIUser) -> some View {
+        Section("Account") {
+            LabeledContent("Signed in as") {
+                Text(user.emailAddress ?? "(private relay)")
+                    .foregroundStyle(.secondary)
+            }
+            LabeledContent("Plan") {
+                Text(user.subscriptionStatus.capitalized)
+                    .foregroundStyle(.secondary)
+            }
+            Button("Sign Out", role: .destructive) {
+                Task { await account.signOut() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var signedOutSection: some View {
+        Section {
+            SignInWithAppleButton(
+                onRequest: { request in
+                    account.prepareAppleRequest(on: request)
+                },
+                onCompletion: { result in
+                    switch result {
+                    case .success(let auth):
+                        if let credential = auth.credential as? ASAuthorizationAppleIDCredential {
+                            Task { await account.signInWithApple(credential: credential) }
+                        }
+                    case .failure(let error):
+                        // Silently ignore user-cancel, surface everything else.
+                        let nsError = error as NSError
+                        if nsError.code != ASAuthorizationError.canceled.rawValue {
+                            account.lastError = error.localizedDescription
+                        }
+                    }
+                }
+            )
+            .signInWithAppleButtonStyle(.black)
+            .frame(height: 32)
+        }
+
+        Section {
+            Picker("Mode", selection: $mode) {
+                ForEach(Mode.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            TextField("Email", text: $email)
+                .textContentType(.emailAddress)
+            SecureField("Password", text: $password)
+                .textContentType(mode == .signIn ? .password : .newPassword)
+
+            Button(mode.rawValue) {
+                Task {
+                    switch mode {
+                    case .signIn:
+                        await account.signInEmail(email: email, password: password)
+                    case .signUp:
+                        await account.signUpEmail(email: email, password: password)
+                    }
+                }
+            }
+            .disabled(email.isEmpty || password.isEmpty || account.isAuthenticating)
+        }
+
+        if let error = account.lastError {
+            Section {
+                Text(error).foregroundStyle(.red)
+            }
+        }
+    }
+}

--- a/Clearly/Clearly-AppStore.entitlements
+++ b/Clearly/Clearly-AppStore.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.print</key>
 	<true/>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -25,5 +25,9 @@
 	<array>
 		<string>com.apple.Terminal</string>
 	</array>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -1007,6 +1007,7 @@ struct ClearlyApp: App {
     @NSApplicationDelegateAdaptor(ClearlyAppDelegate.self) var appDelegate
     @AppStorage("themePreference") private var themePreference = "system"
     @State private var scratchpadManager = ScratchpadManager.shared
+    @State private var accountManager = AccountManager.shared
     private let workspace = WorkspaceManager.shared
     #if canImport(Sparkle)
     private let updaterController: SPUStandardUpdaterController
@@ -1015,6 +1016,7 @@ struct ClearlyApp: App {
     init() {
         DiagnosticLog.trimIfNeeded()
         DiagnosticLog.log("App launched")
+        Task { @MainActor in await AccountManager.shared.bootstrap() }
         #if canImport(Sparkle)
         #if DEBUG
         updaterController = SPUStandardUpdaterController(
@@ -1224,9 +1226,11 @@ struct ClearlyApp: App {
             #if canImport(Sparkle)
             SettingsView(updater: updaterController.updater)
                 .preferredColorScheme(resolvedColorScheme)
+                .environment(accountManager)
             #else
             SettingsView()
                 .preferredColorScheme(resolvedColorScheme)
+                .environment(accountManager)
             #endif
         }
 

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -28,6 +28,11 @@ struct SettingsView: View {
                     Label("Command Line", systemImage: "terminal")
                 }
 
+            AccountsSettingsView()
+                .tabItem {
+                    Label("Account", systemImage: "person.circle")
+                }
+
             aboutView
                 .tabItem {
                     Label("About", systemImage: "info.circle")

--- a/Clearly/Sync/KeychainStore.swift
+++ b/Clearly/Sync/KeychainStore.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    enum Key: String {
+        case sessionToken = "session_token"
+    }
+
+    enum Error: Swift.Error {
+        case unexpectedStatus(OSStatus)
+    }
+
+    static func save(_ value: String, for key: Key) throws {
+        guard let data = value.data(using: .utf8) else { return }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+        ]
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var add = query
+            add.merge(attributes) { _, new in new }
+            let addStatus = SecItemAdd(add as CFDictionary, nil)
+            if addStatus != errSecSuccess { throw Error.unexpectedStatus(addStatus) }
+        default:
+            throw Error.unexpectedStatus(status)
+        }
+    }
+
+    static func read(_ key: Key) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    @discardableResult
+    static func delete(_ key: Key) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/Clearly/Sync/SyncAPI.swift
+++ b/Clearly/Sync/SyncAPI.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+struct SyncAPIUser: Codable, Equatable {
+    let id: String
+    let emailAddress: String?
+    let subscriptionStatus: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case emailAddress = "email_address"
+        case subscriptionStatus = "subscription_status"
+    }
+}
+
+struct SignInResponse: Codable {
+    let token: String
+    let user: SyncAPIUser
+}
+
+struct SyncAPIError: Error, LocalizedError {
+    let status: Int
+    let code: String?
+    let message: String?
+
+    var errorDescription: String? {
+        if let message { return message }
+        if let code { return "\(code) (HTTP \(status))" }
+        return "HTTP \(status)"
+    }
+}
+
+struct SyncAPI {
+    let baseURL: URL
+    var session: URLSession = .shared
+
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    static var defaultBaseURL: URL {
+        if let override = Bundle.main.object(forInfoDictionaryKey: "SyncAPIURL") as? String,
+           let url = URL(string: override) {
+            return url
+        }
+        return URL(string: "http://localhost:3000")!
+    }
+
+    // MARK: - Auth
+
+    func signUpEmail(email: String, password: String) async throws -> SignInResponse {
+        try await post("/auth/users", body: [
+            "user": ["email_address": email, "password": password]
+        ])
+    }
+
+    func signInEmail(email: String, password: String) async throws -> SignInResponse {
+        try await post("/auth/sessions", body: [
+            "session": ["email_address": email, "password": password]
+        ])
+    }
+
+    func signInApple(identityToken: String, nonce: String, email: String?, fullName: PersonNameComponents?) async throws -> SignInResponse {
+        var body: [String: Any] = [
+            "identity_token": identityToken,
+            "nonce": nonce,
+        ]
+        if let email { body["email"] = email }
+        if let fullName { body["full_name"] = PersonNameComponentsFormatter().string(from: fullName) }
+        return try await post("/auth/apple", body: body)
+    }
+
+    func me(token: String) async throws -> SyncAPIUser {
+        try await get("/api/v1/me", token: token)
+    }
+
+    func signOut(token: String) async throws {
+        _ = try await requestEmpty("DELETE", path: "/auth/sessions/current", token: token)
+    }
+
+    // MARK: - Transport
+
+    private func post<T: Decodable>(_ path: String, body: [String: Any], token: String? = nil) async throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: body)
+        let (respData, _) = try await request("POST", path: path, body: data, token: token)
+        return try decode(respData)
+    }
+
+    private func get<T: Decodable>(_ path: String, token: String?) async throws -> T {
+        let (data, _) = try await request("GET", path: path, body: nil, token: token)
+        return try decode(data)
+    }
+
+    @discardableResult
+    private func requestEmpty(_ method: String, path: String, token: String?) async throws -> HTTPURLResponse {
+        let (_, response) = try await request(method, path: path, body: nil, token: token)
+        return response
+    }
+
+    private func request(_ method: String, path: String, body: Data?, token: String?) async throws -> (Data, HTTPURLResponse) {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw URLError(.badURL)
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token { req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        if let body { req.httpBody = body }
+
+        let (data, response) = try await session.data(for: req)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        if !(200..<300).contains(http.statusCode) {
+            let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+            throw SyncAPIError(status: http.statusCode, code: decoded?["error"], message: decoded?["detail"])
+        }
+        return (data, http)
+    }
+
+    private func decode<T: Decodable>(_ data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        return try decoder.decode(T.self, from: data)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -59,6 +59,7 @@ targets:
       - package: Sparkle
       - package: KeyboardShortcuts
       - package: GRDB
+      - sdk: AuthenticationServices.framework
       - target: ClearlyQuickLook
         embed: true
       - target: ClearlyCLI


### PR DESCRIPTION
## Summary
- New Settings → **Account** tab with Sign in with Apple + email/password toggle.
- `AccountManager` (`@Observable`) tracks `currentUser` + `pendingAppleNonce`; `bootstrap()` reads Keychain and calls `/api/v1/me` on launch.
- `SyncAPI` is a thin URLSession client against the Rails backend (`/auth/apple`, `/auth/users`, `/auth/sessions`, `/auth/sessions/current`, `/api/v1/me`). Bearer = `Authorization: Bearer <Session.token>`.
- `KeychainStore` wraps Security.framework for the session token.
- Entitlement `com.apple.developer.applesignin` added to `Clearly.entitlements` and `Clearly-AppStore.entitlements`; `AuthenticationServices.framework` added to the Clearly target in `project.yml`.
- `ClearlyApp` injects `AccountManager.shared` into the Settings scene and kicks off `bootstrap()` from `init`.

Pairs with the Rails server work in [clearlymd/clearly#10](https://github.com/clearlymd/clearly/pull/10).

## Test plan
- [ ] `xcodegen generate && xcodebuild -scheme Clearly -configuration Debug build` — green
- [ ] Phase-0 regression: open an existing local vault, edit/save/search — still works
- [ ] Settings → Account → Sign in with Apple → system sheet → signed-in state shows "Signed in as …"
- [ ] Settings → Account → toggle "Create Account" → enter email + password → signed-in
- [ ] Settings → Account → Sign Out → form reappears; token gone from Keychain Access.app
- [ ] Quit (⌘Q), reopen, Settings → Account → **persists as signed-in without prompting** (this is the most important check — `bootstrap()` is doing its job)
- [ ] Rails logs show `POST /auth/apple` 200 (no `AppleIdentityToken::Unverified`)

## Blockers (Josh-side)
- Enable Sign in with Apple capability on App IDs `com.sabotage.clearly` + `com.sabotage.clearly.dev` in the Apple Developer portal; regenerate provisioning profiles. Without this, the Debug build fails to code-sign; code itself is green (verified with `CODE_SIGNING_ALLOWED=NO`).