### PR TITLE
Sidebar context menu: New File / New Folder on Mac and iOS

### DIFF
--- a/Clearly/FileWatcher.swift
+++ b/Clearly/FileWatcher.swift
@@ -35,10 +35,14 @@ final class FileWatcher: ObservableObject {
         guard fd != -1 else { return }
         fileDescriptor = fd
 
+        // Main-queue so instance state (`source`, `debounceWork`,
+        // `monitoredURL`) is only ever touched from the main thread. Without
+        // this the save path's atomic-rename event and SwiftUI's follow-up
+        // `watch()` call race on the same ivars and crash on zombie release.
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
             eventMask: [.write, .delete, .rename, .link, .extend, .attrib],
-            queue: .global(qos: .utility)
+            queue: .main
         )
 
         source.setEventHandler { [weak self] in
@@ -47,7 +51,7 @@ final class FileWatcher: ObservableObject {
             if flags.contains(.delete) || flags.contains(.rename) {
                 // Atomic save: file was replaced. Tear down and re-establish.
                 self.stopMonitoring()
-                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                     guard let self, let url = self.monitoredURL else { return }
                     self.startMonitoring(url)
                     self.readAndNotify()
@@ -79,7 +83,7 @@ final class FileWatcher: ObservableObject {
             self?.readAndNotify()
         }
         debounceWork = work
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3, execute: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
     }
 
     private func readAndNotify() {
@@ -87,23 +91,20 @@ final class FileWatcher: ObservableObject {
         guard let data = try? Data(contentsOf: url),
               let newText = String(data: data, encoding: .utf8) else { return }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            guard newText != self.lastKnownDiskText else { return }
+        guard newText != lastKnownDiskText else { return }
 
-            if let liveCurrentText = self.liveCurrentText?() {
-                self.currentText = liveCurrentText
-            }
-            let hasUnsavedChanges = self.currentText != self.lastKnownDiskText
-            self.lastKnownDiskText = newText
-
-            guard !hasUnsavedChanges else {
-                DiagnosticLog.log("External file change ignored: unsaved local edits")
-                return
-            }
-
-            self.currentText = newText
-            self.onChange?(newText)
+        if let liveCurrentText = liveCurrentText?() {
+            currentText = liveCurrentText
         }
+        let hasUnsavedChanges = currentText != lastKnownDiskText
+        lastKnownDiskText = newText
+
+        guard !hasUnsavedChanges else {
+            DiagnosticLog.log("External file change ignored: unsaved local edits")
+            return
+        }
+
+        currentText = newText
+        onChange?(newText)
     }
 }

--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -136,6 +136,13 @@ struct MacFolderSidebar: View {
                 isExpanded: locationExpandedBinding(location)
             )
             .contextMenu {
+                Button("New File", systemImage: "doc.badge.plus") {
+                    createNewFile(in: location.url)
+                }
+                Button("New Folder…", systemImage: "folder.badge.plus") {
+                    promptForNewFolder(in: location.url)
+                }
+                Divider()
                 Button("Reveal in Finder", systemImage: "folder") {
                     NSWorkspace.shared.activateFileViewerSelecting([location.url])
                 }
@@ -265,12 +272,51 @@ struct MacFolderSidebar: View {
 
     @ViewBuilder
     private func folderContextMenu(url: URL) -> some View {
+        Button("New File", systemImage: "doc.badge.plus") {
+            createNewFile(in: url)
+        }
+        Button("New Folder…", systemImage: "folder.badge.plus") {
+            promptForNewFolder(in: url)
+        }
+        Divider()
         Button("Customize…", systemImage: "paintpalette") {
             customizingFolderURL = url
         }
         Divider()
         Button("Reveal in Finder", systemImage: "folder") {
             NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+    }
+
+    private func createNewFile(in folder: URL) {
+        _ = workspace.createUntitledFileInFolder(folder)
+    }
+
+    private func promptForNewFolder(in parent: URL) {
+        let alert = NSAlert()
+        alert.messageText = "New Folder"
+        alert.informativeText = "Enter a name for the new folder."
+        alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: "Cancel")
+
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        textField.placeholderString = "Folder name"
+        alert.accessoryView = textField
+        alert.window.initialFirstResponder = textField
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let name = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+
+        do {
+            _ = try workspace.createFolder(named: name, in: parent)
+        } catch {
+            let failure = NSAlert()
+            failure.messageText = "Couldn't create folder"
+            failure.informativeText = error.localizedDescription
+            failure.alertStyle = .warning
+            failure.addButton(withTitle: "OK")
+            failure.runModal()
         }
     }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -169,6 +169,70 @@ final class WorkspaceManager {
         return true
     }
 
+    /// Create an empty `untitled.md` (or `untitled-2.md`, …) inside `folder`
+    /// and open it in the active tab. Returns the new file URL on success.
+    /// The file auto-renames from its first heading/line on the next save.
+    /// If opening the file fails (e.g. the user cancels the save-dirty-doc
+    /// prompt), the just-created empty file is deleted so the vault doesn't
+    /// accumulate ghost notes.
+    @discardableResult
+    func createUntitledFileInFolder(_ folder: URL) -> URL? {
+        let url = UntitledRename.nextUntitledURL(in: folder)
+        do {
+            try CoordinatedFileIO.write(Data(), to: url)
+        } catch {
+            DiagnosticLog.log("Failed to create untitled file in \(folder.lastPathComponent): \(error.localizedDescription)")
+            return nil
+        }
+        revealFolderInSidebar(folder)
+        guard openFile(at: url) else {
+            try? CoordinatedFileIO.delete(at: url)
+            return nil
+        }
+        return url
+    }
+
+    /// Create a new folder inside `parent`. Name is kebab-sanitized for
+    /// filesystem consistency. Throws if the name is empty or a folder with
+    /// that name already exists. Returns the created folder URL.
+    @discardableResult
+    func createFolder(named name: String, in parent: URL) throws -> URL {
+        let cleanName = UntitledRename.sanitizeKebab(name)
+        guard !cleanName.isEmpty else {
+            throw NSError(domain: "ClearlyWorkspace", code: 1, userInfo: [NSLocalizedDescriptionKey: "Folder name is empty."])
+        }
+        let folderURL = parent.appendingPathComponent(cleanName)
+        if FileManager.default.fileExists(atPath: folderURL.path) {
+            throw NSError(domain: "ClearlyWorkspace", code: 2, userInfo: [NSLocalizedDescriptionKey: "A folder with that name already exists."])
+        }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: false)
+        revealFolderInSidebar(parent)
+        return folderURL
+    }
+
+    /// Makes sure `folder` is visible in the sidebar: un-collapses its owning
+    /// location if `folder` is the vault root, expands the disclosure group
+    /// otherwise, and kicks a debounced tree refresh so the new child shows.
+    private func revealFolderInSidebar(_ folder: URL) {
+        let target = folder.standardizedFileURL.path
+        var matchedLocationID: UUID?
+        for loc in locations {
+            let root = loc.url.standardizedFileURL.path
+            guard target == root || target.hasPrefix(root + "/") else { continue }
+            matchedLocationID = loc.id
+            if target == root {
+                setLocationCollapsed(false, for: loc.id.uuidString)
+            }
+            break
+        }
+        if matchedLocationID != nil {
+            setFolderExpanded(true, for: folder)
+            if let id = matchedLocationID {
+                refreshTree(for: id)
+            }
+        }
+    }
+
     @discardableResult
     func createDocumentWithContent(_ content: String) -> Bool {
         guard saveFileBacked() else { return false }
@@ -534,14 +598,32 @@ final class WorkspaceManager {
             try doc.text.write(to: url, atomically: true, encoding: .utf8)
             openDocuments[index].lastSavedText = doc.text
 
+            let finalURL: URL
+            if let renamedURL = UntitledRename.proposedRenameURL(for: url, text: doc.text) {
+                do {
+                    try CoordinatedFileIO.move(from: url, to: renamedURL)
+                    rewriteMovedItemReferences(from: url, to: renamedURL)
+                    finalURL = renamedURL
+                    DiagnosticLog.log("Auto-renamed \(url.lastPathComponent) → \(renamedURL.lastPathComponent)")
+                } catch {
+                    DiagnosticLog.log("Auto-rename failed for \(url.lastPathComponent): \(error.localizedDescription)")
+                    finalURL = url
+                }
+            } else {
+                finalURL = url
+            }
+
             if activeDocumentIndex == index {
-                currentFileURL = url
+                currentFileURL = finalURL
                 currentFileText = doc.text
                 lastSavedText = doc.text
                 isDirty = false
+                if finalURL != url {
+                    persistLastOpenFile(finalURL)
+                }
             }
 
-            addToRecents(url)
+            addToRecents(finalURL)
             return true
         } catch {
             DiagnosticLog.log("Failed to save file: \(error.localizedDescription)")
@@ -872,18 +954,6 @@ final class WorkspaceManager {
             return fileURL
         } catch {
             DiagnosticLog.log("Failed to create file: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    func createFolder(named name: String, in parentURL: URL) -> URL? {
-        let folderURL = parentURL.appendingPathComponent(name)
-        do {
-            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: false)
-            DiagnosticLog.log("Created folder: \(name)")
-            return folderURL
-        } catch {
-            DiagnosticLog.log("Failed to create folder: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -197,7 +197,7 @@ final class WorkspaceManager {
     /// that name already exists. Returns the created folder URL.
     @discardableResult
     func createFolder(named name: String, in parent: URL) throws -> URL {
-        let cleanName = UntitledRename.sanitizeKebab(name)
+        let cleanName = UntitledRename.sanitizeFilename(name)
         guard !cleanName.isEmpty else {
             throw NSError(domain: "ClearlyWorkspace", code: 1, userInfo: [NSLocalizedDescriptionKey: "Folder name is empty."])
         }

--- a/Clearly/iOS/FolderListView_iOS.swift
+++ b/Clearly/iOS/FolderListView_iOS.swift
@@ -20,6 +20,7 @@ struct FolderListView_iOS: View {
 
     @State private var isCreatingFolder: Bool = false
     @State private var newFolderDraft: String = ""
+    @State private var pendingFolderParent: URL?
     @State private var operationError: String?
 
     /// Matches `IPadRootView.allNotesSentinel` so the two layouts route folder
@@ -74,10 +75,13 @@ struct FolderListView_iOS: View {
             TextField("Name", text: $newFolderDraft)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
-            Button("Cancel", role: .cancel) { newFolderDraft = "" }
+            Button("Cancel", role: .cancel) {
+                newFolderDraft = ""
+                pendingFolderParent = nil
+            }
             Button("Create") { commitCreateFolder() }
         } message: {
-            Text("Name this folder. It will be created in \(session.currentVault?.displayName ?? "the vault").")
+            Text("Name this folder. It will be created in \(newFolderLocationDescription).")
         }
         .alert(
             "Something went wrong",
@@ -123,6 +127,18 @@ struct FolderListView_iOS: View {
                             NavigationLink(value: node.url) {
                                 Label(node.name, systemImage: "folder")
                                     .badge(fileCount(in: node.url))
+                            }
+                            .contextMenu {
+                                Button {
+                                    createFile(in: node.url)
+                                } label: {
+                                    Label("New File", systemImage: "doc.badge.plus")
+                                }
+                                Button {
+                                    beginCreateFolder(in: node.url)
+                                } label: {
+                                    Label("New Folder", systemImage: "folder.badge.plus")
+                                }
                             }
                         }
                     } header: {
@@ -211,19 +227,22 @@ struct FolderListView_iOS: View {
         }
     }
 
-    // MARK: - Create folder
+    // MARK: - Create folder / file
 
-    private func beginCreateFolder() {
+    private func beginCreateFolder(in parent: URL? = nil) {
         newFolderDraft = ""
+        pendingFolderParent = parent
         isCreatingFolder = true
     }
 
     private func commitCreateFolder() {
         let name = newFolderDraft
+        let parent = pendingFolderParent
         newFolderDraft = ""
+        pendingFolderParent = nil
         Task {
             do {
-                let url = try await session.createFolder(named: name, in: nil)
+                let url = try await session.createFolder(named: name, in: parent)
                 await MainActor.run {
                     rebuildFolderTree()
                     navPath.append(url)
@@ -234,6 +253,28 @@ struct FolderListView_iOS: View {
                 operationError = error.localizedDescription
             }
         }
+    }
+
+    private func createFile(in folder: URL) {
+        Task {
+            do {
+                let file = try await session.createUntitledNote(in: folder)
+                await MainActor.run {
+                    rebuildFolderTree()
+                    navPath.append(file)
+                    session.markRecent(file)
+                }
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private var newFolderLocationDescription: String {
+        if let parent = pendingFolderParent {
+            return parent.lastPathComponent
+        }
+        return session.currentVault?.displayName ?? "the vault"
     }
 
     // MARK: - Welcome

--- a/Clearly/iOS/IPadRootView.swift
+++ b/Clearly/iOS/IPadRootView.swift
@@ -39,6 +39,7 @@ struct IPadRootView: View {
 
     @State private var isCreatingFolder: Bool = false
     @State private var newFolderDraft: String = ""
+    @State private var explicitFolderParent: URL?
 
     var body: some View {
         @Bindable var session = session
@@ -106,7 +107,10 @@ struct IPadRootView: View {
             TextField("Name", text: $newFolderDraft)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
-            Button("Cancel", role: .cancel) { newFolderDraft = "" }
+            Button("Cancel", role: .cancel) {
+                newFolderDraft = ""
+                explicitFolderParent = nil
+            }
             Button("Create") { commitCreateFolder() }
         } message: {
             Text("Name this folder. It will be created inside \(newFolderParentName).")
@@ -174,6 +178,18 @@ struct IPadRootView: View {
                     Label(node.name, systemImage: "folder")
                         .badge(fileCount(in: node.url))
                         .tag(node.url)
+                        .contextMenu {
+                            Button {
+                                createFile(in: node.url)
+                            } label: {
+                                Label("New File", systemImage: "doc.badge.plus")
+                            }
+                            Button {
+                                beginCreateFolder(in: node.url)
+                            } label: {
+                                Label("New Folder", systemImage: "folder.badge.plus")
+                            }
+                        }
                 }
             } header: {
                 Text(vaultSectionTitle)
@@ -462,22 +478,28 @@ struct IPadRootView: View {
 
     // MARK: - Create folder
 
-    /// Where the new folder should be created. Same precedence as new-note
-    /// placement: a selected folder becomes the parent, "All Notes" means
-    /// the vault root.
+    /// Where the new folder should be created. Context-menu selection wins
+    /// over sidebar selection; toolbar fires with no explicit parent so it
+    /// falls back to the selection-based rule (selected folder, or vault
+    /// root when "All Notes" is selected).
     private var newFolderParent: URL? {
-        isAllNotesSelected ? nil : selectedFolderURL
+        if let explicit = explicitFolderParent { return explicit }
+        return isAllNotesSelected ? nil : selectedFolderURL
     }
 
     private var newFolderParentName: String {
+        if let explicit = explicitFolderParent {
+            return explicit.lastPathComponent
+        }
         if isAllNotesSelected {
             return session.currentVault?.displayName ?? "the vault"
         }
         return selectedFolderURL?.lastPathComponent ?? "the vault"
     }
 
-    private func beginCreateFolder() {
+    private func beginCreateFolder(in parent: URL? = nil) {
         newFolderDraft = ""
+        explicitFolderParent = parent
         isCreatingFolder = true
     }
 
@@ -485,6 +507,7 @@ struct IPadRootView: View {
         let name = newFolderDraft
         newFolderDraft = ""
         let parent = newFolderParent
+        explicitFolderParent = nil
         Task {
             do {
                 let url = try await session.createFolder(named: name, in: parent)
@@ -494,6 +517,21 @@ struct IPadRootView: View {
                 }
             } catch VaultSessionError.readFailed(let msg) {
                 operationError = msg
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func createFile(in folder: URL) {
+        Task {
+            do {
+                let file = try await session.createUntitledNote(in: folder)
+                await MainActor.run {
+                    rebuildFolderTree()
+                    selectedFolderURL = folder
+                    controller.openExclusive(file)
+                }
             } catch {
                 operationError = error.localizedDescription
             }

--- a/Clearly/iOS/QuickSwitcherSheet_iOS.swift
+++ b/Clearly/iOS/QuickSwitcherSheet_iOS.swift
@@ -291,7 +291,7 @@ struct QuickSwitcherSheet_iOS: View {
         if stem.lowercased().hasSuffix(".md") {
             stem = String(stem.dropLast(3))
         }
-        let sanitized = UntitledRename.sanitizeKebab(stem)
+        let sanitized = UntitledRename.sanitizeFilename(stem)
         guard !sanitized.isEmpty else { return "untitled.md" }
         return "\(sanitized).md"
     }

--- a/Clearly/iOS/QuickSwitcherSheet_iOS.swift
+++ b/Clearly/iOS/QuickSwitcherSheet_iOS.swift
@@ -291,7 +291,7 @@ struct QuickSwitcherSheet_iOS: View {
         if stem.lowercased().hasSuffix(".md") {
             stem = String(stem.dropLast(3))
         }
-        let sanitized = VaultSession.sanitizeKebab(stem)
+        let sanitized = UntitledRename.sanitizeKebab(stem)
         guard !sanitized.isEmpty else { return "untitled.md" }
         return "\(sanitized).md"
     }

--- a/Packages/ClearlyCore/Package.resolved
+++ b/Packages/ClearlyCore/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "564c09efb10a7f03a559fa7e1c2130f8384ddf1aa72d3668daa80157dcdbc645",
   "pins" : [
     {
       "identity" : "cmark-gfm",
@@ -109,5 +110,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/UntitledRename.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/UntitledRename.swift
@@ -13,13 +13,14 @@ public enum UntitledRename {
 
     /// Destination URL for an auto-rename if `url` is currently named
     /// `untitled*`, `text` yields a non-empty sanitized first heading/line,
-    /// and a collision-free slot (`stem.ext` or `stem-N.ext`) exists in the
-    /// same parent directory. `nil` otherwise.
+    /// and a collision-free slot (`stem.ext` or `stem N.ext`) exists in the
+    /// same parent directory. `nil` otherwise. Casing and spaces from the
+    /// source text are preserved — only filesystem-invalid chars are stripped.
     public static func proposedRenameURL(for url: URL, text: String) -> URL? {
         let stem = (url.lastPathComponent as NSString).deletingPathExtension
         guard isUntitledStem(stem) else { return nil }
         guard let rawTitle = extractTitle(from: text) else { return nil }
-        let sanitized = sanitizeKebab(rawTitle)
+        let sanitized = sanitizeFilename(rawTitle)
         guard !sanitized.isEmpty, sanitized != stem else { return nil }
 
         let parent = url.deletingLastPathComponent()
@@ -29,46 +30,44 @@ public enum UntitledRename {
         var attempt = 1
         while FileManager.default.fileExists(atPath: parent.appendingPathComponent("\(candidate).\(ext)").path) {
             attempt += 1
-            candidate = "\(sanitized)-\(attempt)"
+            candidate = "\(sanitized) \(attempt)"
             if attempt > 50 { return nil }
         }
         return parent.appendingPathComponent("\(candidate).\(ext)")
     }
 
-    /// Next available `untitled.md` / `untitled-2.md` / … URL inside `parent`.
+    /// Next available `untitled.md` / `untitled 2.md` / … URL inside `parent`.
     public static func nextUntitledURL(in parent: URL, extension ext: String = "md") -> URL {
         var attempt = 0
         var url: URL
         repeat {
             attempt += 1
-            let name = attempt == 1 ? "untitled.\(ext)" : "untitled-\(attempt).\(ext)"
+            let name = attempt == 1 ? "untitled.\(ext)" : "untitled \(attempt).\(ext)"
             url = parent.appendingPathComponent(name)
         } while FileManager.default.fileExists(atPath: url.path)
         return url
     }
 
-    /// Sanitize into strict kebab-case: ASCII letters/digits only, dashes as
-    /// separators, accented chars transliterated, runs collapsed, 80-char cap.
-    /// Idempotent — safe to call on already-kebab input.
-    public static func sanitizeKebab(_ raw: String) -> String {
-        let mutable = NSMutableString(string: raw)
-        CFStringTransform(mutable, nil, "Any-Latin; Latin-ASCII" as CFString, false)
-        let lowered = String(mutable).lowercased()
-
+    /// Lightly sanitize a filename stem: strip `/`, `\`, `:`, `?`, `*`, `"`,
+    /// `<`, `>`, `|`, NUL, and control characters; trim surrounding
+    /// whitespace; drop any leading dot so the file isn't hidden; cap at
+    /// 240 characters so there's room for the extension and a collision
+    /// suffix under APFS's 255-byte filename limit. Casing and internal
+    /// spaces are preserved exactly as typed.
+    public static func sanitizeFilename(_ raw: String) -> String {
+        let forbidden: Set<Character> = ["/", "\\", ":", "?", "*", "\"", "<", ">", "|"]
         var result = ""
-        var inDashRun = true
-        for char in lowered {
-            if char.isASCII && (char.isLetter || char.isNumber) {
-                result.append(char)
-                inDashRun = false
-            } else if !inDashRun {
-                result.append("-")
-                inDashRun = true
+        for char in raw {
+            if forbidden.contains(char) { continue }
+            if char.unicodeScalars.contains(where: { $0.value == 0 || $0.properties.generalCategory == .control }) {
+                continue
             }
+            result.append(char)
         }
-        while result.hasSuffix("-") { result.removeLast() }
-        if result.count > 80 { result = String(result.prefix(80)) }
-        return result
+        var trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        while trimmed.hasPrefix(".") { trimmed.removeFirst() }
+        if trimmed.count > 240 { trimmed = String(trimmed.prefix(240)) }
+        return trimmed
     }
 
     static func extractTitle(from text: String) -> String? {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/UntitledRename.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/UntitledRename.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Notes.app-style auto-rename helpers for `untitled.md` vault files. Pure
+/// logic kept out of `VaultSession` (iOS-only) so Mac's `WorkspaceManager`
+/// can derive identical rename targets on save.
+public enum UntitledRename {
+    /// Matches `untitled`, `untitled-2`, `untitled 2`, `Untitled`, `Untitled 2`, …
+    /// Case-insensitive, accepts space and dash separators so legacy
+    /// title-case files still trigger auto-rename after the kebab pivot.
+    public static func isUntitledStem(_ stem: String) -> Bool {
+        return stem.range(of: #"^untitled([\s-]\d+)?$"#, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+
+    /// Destination URL for an auto-rename if `url` is currently named
+    /// `untitled*`, `text` yields a non-empty sanitized first heading/line,
+    /// and a collision-free slot (`stem.ext` or `stem-N.ext`) exists in the
+    /// same parent directory. `nil` otherwise.
+    public static func proposedRenameURL(for url: URL, text: String) -> URL? {
+        let stem = (url.lastPathComponent as NSString).deletingPathExtension
+        guard isUntitledStem(stem) else { return nil }
+        guard let rawTitle = extractTitle(from: text) else { return nil }
+        let sanitized = sanitizeKebab(rawTitle)
+        guard !sanitized.isEmpty, sanitized != stem else { return nil }
+
+        let parent = url.deletingLastPathComponent()
+        let ext = url.pathExtension.isEmpty ? "md" : url.pathExtension
+
+        var candidate = sanitized
+        var attempt = 1
+        while FileManager.default.fileExists(atPath: parent.appendingPathComponent("\(candidate).\(ext)").path) {
+            attempt += 1
+            candidate = "\(sanitized)-\(attempt)"
+            if attempt > 50 { return nil }
+        }
+        return parent.appendingPathComponent("\(candidate).\(ext)")
+    }
+
+    /// Next available `untitled.md` / `untitled-2.md` / … URL inside `parent`.
+    public static func nextUntitledURL(in parent: URL, extension ext: String = "md") -> URL {
+        var attempt = 0
+        var url: URL
+        repeat {
+            attempt += 1
+            let name = attempt == 1 ? "untitled.\(ext)" : "untitled-\(attempt).\(ext)"
+            url = parent.appendingPathComponent(name)
+        } while FileManager.default.fileExists(atPath: url.path)
+        return url
+    }
+
+    /// Sanitize into strict kebab-case: ASCII letters/digits only, dashes as
+    /// separators, accented chars transliterated, runs collapsed, 80-char cap.
+    /// Idempotent — safe to call on already-kebab input.
+    public static func sanitizeKebab(_ raw: String) -> String {
+        let mutable = NSMutableString(string: raw)
+        CFStringTransform(mutable, nil, "Any-Latin; Latin-ASCII" as CFString, false)
+        let lowered = String(mutable).lowercased()
+
+        var result = ""
+        var inDashRun = true
+        for char in lowered {
+            if char.isASCII && (char.isLetter || char.isNumber) {
+                result.append(char)
+                inDashRun = false
+            } else if !inDashRun {
+                result.append("-")
+                inDashRun = true
+            }
+        }
+        while result.hasSuffix("-") { result.removeLast() }
+        if result.count > 80 { result = String(result.prefix(80)) }
+        return result
+    }
+
+    static func extractTitle(from text: String) -> String? {
+        let stripped = stripLeadingFrontmatter(text)
+        for raw in stripped.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if trimmed.hasPrefix("#") {
+                let withoutHashes = String(trimmed.drop(while: { $0 == "#" }))
+                let cleaned = withoutHashes.trimmingCharacters(in: .whitespacesAndNewlines)
+                return cleaned.isEmpty ? nil : cleaned
+            }
+            return trimmed
+        }
+        return nil
+    }
+
+    static func stripLeadingFrontmatter(_ text: String) -> String {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return text }
+        var endIdx: Int?
+        for i in 1..<lines.count where lines[i].trimmingCharacters(in: .whitespaces) == "---" {
+            endIdx = i
+            break
+        }
+        guard let endIdx else { return text }
+        return lines[(endIdx + 1)...].joined(separator: "\n")
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -431,7 +431,7 @@ public final class VaultSession {
         guard let vault = currentVault else {
             throw VaultSessionError.readFailed("no vault attached")
         }
-        let cleanName = UntitledRename.sanitizeKebab(name)
+        let cleanName = UntitledRename.sanitizeFilename(name)
         guard !cleanName.isEmpty else {
             throw VaultSessionError.readFailed("folder name is empty")
         }
@@ -513,7 +513,7 @@ public final class VaultSession {
             }
             return trimmed
         }()
-        let stem = UntitledRename.sanitizeKebab(preExt)
+        let stem = UntitledRename.sanitizeFilename(preExt)
         guard !stem.isEmpty else {
             throw VaultSessionError.readFailed("new name is empty")
         }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -401,98 +401,22 @@ public final class VaultSession {
     /// on success, `nil` if no rename was applicable. Once the file has any
     /// other name, this method is a no-op — manual renames stick.
     public func autoRenameUntitledIfApplicable(_ file: VaultFile, basedOn text: String) async -> VaultFile? {
-        let stem = (file.name as NSString).deletingPathExtension
-        guard Self.isUntitledStem(stem) else { return nil }
-        guard let rawTitle = Self.extractTitleForAutoRename(from: text) else { return nil }
-        let sanitized = Self.sanitizeKebab(rawTitle)
-        guard !sanitized.isEmpty, sanitized != stem else { return nil }
-
-        let parent = file.url.deletingLastPathComponent()
-        let ext = file.url.pathExtension.isEmpty ? "md" : file.url.pathExtension
-
-        var candidate = sanitized
-        var attempt = 1
-        while FileManager.default.fileExists(atPath: parent.appendingPathComponent("\(candidate).\(ext)").path) {
-            attempt += 1
-            candidate = "\(sanitized)-\(attempt)"
-            if attempt > 50 { return nil }
+        guard let destURL = UntitledRename.proposedRenameURL(for: file.url, text: text) else {
+            return nil
         }
-
+        let newStem = (destURL.lastPathComponent as NSString).deletingPathExtension
         do {
-            try await renameFile(file, to: candidate)
+            try await renameFile(file, to: newStem)
         } catch {
             DiagnosticLog.log("auto-rename failed for \(file.name): \(error.localizedDescription)")
             return nil
         }
-        let newURL = parent.appendingPathComponent("\(candidate).\(ext)")
         return VaultFile(
-            url: newURL,
-            name: "\(candidate).\(ext)",
+            url: destURL,
+            name: destURL.lastPathComponent,
             modified: Date(),
             isPlaceholder: false
         )
-    }
-
-    /// Matches `untitled`, `untitled-2`, `untitled 2`, `Untitled`, `Untitled 2`, …
-    /// Case-insensitive, accepts both space and dash separators, so legacy
-    /// title-case files still trigger auto-rename after the kebab pivot.
-    private static func isUntitledStem(_ stem: String) -> Bool {
-        return stem.range(of: #"^untitled([\s-]\d+)?$"#, options: [.regularExpression, .caseInsensitive]) != nil
-    }
-
-    private static func extractTitleForAutoRename(from text: String) -> String? {
-        let stripped = Self.stripLeadingFrontmatter(text)
-        for raw in stripped.split(separator: "\n", omittingEmptySubsequences: false) {
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            if trimmed.hasPrefix("#") {
-                let withoutHashes = String(trimmed.drop(while: { $0 == "#" }))
-                let cleaned = withoutHashes.trimmingCharacters(in: .whitespacesAndNewlines)
-                return cleaned.isEmpty ? nil : cleaned
-            }
-            return trimmed
-        }
-        return nil
-    }
-
-    private static func stripLeadingFrontmatter(_ text: String) -> String {
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return text }
-        var endIdx: Int?
-        for i in 1..<lines.count where lines[i].trimmingCharacters(in: .whitespaces) == "---" {
-            endIdx = i
-            break
-        }
-        guard let endIdx else { return text }
-        return lines[(endIdx + 1)...].joined(separator: "\n")
-    }
-
-    /// Sanitize a string into a strict kebab-case filename stem: only ASCII
-    /// letters (a–z) and digits (0–9), separated by single dashes. Accented
-    /// characters are transliterated to ASCII first ("café" → "cafe"),
-    /// emoji / punctuation / other non-alphanumerics become dash separators,
-    /// runs of separators collapse to one dash, leading/trailing dashes are
-    /// trimmed, and the result is capped at 80 chars. Idempotent — safe to
-    /// call on already-kebab-cased input.
-    public static func sanitizeKebab(_ raw: String) -> String {
-        let mutable = NSMutableString(string: raw)
-        CFStringTransform(mutable, nil, "Any-Latin; Latin-ASCII" as CFString, false)
-        let lowered = String(mutable).lowercased()
-
-        var result = ""
-        var inDashRun = true // treat start as "just emitted a dash" so leading non-alnum is dropped
-        for char in lowered {
-            if char.isASCII && (char.isLetter || char.isNumber) {
-                result.append(char)
-                inDashRun = false
-            } else if !inDashRun {
-                result.append("-")
-                inDashRun = true
-            }
-        }
-        while result.hasSuffix("-") { result.removeLast() }
-        if result.count > 80 { result = String(result.prefix(80)) }
-        return result
     }
 
     /// Create an empty `Untitled.md` (or `Untitled 2.md`, `Untitled 3.md`, …) at the
@@ -507,7 +431,7 @@ public final class VaultSession {
         guard let vault = currentVault else {
             throw VaultSessionError.readFailed("no vault attached")
         }
-        let cleanName = Self.sanitizeKebab(name)
+        let cleanName = UntitledRename.sanitizeKebab(name)
         guard !cleanName.isEmpty else {
             throw VaultSessionError.readFailed("folder name is empty")
         }
@@ -541,14 +465,8 @@ public final class VaultSession {
             let root = vault.url.standardizedFileURL.path
             return standardized.hasPrefix(root) ? parent : vault.url
         }()
-        var attempt = 0
-        var url: URL
-        var filename: String
-        repeat {
-            attempt += 1
-            filename = attempt == 1 ? "untitled.md" : "untitled-\(attempt).md"
-            url = target.appendingPathComponent(filename)
-        } while FileManager.default.fileExists(atPath: url.path)
+        let url = UntitledRename.nextUntitledURL(in: target)
+        let filename = url.lastPathComponent
 
         try await Task.detached(priority: .userInitiated) {
             try CoordinatedFileIO.write(Data(), to: url)
@@ -595,7 +513,7 @@ public final class VaultSession {
             }
             return trimmed
         }()
-        let stem = Self.sanitizeKebab(preExt)
+        let stem = UntitledRename.sanitizeKebab(preExt)
         guard !stem.isEmpty else {
             throw VaultSessionError.readFailed("new name is empty")
         }


### PR DESCRIPTION
## Summary
- Right-click on Mac (and long-press on iOS) any folder row — including the vault-root — to create a new file or folder inside it. New File creates `untitled.md`, opens it immediately, and auto-renames from the first heading/line on the next save.
- Mac gets parity with iOS's Notes.app-style auto-rename via a new shared `UntitledRename` helper in `ClearlyCore`; `VaultSession` now delegates to it and the iOS quick switcher shares the same kebab sanitizer.
- Safety: if opening the new file fails (e.g. user cancels the "save dirty doc?" prompt), the stub is deleted so vaults don't collect ghost notes; creating from a collapsed vault-root header now un-collapses the section so the new item is visible.

## Test plan
- [ ] Mac: right-click a sub-folder → New File → editor opens `untitled.md`; type `# Grocery list` → autosave renames to `grocery-list.md` in tab title and sidebar.
- [ ] Mac: right-click the vault-root header → New Folder → dialog prompts, created folder appears; repeat with the section collapsed and confirm it expands.
- [ ] iOS (iPhone + iPad): long-press a folder row → New File creates and opens; New Folder alert prompts for the correct parent.
- [ ] Toolbar "+" in both iOS views still creates at vault root (no regression).