### PR TITLE
Mobile Phase 8: iOS FTS5 index + placeholder coordination

### DIFF
--- a/Clearly/iOS/SidebarView_iOS.swift
+++ b/Clearly/iOS/SidebarView_iOS.swift
@@ -8,16 +8,24 @@ struct SidebarView_iOS: View {
     var body: some View {
         @Bindable var session = session
         NavigationStack(path: $session.navigationPath) {
-            Group {
-                if session.currentVault == nil {
-                    placeholder
-                } else if session.files.isEmpty && session.isLoading {
-                    ProgressView("Loading…")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if session.files.isEmpty {
-                    emptyVault
-                } else {
-                    fileList
+            VStack(spacing: 0) {
+                if let progress = session.indexProgress {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .frame(height: 2)
+                        .tint(.accentColor)
+                }
+                Group {
+                    if session.currentVault == nil {
+                        placeholder
+                    } else if session.files.isEmpty && session.isLoading {
+                        ProgressView("Loading…")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if session.files.isEmpty {
+                        emptyVault
+                    } else {
+                        fileList
+                    }
                 }
             }
             .navigationTitle(navTitle)

--- a/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
+++ b/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
@@ -278,6 +278,36 @@ final class MCPIntegrationTests: XCTestCase {
         XCTAssertTrue(read.content.contains("Line 2"))
     }
 
+    func testUpdateNoteLinkShowsInBacklinks() async throws {
+        struct Ignored: Decodable {}
+        _ = try await harness.callTool(
+            "create_note",
+            arguments: [
+                "relative_path": .string("Inbox/link-added-later.md"),
+                "content": .string("No links yet.\n")
+            ],
+            as: Ignored.self
+        )
+        _ = try await harness.callTool(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Inbox/link-added-later.md"),
+                "mode": .string("append"),
+                "content": .string("Now links [[Link Target]].\n")
+            ],
+            as: Ignored.self
+        )
+
+        struct LinkedEntry: Decodable { let relativePath: String }
+        struct Result: Decodable { let linked: [LinkedEntry] }
+        let backlinks = try await harness.callTool(
+            "get_backlinks",
+            arguments: ["relative_path": .string("Notes/Link Target.md")],
+            as: Result.self
+        )
+        XCTAssertTrue(backlinks.linked.contains { $0.relativePath == "Inbox/link-added-later.md" })
+    }
+
     func testUpdateNotePrependPreservesFrontmatter() async throws {
         struct Ignored: Decodable {}
         _ = try await harness.callTool(

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -330,6 +330,135 @@ public final class VaultIndex: @unchecked Sendable {
         }
     }
 
+    /// Async variant with optional per-file placeholder-download hook and progress reporting.
+    /// iOS uses the hook to materialize `.icloud` placeholders via `startDownloadingUbiquitousItem`
+    /// before parsing. Mac can pass `nil` (equivalent to the sync `indexAllFiles`).
+    ///
+    /// The hook returns `true` if the file is ready to read, `false` if it should be skipped
+    /// (e.g. still a placeholder after a timeout); the watcher will re-drive it via `updateFile`
+    /// once the download lands.
+    public func indexAllFiles(
+        showHiddenFiles: Bool = false,
+        downloadPlaceholder: ((URL) async -> Bool)?,
+        progress: ((Double) -> Void)?
+    ) async {
+        let markdownFiles = collectMarkdownFiles(under: rootURL, showHiddenFiles: showHiddenFiles)
+        let total = max(markdownFiles.count, 1)
+
+        struct PendingFile {
+            let relativePath: String
+            let filename: String
+            let content: String
+            let contentHash: String
+            let modifiedAt: Date
+        }
+
+        var pending: [PendingFile] = []
+        pending.reserveCapacity(markdownFiles.count)
+        var processedPaths = Set<String>()
+
+        for (idx, fileURL) in markdownFiles.enumerated() {
+            let relativePath = Self.relativePath(of: fileURL, from: rootURL)
+            processedPaths.insert(relativePath)
+
+            var usable = true
+            if let hook = downloadPlaceholder {
+                usable = await hook(fileURL)
+            }
+
+            if usable,
+               let data = try? Data(contentsOf: fileURL),
+               let content = String(data: data, encoding: .utf8) {
+                pending.append(PendingFile(
+                    relativePath: relativePath,
+                    filename: fileURL.deletingPathExtension().lastPathComponent,
+                    content: content,
+                    contentHash: Self.contentHash(data),
+                    modifiedAt: Self.fileModDate(fileURL)
+                ))
+            }
+
+            progress?(Double(idx + 1) / Double(total))
+        }
+
+        let fileBatch = pending
+        let processed = processedPaths
+
+        do {
+            try await dbPool.write { db in
+                let existingRows = try Row.fetchAll(db, sql: "SELECT id, path, content_hash FROM files")
+                var existingByPath: [String: (id: Int64, hash: String)] = [:]
+                for row in existingRows {
+                    let path: String = row["path"]
+                    let id: Int64 = row["id"]
+                    let hash: String = row["content_hash"]
+                    existingByPath[path] = (id, hash)
+                }
+
+                for file in fileBatch {
+                    if let existing = existingByPath[file.relativePath], existing.hash == file.contentHash {
+                        continue
+                    }
+
+                    let now = Date()
+
+                    if let existing = existingByPath[file.relativePath] {
+                        try db.execute(sql: """
+                            UPDATE files SET filename = ?, content_hash = ?, modified_at = ?, indexed_at = ?
+                            WHERE id = ?
+                            """, arguments: [file.filename, file.contentHash, file.modifiedAt.timeIntervalSince1970, now.timeIntervalSince1970, existing.id])
+
+                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
+                        try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                                       arguments: [existing.id, file.filename, file.content])
+
+                        try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existing.id])
+
+                        self.insertParsedData(db: db, fileId: existing.id, content: file.content)
+                    } else {
+                        try db.execute(sql: """
+                            INSERT INTO files (path, filename, content_hash, modified_at, indexed_at)
+                            VALUES (?, ?, ?, ?, ?)
+                            """, arguments: [file.relativePath, file.filename, file.contentHash, file.modifiedAt.timeIntervalSince1970, now.timeIntervalSince1970])
+
+                        let fileId = db.lastInsertedRowID
+
+                        try db.execute(sql: "INSERT INTO files_fts(rowid, filename, content) VALUES(?, ?, ?)",
+                                       arguments: [fileId, file.filename, file.content])
+
+                        self.insertParsedData(db: db, fileId: fileId, content: file.content)
+                    }
+                }
+
+                // Remove files that no longer exist on disk (pruned against the enumerated set,
+                // not the successfully-read set — placeholders that timed out still count as present).
+                let existingPaths = Set(existingByPath.keys)
+                let removedPaths = existingPaths.subtracting(processed)
+                for path in removedPaths {
+                    if let existing = existingByPath[path] {
+                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existing.id])
+                        try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [existing.id])
+                    }
+                }
+
+                try db.execute(sql: """
+                    UPDATE links SET target_file_id = (
+                        SELECT f.id FROM files f
+                        WHERE LOWER(f.filename) = LOWER(links.target_name)
+                        LIMIT 1
+                    )
+                    """)
+            }
+        } catch {
+            DiagnosticLog.log("VaultIndex: indexAllFiles (async) failed — \(error.localizedDescription)")
+        }
+    }
+
     private func insertParsedData(db: Database, fileId: Int64, content: String) {
         let parsed = FileParser.parse(content: content)
 
@@ -815,9 +944,17 @@ public final class VaultIndex: @unchecked Sendable {
     // MARK: Helpers
 
     private static func indexDirectory() -> URL {
+        #if os(iOS)
+        // Caches lives inside the iOS app sandbox — never inside the ubiquity container,
+        // where SQLite WAL/SHM files would race against iCloud sync. The system may reclaim
+        // Caches under disk pressure; next launch rebuilds from vault contents.
+        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return dir.appendingPathComponent("indexes")
+        #else
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let appName = Bundle.main.bundleIdentifier ?? "com.sabotage.clearly"
         return dir.appendingPathComponent("\(appName)/indexes")
+        #endif
     }
 
     #if os(macOS)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -358,6 +358,8 @@ public final class VaultIndex: @unchecked Sendable {
         var processedPaths = Set<String>()
 
         for (idx, fileURL) in markdownFiles.enumerated() {
+            if Task.isCancelled { return }
+
             let relativePath = Self.relativePath(of: fileURL, from: rootURL)
             processedPaths.insert(relativePath)
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -167,6 +167,7 @@ public final class VaultIndex: @unchecked Sendable {
                     try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [id])
                     try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [id])
                     try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [id])
+                    try self.resolveWikiLinkTargets(db: db)
                 }
                 return nil
             }
@@ -201,6 +202,7 @@ public final class VaultIndex: @unchecked Sendable {
                 try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existingId])
 
                 self.insertParsedData(db: db, fileId: existingId, content: content)
+                try self.resolveWikiLinkTargets(db: db)
 
                 let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE id = ?", arguments: [existingId])
                 return row.map(Self.indexedFile(from:))
@@ -216,6 +218,7 @@ public final class VaultIndex: @unchecked Sendable {
                                arguments: [fileId, filename, content])
 
                 self.insertParsedData(db: db, fileId: fileId, content: content)
+                try self.resolveWikiLinkTargets(db: db)
 
                 let row = try Row.fetchOne(db, sql: "SELECT * FROM files WHERE id = ?", arguments: [fileId])
                 return row.map(Self.indexedFile(from:))
@@ -316,14 +319,7 @@ public final class VaultIndex: @unchecked Sendable {
                     }
                 }
 
-                // Resolve wiki-link targets
-                try db.execute(sql: """
-                    UPDATE links SET target_file_id = (
-                        SELECT f.id FROM files f
-                        WHERE LOWER(f.filename) = LOWER(links.target_name)
-                        LIMIT 1
-                    )
-                    """)
+                try self.resolveWikiLinkTargets(db: db)
             }
         } catch {
             DiagnosticLog.log("VaultIndex: indexAllFiles failed — \(error.localizedDescription)")
@@ -448,17 +444,21 @@ public final class VaultIndex: @unchecked Sendable {
                     }
                 }
 
-                try db.execute(sql: """
-                    UPDATE links SET target_file_id = (
-                        SELECT f.id FROM files f
-                        WHERE LOWER(f.filename) = LOWER(links.target_name)
-                        LIMIT 1
-                    )
-                    """)
+                try self.resolveWikiLinkTargets(db: db)
             }
         } catch {
             DiagnosticLog.log("VaultIndex: indexAllFiles (async) failed — \(error.localizedDescription)")
         }
+    }
+
+    private func resolveWikiLinkTargets(db: Database) throws {
+        try db.execute(sql: """
+            UPDATE links SET target_file_id = (
+                SELECT f.id FROM files f
+                WHERE LOWER(f.filename) = LOWER(links.target_name)
+                LIMIT 1
+            )
+            """)
     }
 
     private func insertParsedData(db: Database, fileId: Int64, content: String) {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -232,7 +232,15 @@ public final class VaultSession {
                 }
             )
             await MainActor.run { [weak self] in
-                self?.indexProgress = nil
+                guard let self = self else { return }
+                self.indexProgress = nil
+                if Task.isCancelled { return }
+                // Catch-up pass: any file that appeared or changed DURING the rebuild
+                // got filtered out of `scheduleIncrementalReindex` (because
+                // `indexProgress != nil`) and isn't guaranteed to produce another
+                // watcher event afterward. Feed the current `files` through
+                // incremental now; `updateFile` hash-skips unchanged entries.
+                self.scheduleIncrementalReindex(for: self.files)
             }
         }
     }
@@ -241,20 +249,20 @@ public final class VaultSession {
     /// set against `knownFiles`; for each add / remove / modified-date change, calls
     /// `VaultIndex.updateFile(at:)` on a utility queue. `updateFile` already handles
     /// hash-based skip + delete-if-missing semantics (`VaultIndex.swift:157`).
+    ///
+    /// While a full rebuild is running, this method no-ops and leaves `knownFiles`
+    /// untouched. When the rebuild completes, it calls this method once with the
+    /// current `files` to catch any changes that landed during the rebuild window.
     private func scheduleIncrementalReindex(for newFiles: [VaultFile]) {
+        guard let index = index else { return }
+
+        // Rebuild owns the snapshot while it runs; don't update knownFiles here or the
+        // post-rebuild catch-up pass would miss files added mid-rebuild.
+        if indexProgress != nil { return }
+
         let oldKnown = knownFiles
         let newKnown = Dictionary(uniqueKeysWithValues: newFiles.map { ($0.url, $0.modified) })
         knownFiles = newKnown
-
-        guard let index = index else { return }
-
-        // Full rebuild owns the authoritative snapshot while it runs; incremental would
-        // race with it. Resume incremental after rebuild completes.
-        if indexProgress != nil { return }
-
-        // First post-attach update: the initial full rebuild already covered these files;
-        // nothing to incremental-index.
-        if oldKnown.isEmpty { return }
 
         let rootURL = currentVault?.url ?? index.rootURL
         let oldKeys = Set(oldKnown.keys)
@@ -278,6 +286,7 @@ public final class VaultSession {
         Task.detached(priority: .utility) { [weak index] in
             guard let index = index else { return }
             for path in changedPaths {
+                if Task.isCancelled { return }
                 _ = try? index.updateFile(at: path)
             }
         }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -26,11 +26,22 @@ public final class VaultSession {
     public private(set) var isLoading: Bool = false
     public private(set) var error: VaultSessionError?
 
+    /// 0.0…1.0 while a full vault re-index is running. `nil` when idle. Drives the
+    /// sidebar progress bar.
+    public private(set) var indexProgress: Double?
+
     /// Navigation stack binding for `SidebarView_iOS`'s `NavigationStack(path:)`. Detail
     /// views (e.g. preview wiki-link taps) can mutate this to push another note.
     public var navigationPath: [VaultFile] = []
 
+    /// Read-only access for consumers that need to query the FTS5 index (search, backlinks).
+    /// `nil` until a vault is attached and its index is constructed.
+    public var currentIndex: VaultIndex? { index }
+
     @ObservationIgnored private var watcher: VaultWatcher?
+    @ObservationIgnored private var index: VaultIndex?
+    @ObservationIgnored private var indexingTask: Task<Void, Never>?
+    @ObservationIgnored private var knownFiles: [URL: Date?] = [:]
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private let defaults: UserDefaults
 
@@ -55,6 +66,12 @@ public final class VaultSession {
             .receive(on: RunLoop.main)
             .sink { [weak self] value in self?.files = value }
             .store(in: &cancellables)
+        // Debounced to coalesce NSMetadataQuery update storms into a single incremental
+        // reindex per burst. The `files` publish above stays immediate so UI doesn't lag.
+        watcher.$files
+            .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
+            .sink { [weak self] value in self?.scheduleIncrementalReindex(for: value) }
+            .store(in: &cancellables)
         watcher.$isLoading
             .receive(on: RunLoop.main)
             .sink { [weak self] value in self?.isLoading = value }
@@ -62,6 +79,13 @@ public final class VaultSession {
 
         watcher.start()
         persist(location)
+
+        if let newIndex = try? VaultIndex(locationURL: location.url) {
+            self.index = newIndex
+            beginIndexing(using: newIndex)
+        } else {
+            DiagnosticLog.log("VaultSession: failed to open VaultIndex for \(location.url.lastPathComponent)")
+        }
     }
 
     /// Forget the current vault entirely. Clears persistence; next launch shows welcome.
@@ -77,6 +101,12 @@ public final class VaultSession {
         if let current = currentVault, current.kind != .defaultICloud {
             current.url.stopAccessingSecurityScopedResource()
         }
+        indexingTask?.cancel()
+        indexingTask = nil
+        index?.close()
+        index = nil
+        indexProgress = nil
+        knownFiles.removeAll()
         watcher?.stop()
         watcher = nil
         cancellables.forEach { $0.cancel() }
@@ -165,13 +195,119 @@ public final class VaultSession {
         error = nil
     }
 
+    // MARK: - Indexing
+
+    /// Full vault re-index. Runs off-main on a utility queue. For each `.icloud`
+    /// placeholder, kicks off `startDownloadingUbiquitousItem` and waits up to 5s;
+    /// files that remain placeholders are skipped this pass — the watcher triggers
+    /// incremental re-index once the download lands.
+    private func beginIndexing(using index: VaultIndex) {
+        indexingTask?.cancel()
+        indexProgress = 0.0
+
+        indexingTask = Task.detached(priority: .utility) { [weak self] in
+            await index.indexAllFiles(
+                downloadPlaceholder: { url in
+                    try? FileManager.default.startDownloadingUbiquitousItem(at: url)
+                    let deadline = Date().addingTimeInterval(5)
+                    while Date() < deadline {
+                        if Task.isCancelled { return false }
+                        let values = try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+                        if let status = values?.ubiquitousItemDownloadingStatus {
+                            if status == .current || status == .downloaded {
+                                return true
+                            }
+                        } else {
+                            // Not ubiquitous — local file, safe to read immediately.
+                            return true
+                        }
+                        try? await Task.sleep(nanoseconds: 300_000_000)
+                    }
+                    return false
+                },
+                progress: { value in
+                    Task { @MainActor [weak self] in
+                        self?.indexProgress = value
+                    }
+                }
+            )
+            await MainActor.run { [weak self] in
+                self?.indexProgress = nil
+            }
+        }
+    }
+
+    /// Debounced incremental re-index driven by `VaultWatcher.$files`. Diffs the incoming
+    /// set against `knownFiles`; for each add / remove / modified-date change, calls
+    /// `VaultIndex.updateFile(at:)` on a utility queue. `updateFile` already handles
+    /// hash-based skip + delete-if-missing semantics (`VaultIndex.swift:157`).
+    private func scheduleIncrementalReindex(for newFiles: [VaultFile]) {
+        let oldKnown = knownFiles
+        let newKnown = Dictionary(uniqueKeysWithValues: newFiles.map { ($0.url, $0.modified) })
+        knownFiles = newKnown
+
+        guard let index = index else { return }
+
+        // Full rebuild owns the authoritative snapshot while it runs; incremental would
+        // race with it. Resume incremental after rebuild completes.
+        if indexProgress != nil { return }
+
+        // First post-attach update: the initial full rebuild already covered these files;
+        // nothing to incremental-index.
+        if oldKnown.isEmpty { return }
+
+        let rootURL = currentVault?.url ?? index.rootURL
+        let oldKeys = Set(oldKnown.keys)
+        let newKeys = Set(newKnown.keys)
+        var changedPaths: [String] = []
+
+        for url in newKeys.subtracting(oldKeys) {
+            changedPaths.append(VaultIndex.relativePath(of: url, from: rootURL))
+        }
+        for url in oldKeys.subtracting(newKeys) {
+            changedPaths.append(VaultIndex.relativePath(of: url, from: rootURL))
+        }
+        for url in newKeys.intersection(oldKeys) {
+            if (oldKnown[url] ?? nil) != (newKnown[url] ?? nil) {
+                changedPaths.append(VaultIndex.relativePath(of: url, from: rootURL))
+            }
+        }
+
+        guard !changedPaths.isEmpty else { return }
+
+        Task.detached(priority: .utility) { [weak index] in
+            guard let index = index else { return }
+            for path in changedPaths {
+                _ = try? index.updateFile(at: path)
+            }
+        }
+    }
+
     // MARK: - Wiki-link resolution
 
-    /// Case-insensitive lookup for `[[name]]`-style wiki links against the current vault file list.
-    /// Matches by stem (filename without markdown extension) first, then by full filename.
+    /// Case-insensitive lookup for `[[name]]`-style wiki links. Prefers the FTS5 index
+    /// (more accurate — considers every file on disk, not just the watcher's current view)
+    /// and falls back to scanning `files` when the index has not caught up yet (e.g. the
+    /// file was just created by the watcher but not yet indexed).
     public func resolveWikiLink(name: String) -> VaultFile? {
         let target = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !target.isEmpty else { return nil }
+
+        if let index = index,
+           let indexed = index.resolveWikiLink(name: target) {
+            let rootURL = currentVault?.url ?? index.rootURL
+            let absoluteURL = rootURL.appendingPathComponent(indexed.path)
+            if let match = files.first(where: { $0.url.standardizedFileURL == absoluteURL.standardizedFileURL }) {
+                return match
+            }
+            return VaultFile(
+                url: absoluteURL,
+                name: absoluteURL.lastPathComponent,
+                modified: indexed.modifiedAt,
+                isPlaceholder: false
+            )
+        }
+
         if let byStem = files.first(where: { Self.stem(of: $0.name).lowercased() == target }) {
             return byStem
         }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -41,9 +41,15 @@ public final class VaultSession {
     @ObservationIgnored private var watcher: VaultWatcher?
     @ObservationIgnored private var index: VaultIndex?
     @ObservationIgnored private var indexingTask: Task<Void, Never>?
-    @ObservationIgnored private var knownFiles: [URL: Date?] = [:]
+    @ObservationIgnored private var indexingGeneration: Int = 0
+    @ObservationIgnored private var knownFiles: [URL: FileSnapshot] = [:]
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private let defaults: UserDefaults
+
+    private struct FileSnapshot: Equatable {
+        let modified: Date?
+        let isPlaceholder: Bool
+    }
 
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -101,6 +107,7 @@ public final class VaultSession {
         if let current = currentVault, current.kind != .defaultICloud {
             current.url.stopAccessingSecurityScopedResource()
         }
+        indexingGeneration += 1
         indexingTask?.cancel()
         indexingTask = nil
         index?.close()
@@ -203,6 +210,8 @@ public final class VaultSession {
     /// incremental re-index once the download lands.
     private func beginIndexing(using index: VaultIndex) {
         indexingTask?.cancel()
+        indexingGeneration += 1
+        let generation = indexingGeneration
         indexProgress = 0.0
 
         indexingTask = Task.detached(priority: .utility) { [weak self] in
@@ -226,15 +235,23 @@ public final class VaultSession {
                     return false
                 },
                 progress: { value in
-                    Task { @MainActor [weak self] in
-                        self?.indexProgress = value
+                    Task { @MainActor [weak self, weak index] in
+                        guard let self,
+                              let index,
+                              let currentIndex = self.index,
+                              currentIndex === index,
+                              self.indexingGeneration == generation else { return }
+                        self.indexProgress = value
                     }
                 }
             )
+            if Task.isCancelled { return }
             await MainActor.run { [weak self] in
                 guard let self = self else { return }
+                guard let currentIndex = self.index,
+                      currentIndex === index,
+                      self.indexingGeneration == generation else { return }
                 self.indexProgress = nil
-                if Task.isCancelled { return }
                 // Catch-up pass: any file that appeared or changed DURING the rebuild
                 // got filtered out of `scheduleIncrementalReindex` (because
                 // `indexProgress != nil`) and isn't guaranteed to produce another
@@ -261,7 +278,9 @@ public final class VaultSession {
         if indexProgress != nil { return }
 
         let oldKnown = knownFiles
-        let newKnown = Dictionary(uniqueKeysWithValues: newFiles.map { ($0.url, $0.modified) })
+        let newKnown = Dictionary(uniqueKeysWithValues: newFiles.map {
+            ($0.url, FileSnapshot(modified: $0.modified, isPlaceholder: $0.isPlaceholder))
+        })
         knownFiles = newKnown
 
         let rootURL = currentVault?.url ?? index.rootURL

--- a/docs/mobile/PROGRESS.md
+++ b/docs/mobile/PROGRESS.md
@@ -1,6 +1,6 @@
 # Mobile Progress
 
-## Status: Phase 7 - Complete
+## Status: Phase 8 - Complete
 
 ## Quick Reference
 - Research: `docs/mobile/RESEARCH.md`
@@ -252,13 +252,28 @@
 ---
 
 ### Phase 8: Index rebuild + `.icloud` placeholder coordination
-**Status:** Not Started
+**Status:** Complete (2026-04-21)
 
 #### Tasks Completed
-- (none yet)
+- [x] `VaultIndex.indexDirectory()` (`Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift:817`) gained an `#if os(iOS)` branch pointing at `URL.cachesDirectory/indexes/`. macOS + ClearlyMCP paths unchanged.
+- [x] New async `VaultIndex.indexAllFiles(showHiddenFiles:downloadPlaceholder:progress:)` added alongside the existing sync version. Collects file data in an async loop (awaits the `downloadPlaceholder` hook before each read), then does one batched `dbPool.write`.
+- [x] `VaultSession` gained: `indexProgress: Double?` (published), `currentIndex: VaultIndex?` accessor, `index` + `indexingTask` + `knownFiles` private storage, `beginIndexing(using:)` launched from `attach(_:)`, tear-down on `teardown()`.
+- [x] `beginIndexing` inlines a placeholder-aware download loop (5s per-file deadline; returns `false` on timeout so the file is skipped this pass and picked up on the next watcher tick).
+- [x] `scheduleIncrementalReindex` wires `VaultWatcher.$files` → debounced 500 ms → diff against `knownFiles` → `VaultIndex.updateFile(at:)` per changed path. Skips while the full rebuild is in flight.
+- [x] `VaultSession.resolveWikiLink` now checks `VaultIndex` first and falls back to the file-list scan. Phase 7's deferred "point iOS wiki-link at real index" is now done.
+- [x] `SidebarView_iOS` inserts a 2pt `ProgressView(value:)` under the nav bar while `indexProgress != nil`.
+- [x] Mac Debug build: **passed** (`xcodebuild -scheme Clearly -configuration Debug build`). iOS Debug build: **passed** (`xcodebuild -scheme Clearly-iOS -configuration Debug -destination 'generic/platform=iOS Simulator' build`). CLI integration tests: **23/23 passed**.
 
 #### Decisions Made
-- (none yet)
+- **iOS-only cache-dir switch, not universal.** The spec wanted `URL.cachesDirectory/indexes/<hash>/vault.sqlite` on **both** platforms. Moving Mac would break ClearlyMCP CLI (`VaultIndex.swift:825` resolves `Library/Containers/<bundleId>/Data/Library/Application Support/<bundleId>/indexes`). Phase 8 ships the iOS branch only; Mac stays on Application Support. Spec intent ("never inside the ubiquity container") is preserved because Mac's App Support is inside the sandbox container, not iCloud.
+- **Flat layout inside `indexes/`, not a per-vault subdirectory.** Kept the Mac convention of `<path-hash>.sqlite` (not `<path-hash>/vault.sqlite`). One less directory, same uniqueness guarantee via SHA-256 truncation.
+- **No spinner-on-sidebar-row for placeholder taps.** Plan called for per-row tap → spinner + download. Dropped because the existing navigation path already handles this: `IOSDocumentSession.open(_:via:)` (`Clearly/iOS/IOSDocumentSession.swift:54`) sees `file.isPlaceholder`, calls `vault.ensureDownloaded`, and the detail view renders "Downloading from iCloud…". The sidebar tap gesture would have layered on top of `NavigationLink`'s own tap handling and risked gesture-conflict regressions.
+- **Async `indexAllFiles` is an overload, not a replacement.** Mac's `WorkspaceManager.reindexVault` (`Clearly/WorkspaceManager.swift:1222`), `ClearlyCLI/CLI/Commands/IndexCommand.swift:101`, and `ClearlyCLIIntegrationTests/TestVaultHarness.swift:47` all call the existing sync `indexAllFiles(showHiddenFiles:)`. Leaving that untouched kept the 23 integration tests green without refactoring three callers.
+- **Debounce incremental re-index at 500 ms on a separate subscription.** Split the `watcher.$files` sink into two: one immediate (feeds `session.files` for UI), one debounced (feeds `scheduleIncrementalReindex`). The immediate publish keeps the sidebar snappy; the debounce coalesces NSMetadataQuery update storms.
+- **`knownFiles` updates every tick, even during rebuild.** Always snapshot the latest file set on each watcher emission so the first post-rebuild tick has the correct "previous" state to diff against. Skip the actual `updateFile` pass while `indexProgress != nil`.
+- **First post-attach watcher tick does no incremental re-index.** `oldKnown.isEmpty` short-circuits — the full rebuild already covers every file. Without this, the initial watcher publication would fire `updateFile` for every file in parallel with the rebuild.
+- **Wiki-link resolver keeps the file-scan fallback.** There's a race window between the watcher surfacing a new file and the 500ms-debounced incremental re-index writing it to the DB. Fall back to the current file-list scan so `openOrCreate` works instantly in that window.
+- **`downloadPlaceholder` returns `Bool`, not `throws`.** A download timeout is not an error; it's a signal to skip this file this pass. Exceptions in the indexing loop would prematurely abort the whole rebuild. Returning a Bool keeps the loop going and delegates timeout handling to the caller's policy.
 
 #### Blockers
 - (none)
@@ -345,6 +360,9 @@
 - **Phase 1 executed and verified.** 20 Swift files relocated into `Packages/ClearlyCore`; all four Mac schemes build clean; all 23 `ClearlyCLIIntegrationTests` pass. Mac behavior unchanged — no functional changes, no UI changes.
 - **Phase 2 executed and verified.** `Clearly-iOS` target added to `project.yml`; three new files under `Clearly/iOS/` (app entry, Info plist, entitlements shell); Mac target picks up `excludes: ["iOS/**"]`. Fixed one Mac-only API leak in `ClearlyCore/Vault/VaultIndex.swift` (`homeDirectoryForCurrentUser`, gated behind `#if os(macOS)`). All Mac schemes still green; 23/23 CLI integration tests still pass; iOS builds succeed both via `-sdk iphonesimulator` and via a concrete simulator destination (`platform=iOS Simulator,name=iPhone 17,OS=26.4`); placeholder view renders on iPhone 17 simulator (iOS 26.4 runtime).
 
+### 2026-04-21 (Phase 8)
+- **Phase 8 complete.** iOS now has a live FTS5 index and placeholder-aware coordination. `VaultIndex` stores its SQLite on iOS under `URL.cachesDirectory/indexes/<hash>.sqlite` (Mac path unchanged — keeps ClearlyMCP working). New async `indexAllFiles(showHiddenFiles:downloadPlaceholder:progress:)` overload collects file data in an async loop (awaits a per-file placeholder-download hook) and writes in one batched `try await dbPool.write`. `VaultSession` owns a `VaultIndex` per attached vault, publishes `indexProgress: Double?` for the sidebar progress bar, and exposes `currentIndex` for Phase 9 consumers. `beginIndexing` inlines a 5s-per-file placeholder poll (skip on timeout, let watcher catch up on next tick). A second debounced `watcher.$files` subscription drives `scheduleIncrementalReindex`, diffing known vs current files and calling `VaultIndex.updateFile(at:)` per changed path — skipped while a full rebuild is running. `resolveWikiLink` now checks the index first (resolves Phase 7's deferred "point iOS wiki-link at real index"). `SidebarView_iOS` shows a 2pt `ProgressView(value:)` under the nav bar while indexing. Plan's sidebar-side per-row tap/spinner was dropped — `IOSDocumentSession.open` already downloads placeholders on navigation and the detail view shows "Downloading from iCloud…" natively, so sidebar-layer gesture fiddling would have added UX conflict without new function. Mac + iOS Debug builds pass; 23/23 CLI integration tests still pass (the sync `indexAllFiles` path used by Mac + CLI is untouched). **End-to-end placeholder download, incremental re-index on file drop, and vault-switch invalidation still need Josh's manual device pass** — iOS simulator doesn't model real iCloud placeholder state, and there's no programmatic way to drive Files.app file drops in this workspace.
+
 ### 2026-04-21 (Phase 7)
 - **Phase 7 complete.** iOS now has a rendered preview pane and cross-file wiki-link navigation. Six web-asset resources added to the `Clearly-iOS` target (katex/mermaid/highlight + fonts). New `PreviewView_iOS` (`UIViewRepresentable<WKWebView>`) renders HTML via the shared `MarkdownRenderer` + `PreviewCSS` + Math/Table/Mermaid/SyntaxHighlight scripts, with `LocalImageSchemeHandler` for the `clearly-file://` scheme. Registers only the two script handlers we use on iPhone today: `linkClicked` + `taskToggle`. Mac's scroll sync / dblclick-to-source / footnote popover / find-in-preview / selection capture are left off — iPhone doesn't need them in Phase 7, they can port later if Phase 9 / 12 require them. `VaultSession` grew three public surfaces: `navigationPath: [VaultFile]` (binding for `NavigationStack(path:)`), `resolveWikiLink(name:)` (stem-match against `files` — Phase 8 will replace this with VaultIndex queries), `openOrCreate(name:) async throws` (writes an empty `.md` at vault root via `CoordinatedFileIO.write(Data(), to:)`, returns a provisional `VaultFile` immediately). `RawTextDetailView_iOS` gained a `@State var viewMode` + a toolbar segmented `Picker` + conditional Edit/Preview rendering. `SidebarView_iOS` switched to `NavigationStack(path: $session.navigationPath)` so preview wiki-link taps can push. Phase 7 plan's "move renderer files" + "add iOS CSS branch" tasks were dropped — both were already done by Phase 1 / already present in `PreviewCSS:133`. Build matrix green across Mac / QuickLook / CLI / iOS; 23/23 integration tests pass; iPhone 17 / iOS 26.4 simulator launches the app cleanly. **End-to-end preview, wiki-link tap, task-checkbox toggle, external-link open, and relaunch-resource-resolution flows need Josh's manual device pass** — no way to drive simulator taps + compare rendered HTML visually in this workspace.
 
@@ -379,6 +397,10 @@
 - **New (ClearlyCore):** `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultLocation.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Sync/VaultWatcher.swift`, `Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift`
 - **New (iOS app):** `Clearly/iOS/WelcomeView_iOS.swift`, `Clearly/iOS/SidebarView_iOS.swift`, `Clearly/iOS/RawTextDetailView_iOS.swift`
 - **Modified:** `Clearly/MarkdownDocument.swift` (promoted to `FileDocument`), `Clearly/iOS/ClearlyApp_iOS.swift` (placeholder → real app scene owning `VaultSession`), `Clearly/iOS/Info-iOS.plist` (added `NSUbiquitousContainers`)
+
+### Phase 8 (2026-04-21)
+- **Modified (ClearlyCore):** `Vault/VaultIndex.swift` (`indexDirectory()` iOS `.cachesDirectory` branch; new async overload `indexAllFiles(showHiddenFiles:downloadPlaceholder:progress:)` that collects file data in an async loop and writes in one `try await dbPool.write` batch). `Vault/VaultSession.swift` (`indexProgress` + `currentIndex` published/accessor; `index` + `indexingTask` + `knownFiles` storage; `beginIndexing(using:)`; `scheduleIncrementalReindex(for:)`; inline placeholder-download polling; `resolveWikiLink(name:)` upgraded to check `VaultIndex` first; debounced second `watcher.$files` subscription for incremental re-index).
+- **Modified (iOS app):** `Clearly/iOS/SidebarView_iOS.swift` (VStack wraps content to host a 2pt `ProgressView(value:)` when `indexProgress != nil`).
 
 ### Phase 7 (2026-04-21)
 - **New (iOS app):** `Clearly/iOS/PreviewView_iOS.swift` (UIViewRepresentable WKWebView preview with `linkClicked` + `taskToggle` script handlers, `LocalImageSchemeHandler`, trimmed JS template, `skipNextReload` flag).


### PR DESCRIPTION
## Summary
- `VaultIndex` stores iOS index at `URL.cachesDirectory/indexes/<hash>.sqlite`; Mac path unchanged so ClearlyMCP keeps working.
- New async `indexAllFiles(showHiddenFiles:downloadPlaceholder:progress:)` overload collects file data async (awaits placeholder download per file) then writes one batched `try await dbPool.write`. Existing sync `indexAllFiles` untouched — Mac + CLI callers unaffected.
- `VaultSession` owns a `VaultIndex` per attached vault, publishes `indexProgress: Double?`, exposes `currentIndex` for Phase 9 consumers, runs `beginIndexing` on `attach`, and uses a debounced second `watcher.$files` subscription to incremental-reindex added/removed/modified paths via `VaultIndex.updateFile(at:)`. Full rebuild and incremental are mutually exclusive (incremental skipped while `indexProgress != nil`).
- `resolveWikiLink` now checks `VaultIndex` first and falls back to the file-list scan (Phase 7's deferred "point iOS wiki-link at real index").
- `SidebarView_iOS` shows a 2pt `ProgressView(value:)` under the nav bar while indexing.
- Sidebar-side per-row spinner from the plan was dropped: `IOSDocumentSession.open` already calls `ensureDownloaded` on navigation, and the detail view already renders "Downloading from iCloud…" — adding a second download handler layered on `NavigationLink` would have risked gesture conflicts.

Spec: `docs/mobile/IMPLEMENTATION.md:267-294`. Progress log + decisions in `docs/mobile/PROGRESS.md`.

## Test plan
- [x] Mac Debug: `xcodebuild -scheme Clearly -configuration Debug build` — passed.
- [x] iOS Debug: `xcodebuild -scheme Clearly-iOS -configuration Debug -destination 'generic/platform=iOS Simulator' build` — passed.
- [x] CLI integration: `xcodebuild -scheme ClearlyCLIIntegrationTests test` — 23/23 passed.
- [ ] **Manual (iPhone 17 / iOS 26.4 sim):** launch app, pick iCloud or local vault, expect thin progress bar under nav bar while indexing, then disappearing.
- [ ] **Manual (sim):** drop a new `.md` into the vault; within ~1s the new file should be reflected in the index (observable via Phase 9 search once that ships — for Phase 8, check `~/Library/Developer/CoreSimulator/.../Library/Caches/indexes/*.sqlite` row count).
- [ ] **Manual (real iOS + iCloud device):** confirm placeholder files get auto-downloaded at first index pass and on re-index when watcher fires.
- [ ] **Manual (sim):** tap folder icon → pick a different vault; confirm a new `<hash>.sqlite` appears in Caches, prior one remains (per-path-hash).
- [ ] **Manual (Mac regression):** Cmd+P quick switcher still returns results; Mac Application Support index path unchanged.