### PR TITLE
Multiplatform issue templates + in-app Report a Bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,16 @@ name: Bug Report
 description: Something isn't working right
 labels: ["bug"]
 body:
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Platform(s) affected
+      description: Tick every platform where you can reproduce this bug.
+      options:
+        - label: macOS
+        - label: iOS
+        - label: iPadOS
+
   - type: textarea
     id: description
     attributes:
@@ -27,8 +37,8 @@ body:
     id: app-version
     attributes:
       label: App version
-      description: "Found in Clearly → Settings → About"
-      placeholder: "e.g. 1.7.4"
+      description: "macOS: Clearly → Settings → About. iOS/iPadOS: Settings screen."
+      placeholder: "e.g. 2.4.0 (240)"
     validations:
       required: true
 
@@ -38,20 +48,31 @@ body:
       label: Installation source
       description: How did you install Clearly?
       options:
-        - Direct download (from website or GitHub)
+        - Direct download (Sparkle / GitHub)
         - Mac App Store
+        - App Store (iPhone/iPad)
+        - TestFlight
         - Not sure
     validations:
       required: true
 
   - type: input
-    id: macos-version
+    id: os-version
     attributes:
-      label: macOS version
-      description: "Found in  → About This Mac"
-      placeholder: "e.g. 15.3"
+      label: OS version
+      description: "macOS:  → About This Mac. iOS/iPadOS: Settings → General → About → Software Version."
+      placeholder: "e.g. macOS 26.1, iOS 18.2, iPadOS 18.2"
     validations:
       required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device (iOS / iPadOS only)
+      description: "Settings → General → About → Model Name, or the hardware identifier (e.g. iPhone16,1)."
+      placeholder: "e.g. iPhone 15 Pro, iPad Air M2"
+    validations:
+      required: false
 
   - type: textarea
     id: screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,16 @@ name: Feature Request
 description: Suggest something new
 labels: ["enhancement"]
 body:
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Platform(s) this applies to
+      description: Tick every platform where this feature would be useful.
+      options:
+        - label: macOS
+        - label: iOS
+        - label: iPadOS
+
   - type: textarea
     id: description
     attributes:

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -758,6 +758,16 @@ struct ClearlyApp: App {
                 Button("Clearly Help") {
                     NSWorkspace.shared.open(URL(string: "https://github.com/Shpigford/clearly/issues")!)
                 }
+                Button("Report a Bug…") {
+                    let version = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "?"
+                    let build = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String) ?? "?"
+                    let url = BugReportURL.build(
+                        platform: .macOS,
+                        appVersion: "\(version) (\(build))",
+                        osVersion: ProcessInfo.processInfo.operatingSystemVersionString
+                    )
+                    NSWorkspace.shared.open(url)
+                }
                 Divider()
                 Button("Sample Document") {
                     if let url = Bundle.main.url(forResource: "demo", withExtension: "md"),

--- a/Clearly/iOS/SettingsView_iOS.swift
+++ b/Clearly/iOS/SettingsView_iOS.swift
@@ -1,11 +1,13 @@
 #if os(iOS)
 import SwiftUI
+import UIKit
 import ClearlyCore
 import Combine
 
 struct SettingsView_iOS: View {
     @Environment(VaultSession.self) private var session
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
 
     @State private var iCloudAvailable = FileManager.default.ubiquityIdentityToken != nil
     @State private var usage: VaultDiskUsage?
@@ -62,6 +64,14 @@ struct SettingsView_iOS: View {
                     Button("Refresh", action: recompute)
                         .disabled(computing || session.currentVault == nil)
                 }
+
+                Section("Help") {
+                    Button {
+                        openReportURL()
+                    } label: {
+                        Label("Report a Bug…", systemImage: "ladybug")
+                    }
+                }
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -102,6 +112,24 @@ struct SettingsView_iOS: View {
 
     private func formattedBytes(_ bytes: Int64) -> String {
         ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func openReportURL() {
+        let version = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "?"
+        let build = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String) ?? "?"
+        let platform: BugReportURL.Platform = UIDevice.current.userInterfaceIdiom == .pad ? .iPadOS : .iOS
+        var size = 0
+        sysctlbyname("hw.machine", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.machine", &machine, &size, nil, 0)
+        let hw = String(cString: machine)
+        let url = BugReportURL.build(
+            platform: platform,
+            appVersion: "\(version) (\(build))",
+            osVersion: "\(platform.rawValue) \(UIDevice.current.systemVersion)",
+            device: hw.isEmpty ? nil : hw
+        )
+        openURL(url)
     }
 }
 #endif

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Diagnostics/BugReportURL.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Diagnostics/BugReportURL.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum BugReportURL {
+    public enum Platform: String {
+        case macOS = "macOS"
+        case iOS = "iOS"
+        case iPadOS = "iPadOS"
+    }
+
+    public static func build(
+        platform _: Platform,
+        appVersion: String,
+        osVersion: String,
+        device: String? = nil,
+        repo: String = "Shpigford/clearly"
+    ) -> URL {
+        var components = URLComponents(string: "https://github.com/\(repo)/issues/new")!
+        var items: [URLQueryItem] = [
+            .init(name: "template", value: "bug_report.yml"),
+            .init(name: "app-version", value: appVersion),
+            .init(name: "os-version", value: osVersion),
+        ]
+        if let device, !device.isEmpty {
+            items.append(.init(name: "device", value: device))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/BugReportURLTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/BugReportURLTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import ClearlyCore
+
+final class BugReportURLTests: XCTestCase {
+    func testBuildPrefillsOnlySafeFormFields() throws {
+        let url = BugReportURL.build(
+            platform: .iOS,
+            appVersion: "2.4.0 (240)",
+            osVersion: "iOS 18.2",
+            device: "iPhone16,1"
+        )
+
+        let items = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+
+        XCTAssertEqual(item(named: "template", in: items), "bug_report.yml")
+        XCTAssertEqual(item(named: "app-version", in: items), "2.4.0 (240)")
+        XCTAssertEqual(item(named: "os-version", in: items), "iOS 18.2")
+        XCTAssertEqual(item(named: "device", in: items), "iPhone16,1")
+        XCTAssertNil(item(named: "labels", in: items))
+        XCTAssertNil(item(named: "description", in: items))
+    }
+
+    func testBuildOmitsEmptyDevice() throws {
+        let url = BugReportURL.build(
+            platform: .macOS,
+            appVersion: "2.4.0 (240)",
+            osVersion: "macOS 26.1",
+            device: ""
+        )
+
+        let items = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        XCTAssertNil(item(named: "device", in: items))
+    }
+
+    private func item(named name: String, in items: [URLQueryItem]) -> String? {
+        items.first(where: { $0.name == name })?.value
+    }
+}


### PR DESCRIPTION
## Summary
- Updates `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` with platform checkboxes (macOS / iOS / iPadOS), a generalized `os-version` input (replacing `macos-version`), an optional `device` input, and TestFlight / iPhone-iPad App Store entries in the install-source dropdown.
- Adds a `BugReportURL` helper in `ClearlyCore` that assembles a pre-filled `issues/new` URL from platform, app version, OS version, and optional device — with unit tests covering query-param shape and empty-device omission.
- Wires a "Report a Bug…" entry into the Mac Help menu and a Help section in `SettingsView_iOS`; the iOS path detects iPhone vs iPad and includes the `hw.machine` identifier.

## Test plan
- [ ] Merge to `main`, then hit the URL produced by the Mac Help button and verify `app-version` / `os-version` pre-fill populate the new form fields.
- [ ] Open iOS build, tap Settings → Report a Bug…, confirm Safari opens GitHub with platform, version, and device fields pre-filled.
- [ ] Tap Settings → Report a Bug… on an iPad target, confirm the platform reads as iPadOS.