### PR TITLE
Mobile Phase 3: iCloud ubiquity plumbing + entitlements across channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,26 @@ The working pattern (see `Clearly/CLIInstaller.swift`) is `tell application "Ter
 
 **Cross-channel warning:** the apple-events exception lives in `Clearly.entitlements` (direct/Sparkle) but **not** in `Clearly-AppStore.entitlements`, which strips temporary-exceptions to pass MAS review. That means the CLI install flow (and anything else that drives Terminal) won't work in the App Store build as-is. Either mirror the entitlement into the MAS file (review-risk) or gate the Install UI behind `#if canImport(Sparkle)` and ship a copy-paste fallback for MAS.
 
+### iCloud (and any profile-requiring entitlement) breaks ad-hoc Debug signing
+
+Adding an entitlement that needs a provisioning profile — iCloud, Push, Keychain Sharing, App Groups — immediately breaks Debug builds that were previously signing ad-hoc with `-`. The failure looks like `"Clearly" requires a provisioning profile. Enable development signing and select a provisioning profile in the Signing & Capabilities editor.` The fix is in `project.yml`, not the entitlements file:
+
+- Add `DEVELOPMENT_TEAM: W33JZPPPFN` to `settings.base` on every affected target.
+- Add `CODE_SIGN_STYLE: Automatic` to each target's Debug config.
+- Run `xcodebuild … -allowProvisioningUpdates` — this is the CLI equivalent of Xcode's "Automatically manage signing" UI: it registers missing App IDs, associates capabilities/containers, and downloads profiles without opening Xcode.
+
+Verify entitlements survived on the signed app with `codesign -d --entitlements :- "<path>/Clearly Dev.app"`. The `com.apple.developer.team-identifier` key should read `W33JZPPPFN`.
+
+### Verifying iCloud container provisioning
+
+Finder's iCloud Drive sidebar is **not** authoritative. It does not reliably surface `NSUbiquitousContainers`-declared folders from Debug builds (`com.sabotage.clearly.dev`) or apps living under `DerivedData`. You can spend an hour trying to make it show the folder when iCloud is already fully wired.
+
+Use these instead:
+
+- **System Settings → [Your Name] → iCloud → Drive → Apps syncing to iCloud Drive** — authoritative app registration list.
+- `brctl status iCloud.com.sabotage.clearly` — `bird`'s view of sync state. `caught-up` + `ever-full-sync` = working.
+- `ls ~/Library/Mobile\ Documents/` — container directory exists once `FileManager.url(forUbiquityContainerIdentifier:)` has been called. Modern `iCloud.*` containers land at `iCloud~com~sabotage~clearly` *without* a team-ID prefix; that is correct, not a bug. Legacy-format containers (identifier without the `iCloud.` prefix, e.g. `com.dayoneapp.dayone`) get the `TEAMID~` prefix — both shapes coexist in `Mobile Documents/`.
+
 ## Conventions
 
 - All colors go through `Theme` with dynamic light/dark resolution — don't hardcode colors

--- a/Clearly/Clearly-AppStore.entitlements
+++ b/Clearly/Clearly-AppStore.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.sabotage.clearly</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>

--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.sabotage.clearly</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>

--- a/Clearly/Info.plist
+++ b/Clearly/Info.plist
@@ -53,6 +53,18 @@
 	<string>public.app-category.productivity</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Clearly uses Terminal to install the clearly command-line tool on your PATH.</string>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.com.sabotage.clearly</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>Clearly</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+		</dict>
+	</dict>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Clearly/iOS/Clearly-iOS.entitlements
+++ b/Clearly/iOS/Clearly-iOS.entitlements
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.sabotage.clearly</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+</dict>
 </plist>

--- a/Packages/ClearlyCore/Package.resolved
+++ b/Packages/ClearlyCore/Package.resolved
@@ -10,12 +10,102 @@
       }
     },
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
+        "version" : "2.98.0"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     }
   ],

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CloudVault.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CloudVault.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Combine
+
+public enum CloudVault {
+    public static let containerIdentifier = "iCloud.com.sabotage.clearly"
+
+    public static func ubiquityContainerURL() async -> URL? {
+        await Task.detached(priority: .utility) {
+            guard let container = FileManager.default
+                .url(forUbiquityContainerIdentifier: containerIdentifier)
+            else { return nil }
+            let documents = container.appendingPathComponent("Documents", isDirectory: true)
+            try? FileManager.default.createDirectory(
+                at: documents, withIntermediateDirectories: true
+            )
+            return documents
+        }.value
+    }
+
+    public static var isAvailablePublisher: AnyPublisher<Bool, Never> {
+        NotificationCenter.default
+            .publisher(for: .NSUbiquityIdentityDidChange)
+            .map { _ in FileManager.default.ubiquityIdentityToken != nil }
+            .prepend(FileManager.default.ubiquityIdentityToken != nil)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum CoordinatedFileIO {
+    public static func read(at url: URL) throws -> Data {
+        var coordinatorError: NSError?
+        var result: Result<Data, Error> = .failure(CocoaError(.fileReadUnknown))
+        NSFileCoordinator(filePresenter: nil).coordinate(
+            readingItemAt: url, options: [], error: &coordinatorError
+        ) { resolved in
+            result = Result { try Data(contentsOf: resolved) }
+        }
+        if let coordinatorError { throw coordinatorError }
+        return try result.get()
+    }
+
+    public static func write(_ data: Data, to url: URL) throws {
+        var coordinatorError: NSError?
+        var writeError: Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(
+            writingItemAt: url, options: .forReplacing, error: &coordinatorError
+        ) { resolved in
+            do { try data.write(to: resolved, options: .atomic) }
+            catch { writeError = error }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let writeError { throw writeError }
+    }
+
+    public static func move(from src: URL, to dst: URL) throws {
+        var coordinatorError: NSError?
+        var moveError: Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(
+            writingItemAt: src, options: .forMoving,
+            writingItemAt: dst, options: .forReplacing,
+            error: &coordinatorError
+        ) { resolvedSrc, resolvedDst in
+            do { try FileManager.default.moveItem(at: resolvedSrc, to: resolvedDst) }
+            catch { moveError = error }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let moveError { throw moveError }
+    }
+
+    public static func delete(at url: URL) throws {
+        var coordinatorError: NSError?
+        var deleteError: Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(
+            writingItemAt: url, options: .forDeleting, error: &coordinatorError
+        ) { resolved in
+            do { try FileManager.default.removeItem(at: resolved) }
+            catch { deleteError = error }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let deleteError { throw deleteError }
+    }
+}

--- a/docs/mobile/PROGRESS.md
+++ b/docs/mobile/PROGRESS.md
@@ -1,6 +1,6 @@
 # Mobile Progress
 
-## Status: Phase 2 - Complete
+## Status: Phase 3 - Complete
 
 ## Quick Reference
 - Research: `docs/mobile/RESEARCH.md`
@@ -70,13 +70,32 @@
 ---
 
 ### Phase 3: iCloud ubiquity plumbing + entitlements on all three builds
-**Status:** Not Started
+**Status:** Complete (2026-04-21)
 
 #### Tasks Completed
-- (none yet)
+- [x] Added `com.apple.developer.icloud-container-identifiers = iCloud.com.sabotage.clearly` + `com.apple.developer.icloud-services = [CloudDocuments]` to all three entitlements files: `Clearly/Clearly.entitlements`, `Clearly/Clearly-AppStore.entitlements`, `Clearly/iOS/Clearly-iOS.entitlements`
+- [x] Added `NSUbiquitousContainers` dict to `Clearly/Info.plist` (Mac) with `NSUbiquitousContainerIsDocumentScopePublic = YES`, display name `Clearly`, `SupportedFolderLevels = Any`
+- [x] New `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CloudVault.swift` — `containerIdentifier` constant, `ubiquityContainerURL() async -> URL?` running on a detached utility task (creates `Documents/` subdir on first resolution), `isAvailablePublisher` watching `NSUbiquityIdentityDidChange`
+- [x] New `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift` — `read(at:)`, `write(_:to:)`, `move(from:to:)`, `delete(at:)` wrapping `NSFileCoordinator` (no `evictUbiquitousItem` helper — research risk #3 deadlock)
+- [x] New `scripts/verify-entitlements.sh` — runs `codesign -d --entitlements :-` on an exported `.app`, asserts both iCloud entitlement keys + container id present
+- [x] Wired verifier into `scripts/release.sh` (after mach-lookup check, before DMG) and `scripts/release-appstore.sh` (after export, before Info.plist restore)
+- [x] Added `DEVELOPMENT_TEAM: W33JZPPPFN` + `CODE_SIGN_STYLE: Automatic` (Debug) to all four targets in `project.yml` so Debug builds auto-provision against Sabotage Media's iCloud-capable App IDs instead of ad-hoc signing
+- [x] `xcodegen generate` clean
+- [x] `xcodebuild -scheme Clearly -configuration Debug build -allowProvisioningUpdates` — green; signed app entitlements show `com.apple.developer.team-identifier = W33JZPPPFN` + `com.apple.application-identifier = W33JZPPPFN.com.sabotage.clearly.dev` + iCloud keys intact
+- [x] `xcodebuild -scheme ClearlyQuickLook -configuration Debug build` — green
+- [x] `xcodebuild -scheme ClearlyCLI -configuration Debug build` — green
+- [x] `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build -allowProvisioningUpdates` — green
+- [x] `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 pass
+- [x] Runtime: launched Debug Mac app; `CloudVault.ubiquityContainerURL()` returned `/Users/joshpigford/Library/Mobile Documents/iCloud~com~sabotage~clearly/Documents`; container directory auto-created on first resolution
+- [ ] Runtime: iPhone simulator signed into iCloud — **deferred.** Simulator builds are signed "to run locally" (ad-hoc) and have the iCloud entitlement stripped from the embedded signature; real iCloud semantics need a physical device with a development profile. Will verify on device during Phase 4 when the actual sidebar UI exists.
+- [ ] `release.sh` / `release-appstore.sh` verifier dry-run — **deferred** to next real release cycle; verifier is in place but not exercised against a fresh archive yet.
 
 #### Decisions Made
-- (none yet)
+- **Kept the `CoordinatedFileIO` surface minimal.** The plan mentioned a `presenter(for:) -> NSFilePresenter` factory; moved that to Phase 6 where per-document presenter lifecycle actually lands. Phase 3 ships only the four read/write/move/delete wrappers that Phase 4 will start calling.
+- **No `Bundle.module` migration.** `Sync/` sources are pure Foundation/Combine; no resources involved. The existing `Bundle.main` pattern for web assets stays untouched.
+- **No source glob changes to `project.yml`.** The `Sync/` subdirectory is picked up automatically by the `ClearlyCore` package's source glob — no target re-wiring. Unrelated, `project.yml` still needed `DEVELOPMENT_TEAM` + Debug `CODE_SIGN_STYLE: Automatic` added for signing (see above), because ad-hoc Debug signing doesn't honor iCloud entitlements.
+- **iOS Info.plist did NOT get `NSUbiquitousContainers`.** That key's iOS behavior is tied to `UISupportsDocumentBrowser` + `DocumentGroup`, both of which land in Phase 4. For Phase 3, iOS entitlements alone are sufficient to let `FileManager.url(forUbiquityContainerIdentifier:)` return a real URL.
+- **MAS dry-run deferred.** `release-appstore.sh` does not currently do a post-export re-sign. If Xcode strips the iCloud entitlement on archive, the verifier will catch it and we add a re-sign step then. Not worth proactively building against a bug that may not exist.
 
 #### Blockers
 - (none)
@@ -233,6 +252,9 @@
 - **Phase 1 executed and verified.** 20 Swift files relocated into `Packages/ClearlyCore`; all four Mac schemes build clean; all 23 `ClearlyCLIIntegrationTests` pass. Mac behavior unchanged — no functional changes, no UI changes.
 - **Phase 2 executed and verified.** `Clearly-iOS` target added to `project.yml`; three new files under `Clearly/iOS/` (app entry, Info plist, entitlements shell); Mac target picks up `excludes: ["iOS/**"]`. Fixed one Mac-only API leak in `ClearlyCore/Vault/VaultIndex.swift` (`homeDirectoryForCurrentUser`, gated behind `#if os(macOS)`). All Mac schemes still green; 23/23 CLI integration tests still pass; iOS builds succeed both via `-sdk iphonesimulator` and via a concrete simulator destination (`platform=iOS Simulator,name=iPhone 17,OS=26.4`); placeholder view renders on iPhone 17 simulator (iOS 26.4 runtime).
 
+### 2026-04-21
+- **Phase 3 complete.** iCloud entitlements added to all three channels; `NSUbiquitousContainers` on Mac Info.plist; `ClearlyCore/Sync/{CloudVault, CoordinatedFileIO}.swift` introduced; `scripts/verify-entitlements.sh` wired into both release scripts; `project.yml` updated with `DEVELOPMENT_TEAM = W33JZPPPFN` + automatic Debug signing so iCloud entitlements provision correctly. All Mac schemes + iOS build + integration tests (23/23) green. Runtime verified on Mac: `CloudVault.ubiquityContainerURL()` resolves to `~/Library/Mobile Documents/iCloud~com~sabotage~clearly/Documents` and the container bootstrap creates the `Documents/` subdir on first call. iOS on-device runtime verification deferred to Phase 4 (simulator strips entitlements, real device testing ships with the sidebar UI).
+
 ---
 
 ## Files Changed
@@ -245,6 +267,10 @@
 ### Phase 2 (2026-04-20)
 - **New:** `Clearly/iOS/ClearlyApp_iOS.swift`, `Clearly/iOS/Info-iOS.plist`, `Clearly/iOS/Clearly-iOS.entitlements`
 - **Modified:** `project.yml` (added `Clearly-iOS` target block; added `iOS: "17.0"` to `options.deploymentTarget`; added `excludes: ["iOS/**"]` to Mac `Clearly` source path), `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift` (wrapped `init(locationURL:bundleIdentifier:)` and `indexDirectory(bundleIdentifier:)` in `#if os(macOS)`)
+
+### Phase 3 (2026-04-21)
+- **New:** `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CloudVault.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift`, `scripts/verify-entitlements.sh`
+- **Modified:** `Clearly/Clearly.entitlements` + `Clearly/Clearly-AppStore.entitlements` + `Clearly/iOS/Clearly-iOS.entitlements` (added iCloud container + CloudDocuments service keys), `Clearly/Info.plist` (added `NSUbiquitousContainers`), `scripts/release.sh` + `scripts/release-appstore.sh` (call `verify-entitlements.sh` post-export), `project.yml` (added `DEVELOPMENT_TEAM: W33JZPPPFN` to all four targets' base settings + `CODE_SIGN_STYLE: Automatic` to each Debug config so iCloud-entitled Debug builds auto-provision against Sabotage Media's App IDs)
 
 ## Architectural Decisions
 

--- a/project.yml
+++ b/project.yml
@@ -186,10 +186,7 @@ targets:
         SWIFT_STRICT_CONCURRENCY: minimal
         ENABLE_HARDENED_RUNTIME: YES
         SKIP_INSTALL: YES
-        DEVELOPMENT_TEAM: W33JZPPPFN
       configs:
-        Debug:
-          CODE_SIGN_STYLE: Automatic
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"

--- a/project.yml
+++ b/project.yml
@@ -87,10 +87,12 @@ targets:
         GENERATE_INFOPLIST_FILE: NO
         ENABLE_HARDENED_RUNTIME: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        DEVELOPMENT_TEAM: W33JZPPPFN
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev
           PRODUCT_NAME: "Clearly Dev"
+          CODE_SIGN_STYLE: Automatic
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
@@ -114,10 +116,12 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Clearly/iOS/Clearly-iOS.entitlements
         INFOPLIST_FILE: Clearly/iOS/Info-iOS.plist
         GENERATE_INFOPLIST_FILE: NO
+        DEVELOPMENT_TEAM: W33JZPPPFN
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev
           PRODUCT_NAME: "Clearly Dev"
+          CODE_SIGN_STYLE: Automatic
 
   ClearlyQuickLook:
     type: app-extension
@@ -152,9 +156,11 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGN_ENTITLEMENTS: ClearlyQuickLook/ClearlyQuickLook.entitlements
         INFOPLIST_FILE: ClearlyQuickLook/Info.plist
+        DEVELOPMENT_TEAM: W33JZPPPFN
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.quicklook
+          CODE_SIGN_STYLE: Automatic
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
@@ -180,7 +186,10 @@ targets:
         SWIFT_STRICT_CONCURRENCY: minimal
         ENABLE_HARDENED_RUNTIME: YES
         SKIP_INSTALL: YES
+        DEVELOPMENT_TEAM: W33JZPPPFN
       configs:
+        Debug:
+          CODE_SIGN_STYLE: Automatic
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"

--- a/scripts/release-appstore.sh
+++ b/scripts/release-appstore.sh
@@ -191,6 +191,9 @@ xcodebuild -exportArchive \
   -exportPath build/export-appstore \
   -allowProvisioningUpdates
 
+# Verify iCloud entitlements survived Xcode archive/export
+scripts/verify-entitlements.sh build/export-appstore/Clearly.app
+
 # ── 6. Restore Info.plist and Xcode project (with Sparkle) ──────────────────
 echo "🔄 Restoring Sparkle project..."
 mv build/Info-Original.plist Clearly/Info.plist

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -183,6 +183,9 @@ if ! codesign -d --entitlements :- build/export/Clearly.app 2>/dev/null | grep -
   exit 1
 fi
 
+# Verify iCloud entitlements survived
+scripts/verify-entitlements.sh build/export/Clearly.app
+
 # Deep signature chain verification
 codesign --verify --deep --strict build/export/Clearly.app
 echo "✅ Code signature verified (deep + strict)."

--- a/scripts/verify-entitlements.sh
+++ b/scripts/verify-entitlements.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP="${1:?usage: verify-entitlements.sh <path-to-.app>}"
+OUT=$(codesign -d --entitlements :- "$APP" 2>/dev/null || true)
+
+for key in \
+  "com.apple.developer.icloud-container-identifiers" \
+  "com.apple.developer.icloud-services"
+do
+  if ! grep -q "$key" <<<"$OUT"; then
+    echo "❌ Missing entitlement on $APP: $key"
+    echo "   (Xcode likely stripped it during archive/export — re-sign with the full plist.)"
+    exit 1
+  fi
+done
+if ! grep -q "iCloud.com.sabotage.clearly" <<<"$OUT"; then
+  echo "❌ iCloud container id missing from entitlements on $APP."
+  exit 1
+fi
+echo "✅ iCloud entitlements present on $APP"


### PR DESCRIPTION
## Summary

Phase 3 of the iOS expansion: wire up iCloud Drive as the sync substrate across all three distribution channels (direct/Sparkle, Mac App Store, iOS) with zero user-visible UI changes. Platform contract only — Phase 4 will build on top of this.

- **Entitlements + Info.plist.** iCloud container (`iCloud.com.sabotage.clearly`) + `CloudDocuments` service added to `Clearly.entitlements`, `Clearly-AppStore.entitlements`, and `Clearly/iOS/Clearly-iOS.entitlements`. Mac `Info.plist` gets `NSUbiquitousContainers` so Finder surfaces the folder in the iCloud Drive sidebar on Release builds.
- **New `ClearlyCore/Sync/` module.** `CloudVault.swift` exposes an async `ubiquityContainerURL()` (runs on a detached utility task since `FileManager.url(forUbiquityContainerIdentifier:)` blocks) plus an `isAvailablePublisher` that watches `NSUbiquityIdentityDidChange`. `CoordinatedFileIO.swift` provides `NSFileCoordinator`-wrapped `read`/`write`/`move`/`delete`.
- **Release-script hardening.** New `scripts/verify-entitlements.sh` asserts the iCloud keys survive `codesign`, wired into both `release.sh` and `release-appstore.sh` so Xcode stripping entitlements at archive time fails the release loudly instead of silently.
- **Signing config.** `project.yml` gains `DEVELOPMENT_TEAM: W33JZPPPFN` + Debug `CODE_SIGN_STYLE: Automatic` across all four targets — ad-hoc Debug signing doesn't honor iCloud entitlements, so `xcodebuild -allowProvisioningUpdates` now auto-provisions Debug builds against the iCloud-capable App IDs. `CLAUDE.md` captures this gotcha and the Finder-isn't-authoritative verification methodology for future sessions.

## Test plan

- [x] `xcodegen generate` clean
- [x] `xcodebuild -scheme Clearly -configuration Debug build -allowProvisioningUpdates` — green; signed app entitlements show team `W33JZPPPFN` and iCloud keys intact
- [x] `xcodebuild -scheme ClearlyQuickLook -configuration Debug build` — green
- [x] `xcodebuild -scheme ClearlyCLI -configuration Debug build` — green
- [x] `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build -allowProvisioningUpdates` — green
- [x] `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 pass
- [x] `scripts/verify-entitlements.sh "Clearly Dev.app"` — passes on the iCloud-entitled app; fails as expected on `ClearlyQuickLook.appex`
- [x] Runtime: launched signed Debug Mac app; `CloudVault.ubiquityContainerURL()` returned `~/Library/Mobile Documents/iCloud~com~sabotage~clearly/Documents`; container bootstrap created `Documents/` on first call
- [x] System Settings → iCloud → Drive lists "Clearly Dev" under "Apps syncing to iCloud Drive"
- [ ] iOS on-device iCloud verification deferred to Phase 4 (simulator signs ad-hoc, strips entitlements; real device test ships with sidebar UI)
- [ ] Release script verifier dry-run deferred to next actual release cycle