### PR TITLE
Mobile Phase 2: iOS target scaffolding + placeholder app

### DIFF
--- a/Clearly/iOS/Clearly-iOS.entitlements
+++ b/Clearly/iOS/Clearly-iOS.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Clearly/iOS/ClearlyApp_iOS.swift
+++ b/Clearly/iOS/ClearlyApp_iOS.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import ClearlyCore
+
+@main
+struct ClearlyApp_iOS: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Clearly — iOS scaffolding")
+        }
+    }
+}

--- a/Clearly/iOS/Info-iOS.plist
+++ b/Clearly/iOS/Info-iOS.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Clearly</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -66,6 +66,7 @@ public final class VaultIndex: @unchecked Sendable {
         try migrate()
     }
 
+    #if os(macOS)
     /// Init with explicit bundle identifier — used by ClearlyMCP to open the main app's index
     public init(locationURL: URL, bundleIdentifier: String) throws {
         self.rootURL = locationURL
@@ -80,6 +81,7 @@ public final class VaultIndex: @unchecked Sendable {
 
         try migrate()
     }
+    #endif
 
     // MARK: Schema
 
@@ -818,6 +820,7 @@ public final class VaultIndex: @unchecked Sendable {
         return dir.appendingPathComponent("\(appName)/indexes")
     }
 
+    #if os(macOS)
     /// Index directory for a specific bundle identifier — resolves sandbox container path for non-sandboxed callers (ClearlyMCP CLI)
     private static func indexDirectory(bundleIdentifier: String) -> URL {
         // Try sandbox container path first (where the sandboxed app stores its index)
@@ -831,6 +834,7 @@ public final class VaultIndex: @unchecked Sendable {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return dir.appendingPathComponent("\(bundleIdentifier)/indexes")
     }
+    #endif
 
     private static func pathHash(_ path: String) -> String {
         let data = Data(path.utf8)

--- a/docs/mobile/PROGRESS.md
+++ b/docs/mobile/PROGRESS.md
@@ -1,6 +1,6 @@
 # Mobile Progress
 
-## Status: Phase 1 - Complete
+## Status: Phase 2 - Complete
 
 ## Quick Reference
 - Research: `docs/mobile/RESEARCH.md`
@@ -38,13 +38,31 @@
 ---
 
 ### Phase 2: iOS target scaffolding + placeholder app
-**Status:** Not Started
+**Status:** Complete (2026-04-20)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `Clearly-iOS` target to `project.yml` (platform iOS, deployment 17.0, `TARGETED_DEVICE_FAMILY: "1,2"`, `SUPPORTS_MACCATALYST: NO`)
+- [x] Bundle ID mirrors Mac: `com.sabotage.clearly` (Release) / `com.sabotage.clearly.dev` (Debug); Universal Purchase pair with MAS via shared Release ID
+- [x] Added `iOS: "17.0"` to top-level `options.deploymentTarget`
+- [x] Added `excludes: ["iOS/**"]` to Mac `Clearly` target's `- path: Clearly` source entry so `Clearly/iOS/**` only compiles into the iOS target
+- [x] New `Clearly/iOS/ClearlyApp_iOS.swift` — minimal `@main App` + `WindowGroup` with `Text("Clearly — iOS scaffolding")`; imports `ClearlyCore` to verify package reachability
+- [x] New `Clearly/iOS/Info-iOS.plist` — minimal iOS plist (display name, launch screen, orientations, `ITSAppUsesNonExemptEncryption = false`)
+- [x] New `Clearly/iOS/Clearly-iOS.entitlements` — empty plist shell (iCloud keys added in Phase 3)
+- [x] Gated Mac-only code in `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift` behind `#if os(macOS)` — `init(locationURL:bundleIdentifier:)` and private `indexDirectory(bundleIdentifier:)` use `FileManager.homeDirectoryForCurrentUser` (unavailable on iOS). Both are only called from the Mac-only CLI; no iOS caller exists.
+- [x] `xcodegen generate` clean
+- [x] `xcodebuild -scheme Clearly -configuration Debug build` — green (Mac unchanged)
+- [x] `xcodebuild -scheme ClearlyQuickLook -configuration Debug build` — green
+- [x] `xcodebuild -scheme ClearlyCLI -configuration Debug build` — green
+- [x] `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 pass
+- [x] `xcodebuild -scheme Clearly-iOS -sdk iphonesimulator -configuration Debug -arch arm64 build` — green
+- [x] `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build` — green
+- [x] Installed resulting `.app` via `xcrun simctl install` on a booted iPhone 17 simulator (iOS 26.4 runtime) + `xcrun simctl launch com.sabotage.clearly.dev` — placeholder "Clearly — iOS scaffolding" renders correctly
 
 #### Decisions Made
-- (none yet)
+- **Source exclusion instead of `#if os(macOS)` on `Clearly/ClearlyApp.swift`.** The implementation plan mentioned gating `ClearlyApp.swift` behind `#if os(macOS)`, but `excludes: ["iOS/**"]` + the iOS target only sourcing `Clearly/iOS/` already means `ClearlyApp.swift` never compiles on iOS. Adding `#if` would be redundant noise. Consistent with the plan's overarching "not `#if` sprinkled through every file" rule.
+- **No asset catalog / app icon this phase.** Dropped `ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon` from the iOS target settings. Proper icon ships with App Store polish in Phase 13.
+- **`ClearlyCore` iOS surface fix deferred to macro-level.** Discovered during the iOS compile that `FileManager.homeDirectoryForCurrentUser` in `VaultIndex.swift` was iOS-unavailable. Gated with `#if os(macOS)` rather than reworking the sandbox-container-path lookup (which is meaningless on iOS anyway — iOS apps always run in their own sandbox container). If a future iOS code path ever needs to construct index directories for foreign bundle identifiers, it'll need a different implementation.
+- **Simulator destination builds work normally.** `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build` resolves correctly in this workspace. `simctl install/launch` remains useful for explicit post-build launch verification, but it's not a workaround for a broken destination resolver.
 
 #### Blockers
 - (none)
@@ -213,6 +231,7 @@
 - Distribution model locked in: same bundle ID `com.sabotage.clearly` across direct / MAS / iOS; Universal Purchase between MAS + iOS; direct-build participates in iCloud sync
 - Progress tracking set up
 - **Phase 1 executed and verified.** 20 Swift files relocated into `Packages/ClearlyCore`; all four Mac schemes build clean; all 23 `ClearlyCLIIntegrationTests` pass. Mac behavior unchanged — no functional changes, no UI changes.
+- **Phase 2 executed and verified.** `Clearly-iOS` target added to `project.yml`; three new files under `Clearly/iOS/` (app entry, Info plist, entitlements shell); Mac target picks up `excludes: ["iOS/**"]`. Fixed one Mac-only API leak in `ClearlyCore/Vault/VaultIndex.swift` (`homeDirectoryForCurrentUser`, gated behind `#if os(macOS)`). All Mac schemes still green; 23/23 CLI integration tests still pass; iOS builds succeed both via `-sdk iphonesimulator` and via a concrete simulator destination (`platform=iOS Simulator,name=iPhone 17,OS=26.4`); placeholder view renders on iPhone 17 simulator (iOS 26.4 runtime).
 
 ---
 
@@ -222,6 +241,10 @@
 - **New:** `Packages/ClearlyCore/Package.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Platform/Platform.swift`
 - **Moved (20 files, history preserved via `git mv`):** `Shared/{MarkdownRenderer,PreviewCSS,MermaidSupport,TableSupport,SyntaxHighlightSupport,EmojiShortcodes,LocalImageSupport,FrontmatterSupport}.swift` → `Packages/ClearlyCore/Sources/ClearlyCore/Rendering/`; `Clearly/{VaultIndex,FileParser,FileNode,IgnoreRules,BookmarkedLocation}.swift` → `Vault/`; `Clearly/{OpenDocument,OutlineState,FindState,JumpToLineState,BacklinksState,PositionSync}.swift` → `State/`; `Clearly/DiagnosticLog.swift` → `Diagnostics/`
 - **Modified:** `project.yml` (all four targets re-wired); 52 consumer files across `Clearly/`, `ClearlyQuickLook/`, `ClearlyCLI/`, `ClearlyCLIIntegrationTests/` got `import ClearlyCore` + types inside moved files made public where accessed cross-module.
+
+### Phase 2 (2026-04-20)
+- **New:** `Clearly/iOS/ClearlyApp_iOS.swift`, `Clearly/iOS/Info-iOS.plist`, `Clearly/iOS/Clearly-iOS.entitlements`
+- **Modified:** `project.yml` (added `Clearly-iOS` target block; added `iOS: "17.0"` to `options.deploymentTarget`; added `excludes: ["iOS/**"]` to Mac `Clearly` source path), `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift` (wrapped `init(locationURL:bundleIdentifier:)` and `indexDirectory(bundleIdentifier:)` in `#if os(macOS)`)
 
 ## Architectural Decisions
 
@@ -236,6 +259,9 @@ Research recommended single-document-per-scene on iPad to match `DocumentGroup` 
 
 ### 2026-04-20 — 13 phases rather than 8
 First draft had 8 phases but several were 2–3 days of work each. Split to 13 phases sized so each can be completed and verified on-device in one focused session (half-day to full-day).
+
+### 2026-04-20 — iOS simulator verification path
+Preferred verification path for the iOS target is a normal destination-based build: `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build`. `xcrun simctl install` + `xcrun simctl launch` remain useful when we want an explicit post-build launch check, but they are not required to work around destination resolution in this workspace.
 
 ## Lessons Learned
 (What worked, what didn't, what to do differently)

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.sabotage
   deploymentTarget:
     macOS: "14.0"
+    iOS: "17.0"
   xcodeVersion: "16.0"
   createIntermediateGroups: true
   fileTypes:
@@ -37,6 +38,8 @@ targets:
     platform: macOS
     sources:
       - path: Clearly
+        excludes:
+          - "iOS/**"
       - path: Shared/Resources/mermaid.min.js
         buildPhase: resources
       - path: Shared/Resources/katex.min.js
@@ -91,6 +94,30 @@ targets:
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
+
+  Clearly-iOS:
+    type: application
+    platform: iOS
+    sources:
+      - path: Clearly/iOS
+    dependencies:
+      - package: ClearlyCore
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly
+        PRODUCT_NAME: Clearly
+        MARKETING_VERSION: "2.3.0"
+        CURRENT_PROJECT_VERSION: "1"
+        SWIFT_VERSION: "5.9"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SUPPORTS_MACCATALYST: NO
+        CODE_SIGN_ENTITLEMENTS: Clearly/iOS/Clearly-iOS.entitlements
+        INFOPLIST_FILE: Clearly/iOS/Info-iOS.plist
+        GENERATE_INFOPLIST_FILE: NO
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev
+          PRODUCT_NAME: "Clearly Dev"
 
   ClearlyQuickLook:
     type: app-extension


### PR DESCRIPTION
## Summary

Lands a native `Clearly-iOS` application target alongside the existing Mac targets. Universal Purchase via shared `com.sabotage.clearly` bundle ID (Debug gets `.dev` suffix, matching the Mac convention). iOS 17 minimum, iPhone + iPad, no iCloud plumbing yet (Phase 3).

The new iOS app builds clean, launches on a simulator, and shows a `Text("Clearly — iOS scaffolding")` placeholder. Mac behavior is unchanged.

## What changed

- New `Clearly-iOS` target in `project.yml`; `iOS: "17.0"` added to `options.deploymentTarget`
- Mac `Clearly` target now excludes `Clearly/iOS/**` from its source path
- New `Clearly/iOS/{ClearlyApp_iOS.swift, Info-iOS.plist, Clearly-iOS.entitlements}` — minimal `@main App` + `WindowGroup`, minimum-viable Info.plist, empty entitlements shell (iCloud keys land in Phase 3)
- `VaultIndex.init(locationURL:bundleIdentifier:)` + private `indexDirectory(bundleIdentifier:)` wrapped in `#if os(macOS)` — the only iOS-unavailable-API leak surfaced during first iOS compile; both are called only from the Mac-only CLI
- `docs/mobile/PROGRESS.md` marked Phase 2 complete

## Test plan

- [x] `xcodebuild -scheme Clearly -configuration Debug build` — green
- [x] `xcodebuild -scheme ClearlyQuickLook -configuration Debug build` — green
- [x] `xcodebuild -scheme ClearlyCLI -configuration Debug build` — green
- [x] `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 pass
- [x] `xcodebuild -scheme Clearly-iOS -sdk iphonesimulator -configuration Debug -arch arm64 build` — green
- [x] `simctl install` + `simctl launch` on iPhone 17 simulator — placeholder renders