### PR TITLE
Fix rendering issue for xmark icon in the sidebar

### DIFF
--- a/Clearly/FileExplorerView.swift
+++ b/Clearly/FileExplorerView.swift
@@ -867,7 +867,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     let addBtn = NSButton(frame: .zero)
                     addBtn.bezelStyle = .inline
                     addBtn.isBordered = false
-                    let btnConfig = NSImage.SymbolConfiguration(pointSize: 11, weight: .bold)
+                    let btnConfig = NSImage.SymbolConfiguration(pointSize: 10, weight: .bold)
                     addBtn.image = NSImage(systemSymbolName: "folder.badge.plus", accessibilityDescription: "Add Location")?.withSymbolConfiguration(btnConfig)
                     addBtn.imagePosition = .imageOnly
                     addBtn.toolTip = "Add Location (⌘O)"
@@ -887,7 +887,7 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     let clearBtn = NSButton(frame: .zero)
                     clearBtn.bezelStyle = .inline
                     clearBtn.isBordered = false
-                    let clearConfig = NSImage.SymbolConfiguration(pointSize: 11, weight: .bold)
+                    let clearConfig = NSImage.SymbolConfiguration(pointSize: 10, weight: .bold)
                     clearBtn.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Clear Recents")?.withSymbolConfiguration(clearConfig)
                     clearBtn.imagePosition = .imageOnly
                     clearBtn.toolTip = "Clear Recents"
@@ -902,8 +902,8 @@ struct FileExplorerOutlineView: NSViewRepresentable {
                     NSLayoutConstraint.activate([
                         clearBtn.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -7),
                         clearBtn.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-                        clearBtn.widthAnchor.constraint(equalToConstant: 10),
-                        clearBtn.heightAnchor.constraint(equalToConstant: 10),
+                        clearBtn.widthAnchor.constraint(equalToConstant: 14),
+                        clearBtn.heightAnchor.constraint(equalToConstant: 14),
                     ])
                 }
 


### PR DESCRIPTION
Set `pointSize` to an even number to fix a rendering issue on 1x external monitors. This is especially a problem for symmetric icons like the `xmark` icon. I've also adjusted the frame constraints to 14 points to make the hit area the same with the "Add location" icon.

Before:
<img width="189" height="72" alt="CleanShot 2026-04-20 at 11 02 21" src="https://github.com/user-attachments/assets/f9aa8193-15b0-4d88-a06b-9a345de06864" />

After:
<img width="192" height="70" alt="CleanShot 2026-04-20 at 11 02 44" src="https://github.com/user-attachments/assets/8c6b2e26-f185-4545-9c30-b803298d80c5" />