### PR TITLE
[mac] Settings from menu bar now opens in front (#201)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -53,16 +53,19 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     private var quickSwitcherMonitor: Any?
     private var themeObserver: Any?
     private var isProgrammaticallyClosingWindows = false
+    private weak var trackedSettingsWindow: NSWindow?
+    private var isOpeningSettingsFromMenuBar = false
 
     /// Returns the active main document window if SwiftUI has presented one.
     var mainWindow: NSWindow? {
         NSApp.windows.first { WindowRouter.isUserFacingDocumentWindow($0) }
     }
 
-    /// When true, `bringMainWindowToFrontIfNeeded()` is a no-op. Set briefly
-    /// while opening Settings from the menu bar popover so activating the app
-    /// doesn't also raise a hidden workspace window over the Settings window.
-    var suppressMainWindowFocus: Bool = false
+    /// Suppress document-window focus while menu-bar-driven Settings activation
+    /// is in flight or while the Settings window stays open.
+    var shouldSuppressMainWindowFocus: Bool {
+        isOpeningSettingsFromMenuBar || (trackedSettingsWindow != nil && trackedSettingsWindow?.isMiniaturized == false)
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
@@ -90,9 +93,12 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
         // Watch multiple signals — window close, app deactivate, main window change
         let nc = NotificationCenter.default
-        observers.append(nc.addObserver(forName: NSWindow.willCloseNotification, object: nil, queue: .main) { [weak self] _ in
+        observers.append(nc.addObserver(forName: NSWindow.willCloseNotification, object: nil, queue: .main) { [weak self] notification in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                if let window = notification.object as? NSWindow {
+                    self.clearTrackedSettingsWindow(window)
+                }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
                     self?.updateActivationPolicy()
                 }
@@ -555,11 +561,27 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     /// scene — we just need to bring whichever instance exists to the front on
     /// dock clicks and re-activation events.
     private func bringMainWindowToFrontIfNeeded() {
-        guard !suppressMainWindowFocus else { return }
+        guard !shouldSuppressMainWindowFocus else { return }
         guard isForegroundActivation, !ScratchpadManager.shared.hasOpenWindows else { return }
         if let window = NSApp.windows.first(where: { WindowRouter.isUserFacingDocumentWindow($0) }) {
             window.makeKeyAndOrderFront(nil)
         }
+    }
+
+    func prepareForMenuBarSettingsActivation() {
+        isOpeningSettingsFromMenuBar = true
+    }
+
+    func registerSettingsWindow(_ window: NSWindow) {
+        trackedSettingsWindow = window
+        isOpeningSettingsFromMenuBar = false
+    }
+
+    func clearTrackedSettingsWindow(_ window: NSWindow) {
+        if trackedSettingsWindow === window {
+            trackedSettingsWindow = nil
+        }
+        isOpeningSettingsFromMenuBar = false
     }
 
     func closeDocumentWindowsToMenuBar() {
@@ -904,6 +926,37 @@ struct ClearlyApp: App {
         }
     }
 
+}
+
+struct SettingsWindowObserver: NSViewRepresentable {
+    final class Holder {
+        weak var window: NSWindow?
+    }
+
+    func makeCoordinator() -> Holder { Holder() }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        registerWindow(from: view, context: context)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        registerWindow(from: nsView, context: context)
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Holder) {
+        guard let window = coordinator.window else { return }
+        ClearlyAppDelegate.shared?.clearTrackedSettingsWindow(window)
+    }
+
+    private func registerWindow(from view: NSView, context: Context) {
+        DispatchQueue.main.async { [weak view] in
+            guard let window = view?.window else { return }
+            context.coordinator.window = window
+            ClearlyAppDelegate.shared?.registerSettingsWindow(window)
+        }
+    }
 }
 
 struct FindCommand: View {

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -59,6 +59,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         NSApp.windows.first { WindowRouter.isUserFacingDocumentWindow($0) }
     }
 
+    /// When true, `bringMainWindowToFrontIfNeeded()` is a no-op. Set briefly
+    /// while opening Settings from the menu bar popover so activating the app
+    /// doesn't also raise a hidden workspace window over the Settings window.
+    var suppressMainWindowFocus: Bool = false
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
 
@@ -550,6 +555,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     /// scene — we just need to bring whichever instance exists to the front on
     /// dock clicks and re-activation events.
     private func bringMainWindowToFrontIfNeeded() {
+        guard !suppressMainWindowFocus else { return }
         guard isForegroundActivation, !ScratchpadManager.shared.hasOpenWindows else { return }
         if let window = NSApp.windows.first(where: { WindowRouter.isUserFacingDocumentWindow($0) }) {
             window.makeKeyAndOrderFront(nil)

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -72,13 +72,10 @@ struct ScratchpadMenuBar: View {
     private func performSettingsMenuBarAction() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let delegate = ClearlyAppDelegate.shared
-            delegate?.suppressMainWindowFocus = true
+            delegate?.prepareForMenuBarSettingsActivation()
             activateDocumentApp()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 openSettings()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    delegate?.suppressMainWindowFocus = false
-                }
             }
         }
     }

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -3,6 +3,7 @@ import KeyboardShortcuts
 
 struct ScratchpadMenuBar: View {
     var manager: ScratchpadManager
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         Button("New Scratchpad") {
@@ -48,8 +49,8 @@ struct ScratchpadMenuBar: View {
 
         Divider()
 
-        SettingsLink {
-            Text("Settings…")
+        Button("Settings…") {
+            performSettingsMenuBarAction()
         }
         .keyboardShortcut(",", modifiers: [.command])
 
@@ -64,6 +65,20 @@ struct ScratchpadMenuBar: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 WindowRouter.shared.showMainWindow()
                 action()
+            }
+        }
+    }
+
+    private func performSettingsMenuBarAction() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            let delegate = ClearlyAppDelegate.shared
+            delegate?.suppressMainWindowFocus = true
+            activateDocumentApp()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                openSettings()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    delegate?.suppressMainWindowFocus = false
+                }
             }
         }
     }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -42,6 +42,7 @@ struct SettingsView: View {
         }
         .frame(width: 460)
         .fixedSize(horizontal: false, vertical: true)
+        .background(SettingsWindowObserver())
     }
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled


### PR DESCRIPTION
## Summary

- Fixes #201: clicking **Settings…** in the menu bar popover used to open Settings behind other apps (and, after the first pass, also dragged the hidden workspace back on top of Settings).
- Replaces `SettingsLink` with a `Button` that runs the popover's existing `activateDocumentApp()` sequence, then calls `openSettings()`.
- Adds a lifecycle-tracked `shouldSuppressMainWindowFocus` flag on `ClearlyAppDelegate` so `bringMainWindowToFrontIfNeeded()` stays a no-op while Settings is open, preventing the workspace from being raised over it on activation.
- `SettingsWindowObserver` (an `NSViewRepresentable` attached to `SettingsView`) registers the Settings window on mount and clears it on close/dismantle.

## Test plan

- [ ] Launch Clearly, close the editor window, click another app so Clearly is background, open menu bar popover → **Settings…** — Settings appears in front; workspace stays closed.
- [ ] With Settings open, switch to another app and back to Clearly — Settings stays in front; workspace does not come up.
- [ ] Settings already open → popover → **Settings…** focuses the existing window (no duplicate).
- [ ] ⌘, from the main menu bar (app frontmost) still opens Settings.
- [ ] Close Settings → reopen workspace via dock click or `WindowRouter.showMainWindow()` → workspace behaves normally.