### PR TITLE
[shared] Fix iOS crash when typing triggers stale edited range

### DIFF
--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -469,8 +469,19 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         let text = textStorage.string
         let nsText = text as NSString
 
-        // Compute the post-edit affected range and expand to paragraph boundaries
-        let postEditRange = NSRange(location: editedRange.location, length: replacementLength)
+        // Compute the post-edit affected range and expand to paragraph boundaries.
+        // iOS predictive text / marked-text composition can fire textViewDidChange
+        // without a matching shouldChangeTextIn, so the cached editedRange may no
+        // longer fit the live string. Validate before calling paragraphRange, which
+        // throws NSRangeException on out-of-bounds input.
+        let textLength = nsText.length
+        let safeLocation = max(0, min(editedRange.location, textLength))
+        let safeLength = max(0, min(replacementLength, textLength - safeLocation))
+        if safeLocation != editedRange.location || safeLength != replacementLength {
+            highlightAll(textStorage, caller: "\(caller)-stale-range")
+            return
+        }
+        let postEditRange = NSRange(location: safeLocation, length: safeLength)
         let paragraphRange = nsText.paragraphRange(for: postEditRange)
 
         // If the edited paragraph contains a block delimiter, the change could affect


### PR DESCRIPTION
## Summary
- iOS TestFlight crash on keystroke: `paragraphRange(for:)` in `MarkdownSyntaxHighlighter.highlightAround` threw `NSRangeException` when iOS predictive text / marked-text composition fired `textViewDidChange` without a paired `shouldChangeTextIn`, leaving `lastEditedRange` out of bounds for the live string.
- Guard the incoming range in the shared highlighter and fall back to `highlightAll` (with a `-stale-range` caller tag for diagnostics) instead of crashing. Covers iOS, Mac, and the scratchpad editor since all three share this code path.

## Test plan
- [x] `xcodebuild -scheme Clearly-iOS -destination 'generic/platform=iOS Simulator' build` — succeeds
- [x] `xcodebuild -scheme Clearly build` — succeeds
- [ ] Ship TestFlight build and confirm the reporter (@codejake) no longer hits the crash when typing after an H1