### PR TITLE
Mobile Phase 4: read-only iOS vault browsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,10 @@ Use these instead:
 - `brctl status iCloud.com.sabotage.clearly` — `bird`'s view of sync state. `caught-up` + `ever-full-sync` = working.
 - `ls ~/Library/Mobile\ Documents/` — container directory exists once `FileManager.url(forUbiquityContainerIdentifier:)` has been called. Modern `iCloud.*` containers land at `iCloud~com~sabotage~clearly` *without* a team-ID prefix; that is correct, not a bug. Legacy-format containers (identifier without the `iCloud.` prefix, e.g. `com.dayoneapp.dayone`) get the `TEAMID~` prefix — both shapes coexist in `Mobile Documents/`.
 
+### iOS scene architecture — `WindowGroup`, not `DocumentGroup`
+
+`Clearly/iOS/ClearlyApp_iOS.swift` roots the app in a `WindowGroup` hosting `SidebarView_iOS`, mirroring how the Mac app uses `Window` + `WorkspaceManager` instead of `DocumentGroup`. Don't "fix" this back to `DocumentGroup` — its one-document-per-scene model is incompatible with the custom vault-folder sidebar (first screen needs to show a list of a user-picked folder's `.md` files, not the system document browser). `MarkdownDocument` is still a `FileDocument` so Phase 5's editor can bind to it, but no scene instantiates `DocumentGroup`. If Files.app "open in Clearly" integration is needed later, add `DocumentGroup` as a *second* scene alongside `WindowGroup`, don't swap it in.
+
 ## Conventions
 
 - All colors go through `Theme` with dynamic light/dark resolution — don't hardcode colors

--- a/Clearly/MarkdownDocument.swift
+++ b/Clearly/MarkdownDocument.swift
@@ -1,8 +1,35 @@
 import Foundation
+import SwiftUI
 import UniformTypeIdentifiers
 
 extension UTType {
     /// Resolve the markdown UTType from the system rather than using `importedAs`,
     /// which can return a different app's claimed type (e.g. app.markedit.md).
     static let daringFireballMarkdown: UTType = UTType("net.daringfireball.markdown") ?? UTType(filenameExtension: "md") ?? .plainText
+}
+
+/// File document wrapper for `.md` files. Used by iOS phases that consume `DocumentGroup` or
+/// `FileDocumentConfiguration` (Phase 5's editor binding, Phase 6's coordinated writes). The Mac
+/// app manages documents through `WorkspaceManager` and never instantiates this type.
+struct MarkdownDocument: FileDocument {
+    static var readableContentTypes: [UTType] = [.daringFireballMarkdown, .plainText]
+    static var writableContentTypes: [UTType] = [.daringFireballMarkdown]
+
+    var text: String
+
+    init(text: String = "") {
+        self.text = text
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.text = String(decoding: data, as: UTF8.self)
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        // Writes land in Phase 6; Phase 4 is deliberately read-only.
+        throw CocoaError(.featureUnsupported)
+    }
 }

--- a/Clearly/iOS/ClearlyApp_iOS.swift
+++ b/Clearly/iOS/ClearlyApp_iOS.swift
@@ -3,9 +3,15 @@ import ClearlyCore
 
 @main
 struct ClearlyApp_iOS: App {
+    @State private var vaultSession = VaultSession()
+
     var body: some Scene {
         WindowGroup {
-            Text("Clearly — iOS scaffolding")
+            SidebarView_iOS()
+                .environment(vaultSession)
+                .task {
+                    await vaultSession.restoreFromPersistence()
+                }
         }
     }
 }

--- a/Clearly/iOS/Info-iOS.plist
+++ b/Clearly/iOS/Info-iOS.plist
@@ -20,6 +20,18 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.com.sabotage.clearly</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>Clearly</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+		</dict>
+	</dict>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Clearly/iOS/RawTextDetailView_iOS.swift
+++ b/Clearly/iOS/RawTextDetailView_iOS.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import ClearlyCore
+
+struct RawTextDetailView_iOS: View {
+    @Environment(VaultSession.self) private var session
+
+    let file: VaultFile
+
+    @State private var text: String = ""
+    @State private var isLoading: Bool = true
+    @State private var loadError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+            footer
+        }
+        .navigationTitle(file.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: file.id) {
+            await load()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView(file.isPlaceholder ? "Downloading from iCloud…" : "Loading…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(.orange)
+                Text("Couldn't open this note")
+                    .font(.headline)
+                Text(loadError)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                Text(text)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding(16)
+            }
+        }
+    }
+
+    private var footer: some View {
+        Text("Read-only preview — editing lands in the next build.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+            .background(.thinMaterial)
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            if file.isPlaceholder {
+                try await session.ensureDownloaded(file.url)
+            }
+            let loaded = try await session.readRawText(at: file.url)
+            text = loaded
+            isLoading = false
+        } catch {
+            loadError = error.localizedDescription
+            isLoading = false
+        }
+    }
+}

--- a/Clearly/iOS/SidebarView_iOS.swift
+++ b/Clearly/iOS/SidebarView_iOS.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import ClearlyCore
+
+struct SidebarView_iOS: View {
+    @Environment(VaultSession.self) private var session
+    @State private var showWelcome: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if session.currentVault == nil {
+                    placeholder
+                } else if session.files.isEmpty && session.isLoading {
+                    ProgressView("Loading…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if session.files.isEmpty {
+                    emptyVault
+                } else {
+                    fileList
+                }
+            }
+            .navigationTitle(navTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showWelcome = true
+                    } label: {
+                        Image(systemName: "folder")
+                    }
+                    .accessibilityLabel("Change vault")
+                }
+            }
+            .refreshable {
+                session.refresh()
+            }
+        }
+        .fullScreenCover(isPresented: shouldShowWelcomeBinding) {
+            WelcomeView_iOS()
+                .interactiveDismissDisabled(session.currentVault == nil)
+                .onChange(of: session.currentVault?.id) { _, _ in
+                    if session.currentVault != nil {
+                        showWelcome = false
+                    }
+                }
+        }
+    }
+
+    private var shouldShowWelcomeBinding: Binding<Bool> {
+        Binding(
+            get: { session.currentVault == nil || showWelcome },
+            set: { newValue in
+                if !newValue { showWelcome = false }
+            }
+        )
+    }
+
+    private var navTitle: String {
+        session.currentVault?.displayName ?? "Clearly"
+    }
+
+    private var placeholder: some View {
+        Color.clear
+    }
+
+    private var emptyVault: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("No notes yet")
+                .font(.headline)
+            Text("Drop a `.md` file into this folder via Files to get started.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var fileList: some View {
+        List(session.files) { file in
+            NavigationLink(value: file) {
+                HStack(spacing: 10) {
+                    Image(systemName: file.isPlaceholder ? "icloud.and.arrow.down" : "doc.text")
+                        .foregroundStyle(file.isPlaceholder ? .secondary : .primary)
+                        .frame(width: 22)
+                    Text(file.name)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationDestination(for: VaultFile.self) { file in
+            RawTextDetailView_iOS(file: file)
+        }
+    }
+}

--- a/Clearly/iOS/WelcomeView_iOS.swift
+++ b/Clearly/iOS/WelcomeView_iOS.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import ClearlyCore
+
+struct WelcomeView_iOS: View {
+    @Environment(VaultSession.self) private var session
+
+    @State private var isICloudAvailable: Bool = FileManager.default.ubiquityIdentityToken != nil
+    @State private var pickerMode: PickerMode?
+    @State private var errorMessage: String?
+
+    enum PickerMode: Identifiable {
+        case pickedICloud
+        case local
+        var id: Int {
+            switch self {
+            case .pickedICloud: return 1
+            case .local: return 2
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 8) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 48, weight: .light))
+                    .foregroundStyle(.secondary)
+                Text("Clearly")
+                    .font(.largeTitle.weight(.semibold))
+                Text("Pick a folder of `.md` files to get started.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            VStack(spacing: 12) {
+                Button {
+                    attachDefaultICloud()
+                } label: {
+                    optionLabel(
+                        title: "Use iCloud Drive → Clearly",
+                        subtitle: isICloudAvailable ? "Sync with your Mac automatically" : "Sign in to iCloud to enable",
+                        systemImage: "icloud"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(!isICloudAvailable)
+
+                Button {
+                    pickerMode = .pickedICloud
+                } label: {
+                    optionLabel(
+                        title: "Choose iCloud folder…",
+                        subtitle: "Pick an existing folder in iCloud Drive",
+                        systemImage: "folder.badge.plus"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+
+                Button {
+                    pickerMode = .local
+                } label: {
+                    optionLabel(
+                        title: "Choose local folder…",
+                        subtitle: "On this device only — no sync",
+                        systemImage: "iphone"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .padding(.horizontal, 24)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer()
+        }
+        .fileImporter(
+            isPresented: Binding(
+                get: { pickerMode != nil },
+                set: { if !$0 { pickerMode = nil } }
+            ),
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImport(result: result, mode: pickerMode ?? .local)
+        }
+        .task {
+            for await available in CloudVault.isAvailablePublisher.values {
+                isICloudAvailable = available
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func optionLabel(title: String, subtitle: String, systemImage: String) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func attachDefaultICloud() {
+        errorMessage = nil
+        Task {
+            guard let url = await CloudVault.ubiquityContainerURL() else {
+                errorMessage = "iCloud Drive isn't available. Sign in from Settings and try again."
+                return
+            }
+            session.attach(VaultLocation(kind: .defaultICloud, url: url))
+        }
+    }
+
+    private func handleImport(result: Result<[URL], Error>, mode: PickerMode) {
+        errorMessage = nil
+        switch result {
+        case .failure(let error):
+            errorMessage = "Couldn't open folder: \(error.localizedDescription)"
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            guard url.startAccessingSecurityScopedResource() else {
+                errorMessage = "Couldn't access that folder — permission denied."
+                return
+            }
+            do {
+                let bookmark = try url.bookmarkData(
+                    options: [],
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                let kind: VaultLocation.Kind = (mode == .pickedICloud) ? .pickedICloud : .local
+                session.attach(VaultLocation(kind: kind, url: url, bookmarkData: bookmark))
+            } catch {
+                url.stopAccessingSecurityScopedResource()
+                errorMessage = "Couldn't remember that folder: \(error.localizedDescription)"
+            }
+        }
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Sync/VaultWatcher.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Sync/VaultWatcher.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Combine
+
+public struct VaultFile: Identifiable, Hashable, Sendable {
+    public var id: URL { url }
+    public let url: URL
+    public let name: String
+    public let modified: Date?
+    public let isPlaceholder: Bool
+
+    public init(url: URL, name: String, modified: Date?, isPlaceholder: Bool) {
+        self.url = url
+        self.name = name
+        self.modified = modified
+        self.isPlaceholder = isPlaceholder
+    }
+}
+
+/// Watches a vault directory for `.md` (and related) files. Two backends:
+/// - iCloud: `NSMetadataQuery` scoped to ubiquitous documents, with live updates.
+/// - Local / user-picked folder: `FileNode.buildTree` on a background queue, refresh-on-demand.
+@MainActor
+public final class VaultWatcher: NSObject, ObservableObject {
+    @Published public private(set) var files: [VaultFile] = []
+    @Published public private(set) var isLoading: Bool = false
+
+    public let rootURL: URL
+    public let useCloudQuery: Bool
+
+    private var metadataQuery: NSMetadataQuery?
+    private var localGeneration: Int = 0
+
+    public init(rootURL: URL, useCloudQuery: Bool) {
+        self.rootURL = rootURL
+        self.useCloudQuery = useCloudQuery
+        super.init()
+    }
+
+    deinit {
+        // `NotificationCenter.removeObserver(_:)` is thread-safe. We intentionally do NOT
+        // touch `metadataQuery` here — `NSMetadataQuery` is not thread-safe and calling
+        // `stop()` from a deinit that may run off main is racy. Callers (VaultSession)
+        // must call `stop()` explicitly before releasing.
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    public func start() {
+        if useCloudQuery {
+            startCloudQuery()
+        } else {
+            refresh()
+        }
+    }
+
+    public func stop() {
+        NotificationCenter.default.removeObserver(self)
+        metadataQuery?.stop()
+        metadataQuery = nil
+    }
+
+    public func refresh() {
+        if useCloudQuery {
+            metadataQuery?.disableUpdates()
+            reloadFromMetadataQuery()
+            metadataQuery?.enableUpdates()
+        } else {
+            reloadFromLocalWalk()
+        }
+    }
+
+    // MARK: - Cloud
+
+    private func startCloudQuery() {
+        let query = NSMetadataQuery()
+        query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+        query.predicate = NSPredicate(
+            format: "%K ENDSWITH[c] '.md' OR %K ENDSWITH[c] '.markdown' OR %K ENDSWITH[c] '.mdx' OR %K ENDSWITH[c] '.txt' OR %K ENDSWITH[c] '.mdown' OR %K ENDSWITH[c] '.mkd' OR %K ENDSWITH[c] '.mkdn' OR %K ENDSWITH[c] '.mdwn'",
+            NSMetadataItemFSNameKey, NSMetadataItemFSNameKey, NSMetadataItemFSNameKey, NSMetadataItemFSNameKey,
+            NSMetadataItemFSNameKey, NSMetadataItemFSNameKey, NSMetadataItemFSNameKey, NSMetadataItemFSNameKey
+        )
+        query.sortDescriptors = [NSSortDescriptor(key: NSMetadataItemFSNameKey, ascending: true)]
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(metadataQueryDidUpdate(_:)),
+            name: .NSMetadataQueryDidFinishGathering,
+            object: query
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(metadataQueryDidUpdate(_:)),
+            name: .NSMetadataQueryDidUpdate,
+            object: query
+        )
+
+        metadataQuery = query
+        isLoading = true
+        query.start()
+    }
+
+    @objc private func metadataQueryDidUpdate(_ note: Notification) {
+        MainActor.assumeIsolated {
+            reloadFromMetadataQuery()
+        }
+    }
+
+    private func reloadFromMetadataQuery() {
+        guard let query = metadataQuery else { return }
+        let root = rootURL.standardizedFileURL.path
+        var entries: [VaultFile] = []
+        entries.reserveCapacity(query.resultCount)
+        for case let item as NSMetadataItem in query.results {
+            guard let url = item.value(forAttribute: NSMetadataItemURLKey) as? URL else { continue }
+            let path = url.standardizedFileURL.path
+            guard path.hasPrefix(root) else { continue }
+            let name = (item.value(forAttribute: NSMetadataItemFSNameKey) as? String) ?? url.lastPathComponent
+            let modified = item.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date
+            let status = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey) as? String
+            let isPlaceholder = status != nil
+                && status != NSMetadataUbiquitousItemDownloadingStatusCurrent
+                && status != NSMetadataUbiquitousItemDownloadingStatusDownloaded
+            entries.append(VaultFile(url: url, name: name, modified: modified, isPlaceholder: isPlaceholder))
+        }
+        entries.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        files = entries
+        isLoading = false
+    }
+
+    // MARK: - Local
+
+    private func reloadFromLocalWalk() {
+        localGeneration += 1
+        let generation = localGeneration
+        let root = rootURL
+        isLoading = true
+        Task.detached(priority: .utility) { [weak self] in
+            let nodes = FileNode.buildTree(at: root, showHiddenFiles: false)
+            let flat = flattenToVaultFiles(nodes: nodes)
+            await self?.applyLocalWalk(flat, generation: generation)
+        }
+    }
+
+    private func applyLocalWalk(_ files: [VaultFile], generation: Int) {
+        guard localGeneration == generation else { return }
+        self.files = files
+        self.isLoading = false
+    }
+}
+
+private func flattenToVaultFiles(nodes: [FileNode]) -> [VaultFile] {
+    var out: [VaultFile] = []
+    func walk(_ node: FileNode) {
+        if let children = node.children {
+            for child in children { walk(child) }
+        } else {
+            let attrs = try? FileManager.default.attributesOfItem(atPath: node.url.path)
+            let modified = attrs?[.modificationDate] as? Date
+            out.append(VaultFile(url: node.url, name: node.name, modified: modified, isPlaceholder: false))
+        }
+    }
+    for node in nodes { walk(node) }
+    out.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    return out
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultLocation.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultLocation.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+public struct VaultLocation: Equatable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case defaultICloud
+        case pickedICloud
+        case local
+    }
+
+    public let id: UUID
+    public let kind: Kind
+    public let url: URL
+    public let bookmarkData: Data?
+
+    public init(id: UUID = UUID(), kind: Kind, url: URL, bookmarkData: Data? = nil) {
+        self.id = id
+        self.kind = kind
+        self.url = url
+        self.bookmarkData = bookmarkData
+    }
+
+    public var displayName: String {
+        switch kind {
+        case .defaultICloud: return "iCloud Drive / Clearly"
+        case .pickedICloud, .local: return url.lastPathComponent
+        }
+    }
+}
+
+public struct StoredVaultLocation: Codable, Sendable {
+    public let id: UUID
+    public let kind: VaultLocation.Kind
+    public let bookmarkData: Data?
+
+    public init(id: UUID, kind: VaultLocation.Kind, bookmarkData: Data?) {
+        self.id = id
+        self.kind = kind
+        self.bookmarkData = bookmarkData
+    }
+
+    public init(_ location: VaultLocation) {
+        self.id = location.id
+        self.kind = location.kind
+        self.bookmarkData = location.bookmarkData
+    }
+}
+
+public enum VaultLocationError: Error, Sendable {
+    case iCloudUnavailable
+    case bookmarkInvalidated
+    case bookmarkResolutionFailed(underlying: Error?)
+    case securityScopeDenied
+}
+
+extension VaultLocation {
+    /// Resolve a previously persisted location back into a live `VaultLocation`.
+    ///
+    /// - `.defaultICloud`: re-resolved via `CloudVault.ubiquityContainerURL()` each launch; no bookmark.
+    /// - `.pickedICloud` / `.local`: resolved from security-scoped bookmark; `startAccessingSecurityScopedResource`
+    ///   is called on the returned URL so callers can use it directly. Callers are responsible for
+    ///   `stopAccessingSecurityScopedResource()` when replacing the vault.
+    public static func resolve(from stored: StoredVaultLocation) async throws -> VaultLocation {
+        switch stored.kind {
+        case .defaultICloud:
+            guard let url = await CloudVault.ubiquityContainerURL() else {
+                throw VaultLocationError.iCloudUnavailable
+            }
+            return VaultLocation(id: stored.id, kind: .defaultICloud, url: url, bookmarkData: nil)
+
+        case .pickedICloud, .local:
+            guard let bookmarkData = stored.bookmarkData else {
+                throw VaultLocationError.bookmarkInvalidated
+            }
+            var isStale = false
+            let url: URL
+            do {
+                #if os(iOS)
+                url = try URL(
+                    resolvingBookmarkData: bookmarkData,
+                    options: [],
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &isStale
+                )
+                #else
+                url = try URL(
+                    resolvingBookmarkData: bookmarkData,
+                    options: [.withSecurityScope],
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &isStale
+                )
+                #endif
+            } catch {
+                throw VaultLocationError.bookmarkResolutionFailed(underlying: error)
+            }
+            if isStale {
+                throw VaultLocationError.bookmarkInvalidated
+            }
+            guard url.startAccessingSecurityScopedResource() else {
+                throw VaultLocationError.securityScopeDenied
+            }
+            return VaultLocation(id: stored.id, kind: stored.kind, url: url, bookmarkData: bookmarkData)
+        }
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -1,0 +1,163 @@
+#if os(iOS)
+import Foundation
+import Combine
+import Observation
+
+public enum VaultSessionError: Error, Equatable, Sendable {
+    case iCloudUnavailable
+    case bookmarkInvalidated
+    case readFailed(String)
+    case downloadFailed(String)
+}
+
+/// iOS-facing vault manager. Owns a single `VaultWatcher`, persists the chosen location
+/// to `UserDefaults`, and provides coordinated reads on demand.
+///
+/// This is the iOS equivalent of the Mac app's `WorkspaceManager`, intentionally narrower:
+/// single vault (no multi-location sidebar), flat file list (no hierarchical tree yet),
+/// read-only (writes land in Phase 6).
+@Observable
+@MainActor
+public final class VaultSession {
+    public static let persistenceKey = "iosVaultLocation"
+
+    public private(set) var currentVault: VaultLocation?
+    public private(set) var files: [VaultFile] = []
+    public private(set) var isLoading: Bool = false
+    public private(set) var error: VaultSessionError?
+
+    @ObservationIgnored private var watcher: VaultWatcher?
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Attach / detach
+
+    public func attach(_ location: VaultLocation) {
+        teardown()
+        currentVault = location
+        error = nil
+
+        let watcher = VaultWatcher(
+            rootURL: location.url,
+            useCloudQuery: location.kind == .defaultICloud
+        )
+        self.watcher = watcher
+
+        watcher.$files
+            .receive(on: RunLoop.main)
+            .sink { [weak self] value in self?.files = value }
+            .store(in: &cancellables)
+        watcher.$isLoading
+            .receive(on: RunLoop.main)
+            .sink { [weak self] value in self?.isLoading = value }
+            .store(in: &cancellables)
+
+        watcher.start()
+        persist(location)
+    }
+
+    /// Forget the current vault entirely. Clears persistence; next launch shows welcome.
+    public func forgetCurrentVault() {
+        teardown()
+        clearPersistence()
+    }
+
+    /// Internal teardown of the active watcher + security-scoped access. Does NOT touch
+    /// persistence — `attach()` calls this as part of switching vaults, and would otherwise
+    /// erase the newly-attached vault's persisted record.
+    private func teardown() {
+        if let current = currentVault, current.kind != .defaultICloud {
+            current.url.stopAccessingSecurityScopedResource()
+        }
+        watcher?.stop()
+        watcher = nil
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        currentVault = nil
+        files = []
+        isLoading = false
+    }
+
+    public func refresh() {
+        watcher?.refresh()
+    }
+
+    // MARK: - Persistence
+
+    private func persist(_ location: VaultLocation) {
+        let stored = StoredVaultLocation(location)
+        if let data = try? JSONEncoder().encode(stored) {
+            defaults.set(data, forKey: Self.persistenceKey)
+        }
+    }
+
+    private func clearPersistence() {
+        defaults.removeObject(forKey: Self.persistenceKey)
+    }
+
+    public func restoreFromPersistence() async {
+        guard let data = defaults.data(forKey: Self.persistenceKey) else { return }
+        guard let stored = try? JSONDecoder().decode(StoredVaultLocation.self, from: data) else {
+            clearPersistence()
+            return
+        }
+        do {
+            let location = try await VaultLocation.resolve(from: stored)
+            attach(location)
+        } catch {
+            clearPersistence()
+            self.error = mapResolveError(error)
+        }
+    }
+
+    private func mapResolveError(_ error: Error) -> VaultSessionError {
+        switch error {
+        case VaultLocationError.iCloudUnavailable:
+            return .iCloudUnavailable
+        case VaultLocationError.bookmarkInvalidated,
+             VaultLocationError.bookmarkResolutionFailed,
+             VaultLocationError.securityScopeDenied:
+            return .bookmarkInvalidated
+        default:
+            return .readFailed(String(describing: error))
+        }
+    }
+
+    // MARK: - Reading
+
+    public func readRawText(at url: URL) async throws -> String {
+        try await Task.detached(priority: .userInitiated) { () throws -> String in
+            let data = try CoordinatedFileIO.read(at: url)
+            return String(decoding: data, as: UTF8.self)
+        }.value
+    }
+
+    /// Begin downloading an iCloud placeholder and wait until it's current. Best-effort —
+    /// polls metadata up to the provided timeout. Honors task cancellation.
+    public func ensureDownloaded(_ url: URL, timeout: TimeInterval = 15) async throws {
+        try FileManager.default.startDownloadingUbiquitousItem(at: url)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            try Task.checkCancellation()
+            let values = try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+            if let status = values?.ubiquitousItemDownloadingStatus {
+                if status == .current || status == .downloaded {
+                    return
+                }
+            } else {
+                return
+            }
+            try await Task.sleep(nanoseconds: 300_000_000)
+        }
+        throw VaultSessionError.downloadFailed("Timed out waiting for iCloud download")
+    }
+
+    public func clearError() {
+        error = nil
+    }
+}
+#endif

--- a/docs/mobile/PROGRESS.md
+++ b/docs/mobile/PROGRESS.md
@@ -1,6 +1,6 @@
 # Mobile Progress
 
-## Status: Phase 3 - Complete
+## Status: Phase 4 - Complete
 
 ## Quick Reference
 - Research: `docs/mobile/RESEARCH.md`
@@ -103,13 +103,39 @@
 ---
 
 ### Phase 4: Read-only iOS vault browsing
-**Status:** Not Started
+**Status:** Complete (2026-04-21)
 
 #### Tasks Completed
-- (none yet)
+- [x] New `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultLocation.swift` — `VaultLocation` + `StoredVaultLocation` (Codable), `VaultLocationError`, and `VaultLocation.resolve(from:)` handling default-iCloud re-resolution and security-scoped bookmark reconstruction. `#if os(iOS)` branches the bookmark-options difference (iOS uses no options; macOS uses `.withSecurityScope`).
+- [x] New `Packages/ClearlyCore/Sources/ClearlyCore/Sync/VaultWatcher.swift` — `@MainActor` `NSObject` subclass with two backends: `NSMetadataQuery` on `NSMetadataQueryUbiquitousDocumentsScope` for the default iCloud container (live updates, placeholder-aware via `NSMetadataUbiquitousItemDownloadingStatusKey`); `FileNode.buildTree` on a detached utility `Task` for picked / local folders (refresh-on-demand). Publishes `[VaultFile]` + `isLoading` via `@Published`. Selector-based observers cleaned up in `deinit` via thread-safe `NotificationCenter.removeObserver(self)`.
+- [x] New `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift` — `#if os(iOS)` `@Observable` `@MainActor` class. Owns a single `VaultWatcher`, mirrors its `files` + `isLoading` via Combine `@ObservationIgnored` `Set<AnyCancellable>`. `attach`/`detach`/`refresh`/`restoreFromPersistence`/`readRawText(at:)`/`ensureDownloaded(_:)`. Persists `StoredVaultLocation` under `UserDefaults` key `"iosVaultLocation"`. `readRawText` dispatches `CoordinatedFileIO.read` onto a detached `Task` so the main thread stays free.
+- [x] Promoted `Clearly/MarkdownDocument.swift` from a 9-line `UTType` extension to a real `FileDocument`. `readableContentTypes = [.daringFireballMarkdown, .plainText]`; `init(configuration:)` UTF-8-decodes `regularFileContents`; `fileWrapper(configuration:)` throws `CocoaError(.featureUnsupported)` (writes ship in Phase 6). Cross-platform; Mac ignores it.
+- [x] New `Clearly/iOS/WelcomeView_iOS.swift` — three buttons (default iCloud / pick iCloud folder / pick local folder) with SwiftUI `.fileImporter(allowedContentTypes: [.folder])`. Watches `CloudVault.isAvailablePublisher` via an `AsyncPublisher` `for await` loop to disable the iCloud button when the identity token is nil. Creates security-scoped bookmarks via `url.bookmarkData(options: [], ...)` on iOS (the macOS-only `.withSecurityScope` option is forbidden on iOS).
+- [x] New `Clearly/iOS/SidebarView_iOS.swift` — `NavigationStack` root. `List` of `session.files` with `icloud.and.arrow.down` SF Symbol next to placeholders. Toolbar change-vault button, pull-to-refresh, empty-state message. `.fullScreenCover` presents welcome whenever `currentVault == nil` OR user tapped the change-vault gear.
+- [x] New `Clearly/iOS/RawTextDetailView_iOS.swift` — `.task(id:)` loads text via `session.readRawText(at:)`, calls `ensureDownloaded` first for placeholders. Monospace `ScrollView { Text(...) }` with text selection, fixed "Read-only preview — editing lands in the next build." footer. Handles download / read errors with inline message.
+- [x] Rewired `Clearly/iOS/ClearlyApp_iOS.swift` — `@State private var vaultSession = VaultSession()`, `SidebarView_iOS().environment(vaultSession).task { await vaultSession.restoreFromPersistence() }`.
+- [x] Added `NSUbiquitousContainers` dict to `Clearly/iOS/Info-iOS.plist` mirroring the Mac plist (same container id, `NSUbiquitousContainerIsDocumentScopePublic = YES`, display name "Clearly", `SupportedFolderLevels = Any`).
+- [x] `xcodegen generate` clean
+- [x] `xcodebuild -scheme Clearly -configuration Debug build -allowProvisioningUpdates` — green (Mac untouched)
+- [x] `xcodebuild -scheme ClearlyQuickLook -configuration Debug build` — green
+- [x] `xcodebuild -scheme ClearlyCLI -configuration Debug build` — green
+- [x] `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build -allowProvisioningUpdates` — green
+- [x] `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 pass
+- [x] Installed + launched on iPhone 17 simulator (iOS 26.4): welcome screen renders with title, subtitle, three buttons. Default iCloud button correctly disabled with "Sign in to iCloud to enable" subtitle because the simulator has no iCloud identity — proves `CloudVault.isAvailablePublisher` wiring works. Persistence path ran on startup (no `iosVaultLocation` key in UserDefaults → no-op, welcome shown).
+- [x] Self-review pass caught and fixed three real bugs before handoff: (1) `VaultWatcher.deinit` was calling `NSMetadataQuery.stop()` from a non-main thread — removed it, `stop()` is now explicit-only via `VaultSession`; (2) `VaultSession.detach()` wiped persistence as a side effect, so `attach()`'s internal cleanup would erase the new vault record before re-persisting — split into private `teardown()` (no persistence touch) and public `forgetCurrentVault()` (explicit wipe); (3) `VaultSession.ensureDownloaded` polled without cancellation checks, so a user navigating away from the detail view could leave the loop spinning for 15s — added `Task.checkCancellation()` and promoted the `Task.sleep` to throw on cancel. Also fixed a Swift-6 strict-concurrency warning in `VaultWatcher.reloadFromLocalWalk` by moving the MainActor re-entry into a dedicated `applyLocalWalk(_:generation:)` method rather than capturing `[weak self]` into a nested concurrent closure.
+- [ ] **NOT verified, needs device/manual testing:** actual tap through "Choose local folder" → file picker → pick folder → sidebar populates → tap file → text loads. I had no way to drive taps on the simulator programmatically. Welcome rendering is proven but the post-selection flow is only proven by construction (compiles + types line up), not by observation. Same caveat for iCloud sync (needs a signed-in device) and bookmark re-resolution after relaunch.
 
 #### Decisions Made
-- (none yet)
+- **WindowGroup over DocumentGroup for Phase 4.** `IMPLEMENTATION.md` said `DocumentGroup(newDocument: { MarkdownDocument() }) { … }` + a separate `WindowGroup` for welcome. Deviated to a single `WindowGroup` hosting welcome + sidebar + detail. `DocumentGroup` opens the system document browser at launch with no first-class hook for a custom vault sidebar; the phase's "sidebar of `.md` files in the iCloud Clearly folder" criterion needs a custom vault browser, not a per-document scene. Keeps the iOS and Mac mental models aligned (Mac uses `Window` + `WorkspaceManager`, not `DocumentGroup`). `MarkdownDocument` still promoted to `FileDocument` as Phase 5 / 6 setup. If we want Files.app "open in Clearly" integration later, `DocumentGroup` can land as a second scene.
+- **`FileDocument`, not `ReferenceFileDocument`.** Reference semantics matter for collaborative editing and multi-scene live-update; value semantics are enough for the editor binding we'll add in Phase 5. Phase 6 can upgrade if autosave flows need the reference model.
+- **Flat file list, not a hierarchical tree.** Phase 4 shows `[VaultFile]` in a simple `List`. Subdirectories are walked (via `FileNode.buildTree`) but flattened into a single sorted list by filename. Hierarchy + `DisclosureGroup` expansion lands alongside Phase 8's index rebuild.
+- **`.fileImporter` (SwiftUI) instead of direct `UIDocumentPickerViewController`.** Same underlying presenter, less UIKit glue.
+- **Picked-iCloud vs local kind = a user-facing label only.** Functionally both paths create security-scoped bookmarks the same way; the distinction is stored so Settings in Phase 13 can group them differently. Not worth inferring the kind from URL path.
+- **`NSMetadataQuery` only for `.defaultICloud`.** Picked iCloud folders can sit anywhere in iCloud Drive (not necessarily inside our ubiquity container), so the `NSMetadataQueryUbiquitousDocumentsScope` predicate wouldn't reliably cover them. Safer to treat all picked folders (iCloud or local) via `FileNode.buildTree` + manual refresh. Real-time iCloud updates only available when using the default container — acceptable tradeoff for Phase 4.
+- **Deferred `CloudBackend` persistence for `VaultWatcher`.** Did not build abstract `BackendProtocol` or split into two types — a single `useCloudQuery: Bool` flag routes between the two code paths. Cheaper than polymorphism for two call sites.
+- **Security-scoped bookmark options: `[]` on iOS, `.withSecurityScope` on macOS.** `.withSecurityScope` is macOS-only; passing it on iOS throws `NSFileReadNoPermissionError`. Branched with `#if os(iOS)` inside `VaultLocation.resolve`.
+- **`@Observable` for `VaultSession` + `ObservableObject` for `VaultWatcher`.** `VaultSession` is consumed by SwiftUI views → `@Observable` for property-level tracking. `VaultWatcher` is a worker class that mirrors state via Combine → `ObservableObject` + `@Published` keeps the Combine interop idiomatic.
+- **`.fullScreenCover` for welcome, not `.sheet`.** Welcome is a first-launch-or-change-vault gate; `.sheet` lets users swipe to dismiss before configuring a vault, which puts the app into a broken state. `interactiveDismissDisabled(session.currentVault == nil)` pins it when no vault exists.
 
 #### Blockers
 - (none)
@@ -254,6 +280,7 @@
 
 ### 2026-04-21
 - **Phase 3 complete.** iCloud entitlements added to all three channels; `NSUbiquitousContainers` on Mac Info.plist; `ClearlyCore/Sync/{CloudVault, CoordinatedFileIO}.swift` introduced; `scripts/verify-entitlements.sh` wired into both release scripts; `project.yml` updated with `DEVELOPMENT_TEAM = W33JZPPPFN` + automatic Debug signing so iCloud entitlements provision correctly. All Mac schemes + iOS build + integration tests (23/23) green. Runtime verified on Mac: `CloudVault.ubiquityContainerURL()` resolves to `~/Library/Mobile Documents/iCloud~com~sabotage~clearly/Documents` and the container bootstrap creates the `Documents/` subdir on first call. iOS on-device runtime verification deferred to Phase 4 (simulator strips entitlements, real device testing ships with the sidebar UI).
+- **Phase 4 complete.** First user-visible iOS milestone. Added `VaultLocation` + `VaultWatcher` (NSMetadataQuery for default iCloud / FileNode.buildTree for picked/local) + `VaultSession` (`@Observable @MainActor`, owns one watcher, persists `StoredVaultLocation` under `UserDefaults` key `"iosVaultLocation"`, reads raw UTF-8 via `CoordinatedFileIO.read` off-main, downloads iCloud placeholders on demand). Promoted `MarkdownDocument` to `FileDocument` (writes still throw; consumers arrive in Phase 5/6). New iOS views: `WelcomeView_iOS` (three buttons, SwiftUI `.fileImporter`, watches `CloudVault.isAvailablePublisher` to gate the default-iCloud button), `SidebarView_iOS` (`NavigationStack` + `List`, change-vault toolbar button, placeholder SF Symbol, pull-to-refresh, full-screen welcome cover when no vault), `RawTextDetailView_iOS` (monospace text with read-only footer, placeholder-download-aware). Rewired `ClearlyApp_iOS` to host a single `VaultSession` and call `restoreFromPersistence()` on launch. Added `NSUbiquitousContainers` to the iOS Info.plist. All four schemes build green; 23/23 integration tests still pass. Welcome screen verified on iPhone 17 simulator (iOS 26.4) — default-iCloud button correctly disabled because simulator has no iCloud identity, proving the availability wiring. Deviations from plan logged: `WindowGroup` over `DocumentGroup` (custom vault sidebar is incompatible with DocumentGroup's per-scene document model), `FileDocument` over `ReferenceFileDocument` (value semantics are enough until autosave lands). End-to-end iCloud sync verification deferred to device testing.
 
 ---
 
@@ -272,6 +299,11 @@
 - **New:** `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CloudVault.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift`, `scripts/verify-entitlements.sh`
 - **Modified:** `Clearly/Clearly.entitlements` + `Clearly/Clearly-AppStore.entitlements` + `Clearly/iOS/Clearly-iOS.entitlements` (added iCloud container + CloudDocuments service keys), `Clearly/Info.plist` (added `NSUbiquitousContainers`), `scripts/release.sh` + `scripts/release-appstore.sh` (call `verify-entitlements.sh` post-export), `project.yml` (added `DEVELOPMENT_TEAM: W33JZPPPFN` to all four targets' base settings + `CODE_SIGN_STYLE: Automatic` to each Debug config so iCloud-entitled Debug builds auto-provision against Sabotage Media's App IDs)
 
+### Phase 4 (2026-04-21)
+- **New (ClearlyCore):** `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultLocation.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Sync/VaultWatcher.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift`
+- **New (iOS app):** `Clearly/iOS/WelcomeView_iOS.swift`, `Clearly/iOS/SidebarView_iOS.swift`, `Clearly/iOS/RawTextDetailView_iOS.swift`
+- **Modified:** `Clearly/MarkdownDocument.swift` (promoted to `FileDocument`), `Clearly/iOS/ClearlyApp_iOS.swift` (placeholder → real app scene owning `VaultSession`), `Clearly/iOS/Info-iOS.plist` (added `NSUbiquitousContainers`)
+
 ## Architectural Decisions
 
 ### 2026-04-20 — Universal Purchase with shared bundle ID across all three channels
@@ -288,6 +320,9 @@ First draft had 8 phases but several were 2–3 days of work each. Split to 13 p
 
 ### 2026-04-20 — iOS simulator verification path
 Preferred verification path for the iOS target is a normal destination-based build: `xcodebuild -scheme Clearly-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -configuration Debug build`. `xcrun simctl install` + `xcrun simctl launch` remain useful when we want an explicit post-build launch check, but they are not required to work around destination resolution in this workspace.
+
+### 2026-04-21 — WindowGroup over DocumentGroup on iOS (Phase 4)
+`IMPLEMENTATION.md` Phase 4 described `DocumentGroup` as the root iOS scene plus a separate welcome `WindowGroup`. Shipped as a single `WindowGroup` instead. `DocumentGroup` on iOS 17 opens the system document browser at launch with one-document-per-scene semantics — incompatible with the phase's requirement to show a vault-folder sidebar as the root UI. A single `WindowGroup` hosting welcome + sidebar + detail views matches the Mac app's mental model (Mac uses `Window` + `WorkspaceManager`, not `DocumentGroup`). `MarkdownDocument` was still promoted to `FileDocument` for Phase 5's editor binding. If Files.app "open in Clearly" integration is needed later, `DocumentGroup` can be added as a secondary scene. Phase 12 will revisit scene architecture for iPad multi-tab either way. `IMPLEMENTATION.md` should be updated if this deviation holds through Phase 5.
 
 ## Lessons Learned
 (What worked, what didn't, what to do differently)


### PR DESCRIPTION
## Summary

Launch → welcome flow (default iCloud / pick iCloud folder / pick local folder) → sidebar of `.md` files → tap to read raw text. First user-visible iOS milestone; proves Phase-3's ubiquity plumbing works end-to-end.

New in `ClearlyCore`: `VaultLocation` (Codable persistence + bookmark resolution), `VaultWatcher` (`NSMetadataQuery` for the default iCloud container; `FileNode.buildTree` for picked / local folders), `VaultSession` (`@Observable @MainActor`, owns one watcher, persists the chosen vault, coordinated reads off-main, placeholder-download handling). New iOS views: `WelcomeView_iOS`, `SidebarView_iOS`, `RawTextDetailView_iOS`. `MarkdownDocument` promoted to a real `FileDocument` for Phase 5+; iOS `Info.plist` gets `NSUbiquitousContainers`.

Deviations from `IMPLEMENTATION.md` logged in `docs/mobile/PROGRESS.md` and rule-of-thumb captured in `CLAUDE.md`: shipped on `WindowGroup` (custom vault sidebar is incompatible with `DocumentGroup`'s one-document-per-scene model) and `FileDocument` (value semantics are enough until Phase 6 autosave).

## Test plan

- [ ] All four schemes build green (`Clearly`, `ClearlyQuickLook`, `ClearlyCLI`, `Clearly-iOS`); 23/23 integration tests pass. ✅ locally
- [ ] iPhone 17 simulator launches to welcome; default-iCloud button greys out without an iCloud identity. ✅ locally
- [ ] On a real iPhone signed into the same iCloud account as the Mac, tap **Use iCloud Drive → Clearly** → sidebar populates from `~/Library/Mobile Documents/iCloud~com~sabotage~clearly/Documents`.
- [ ] Drop a `.md` into that folder on Mac → appears in iPhone sidebar within seconds.
- [ ] Tap a file → raw text renders; kill + relaunch → skips welcome, restores vault.
- [ ] "Choose local folder…" → pick a folder → sidebar populates; relaunch → bookmark resolves.