### PR TITLE
[mac] Recoverable CLI install UX + diagnostics (#218)

### DIFF
--- a/Clearly/CLIInstaller.swift
+++ b/Clearly/CLIInstaller.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ClearlyCore
 
 enum CLIInstaller {
     static let symlinkPath = "/usr/local/bin/clearly"
@@ -11,20 +12,38 @@ enum CLIInstaller {
 
     enum CLIInstallerError: LocalizedError {
         case notBundled
-        case terminalUnavailable
+        case wrongOwner(existingTarget: URL?)
+        case appleScriptCompileFailed
+        case terminalAutomationDenied(code: Int, message: String)
         case scriptFailed(code: Int, message: String)
-        case wrongOwner
 
         var errorDescription: String? {
             switch self {
             case .notBundled:
                 return "The clearly binary isn't bundled with this build."
-            case .terminalUnavailable:
-                return "Couldn't open Terminal. Check Privacy & Security → Automation and allow Clearly to control Terminal."
-            case .scriptFailed(let code, let message):
-                return "Couldn't open Terminal (code \(code)): \(message)"
             case .wrongOwner:
                 return "/usr/local/bin/clearly points at a different tool — remove it manually first."
+            case .appleScriptCompileFailed:
+                return "Couldn't build the install command — please report this."
+            case .terminalAutomationDenied:
+                return "Clearly doesn't have permission to control Terminal. Open Privacy & Security → Automation and allow Clearly, or copy the command and run it yourself."
+            case .scriptFailed(let code, let message):
+                return "Terminal returned an error (code \(code)): \(message)"
+            }
+        }
+
+        var diagnosticPayload: String {
+            switch self {
+            case .notBundled:
+                return "notBundled"
+            case .wrongOwner(let existingTarget):
+                return "wrongOwner existingTarget=\(existingTarget?.path ?? "<unreadable>")"
+            case .appleScriptCompileFailed:
+                return "appleScriptCompileFailed"
+            case .terminalAutomationDenied(let code, let message):
+                return "terminalAutomationDenied code=\(code) message=\(message)"
+            case .scriptFailed(let code, let message):
+                return "scriptFailed code=\(code) message=\(message)"
             }
         }
     }
@@ -65,30 +84,74 @@ enum CLIInstaller {
         }
     }
 
+    /// The exact one-liner a user can copy and run in Terminal themselves.
+    /// Returns nil when the helper binary isn't bundled with this build.
+    static var shellCommand: String? {
+        guard let source = bundledBinaryURL() else { return nil }
+        return
+            "sudo mkdir -p /usr/local/bin && " +
+            "sudo ln -sf '\(shellEscape(source.path))' '\(symlinkPath)'"
+    }
+
+    /// Ordered key/value pairs describing the current install environment.
+    /// Surfaced in the Settings "Details" disclosure and copied into bug reports.
+    static var diagnosticContext: [(String, String)] {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        let bundleId = info?["CFBundleIdentifier"] as? String ?? "?"
+        let os = ProcessInfo.processInfo.operatingSystemVersion
+        let osString = "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
+        return [
+            ("app", "\(version) (\(build))"),
+            ("bundleId", bundleId),
+            ("macOS", osString),
+            ("symlinkTarget", symlinkPath),
+            ("bundledBinary", bundledBinaryURL()?.path ?? "<missing>"),
+        ]
+    }
+
     static func install() async throws {
+        DiagnosticLog.log("[cli-install] install requested")
         guard let source = bundledBinaryURL() else {
+            DiagnosticLog.log("[cli-install] install failed: notBundled")
             throw CLIInstallerError.notBundled
         }
-        if case .installedElsewhere = symlinkState() {
-            throw CLIInstallerError.wrongOwner
+        if case .installedElsewhere(let url) = symlinkState() {
+            DiagnosticLog.log("[cli-install] install aborted: wrongOwner existingTarget=\(url.path)")
+            throw CLIInstallerError.wrongOwner(existingTarget: url)
         }
-        let shellCommand =
+        let scriptCommand =
             "sudo mkdir -p /usr/local/bin && " +
             "sudo ln -sf '\(shellEscape(source.path))' '\(symlinkPath)' && " +
             "echo '' && " +
             "echo '✓ Installed. You can close this window — clearly is on your PATH.'"
-        try await runInTerminal(shellCommand)
+        do {
+            try await runInTerminal(scriptCommand)
+            DiagnosticLog.log("[cli-install] install dispatched to Terminal")
+        } catch let error as CLIInstallerError {
+            DiagnosticLog.log("[cli-install] install failed: \(error.diagnosticPayload)")
+            throw error
+        }
     }
 
     static func uninstall() async throws {
+        DiagnosticLog.log("[cli-install] uninstall requested")
         guard symlinkState() == .installed else {
-            throw CLIInstallerError.wrongOwner
+            DiagnosticLog.log("[cli-install] uninstall aborted: wrongOwner")
+            throw CLIInstallerError.wrongOwner(existingTarget: URL(fileURLWithPath: symlinkPath))
         }
-        let shellCommand =
+        let scriptCommand =
             "sudo rm -f '\(symlinkPath)' && " +
             "echo '' && " +
             "echo '✓ Uninstalled. You can close this window.'"
-        try await runInTerminal(shellCommand)
+        do {
+            try await runInTerminal(scriptCommand)
+            DiagnosticLog.log("[cli-install] uninstall dispatched to Terminal")
+        } catch let error as CLIInstallerError {
+            DiagnosticLog.log("[cli-install] uninstall failed: \(error.diagnosticPayload)")
+            throw error
+        }
     }
 
     private static func runInTerminal(_ shellCommand: String) async throws {
@@ -104,14 +167,14 @@ enum CLIInstaller {
         try await Task.detached(priority: .userInitiated) {
             var errorDict: NSDictionary?
             guard let apple = NSAppleScript(source: script) else {
-                throw CLIInstallerError.scriptFailed(code: -1, message: "Could not compile AppleScript")
+                throw CLIInstallerError.appleScriptCompileFailed
             }
             _ = apple.executeAndReturnError(&errorDict)
             if let err = errorDict {
                 let code = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
                 let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "Unknown error"
                 if code == -1743 || code == -600 {
-                    throw CLIInstallerError.terminalUnavailable
+                    throw CLIInstallerError.terminalAutomationDenied(code: code, message: msg)
                 }
                 throw CLIInstallerError.scriptFailed(code: code, message: msg)
             }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -100,7 +100,10 @@ struct SettingsView: View {
     @State private var mcpCopied = false
     @State private var cliSymlinkState: CLIInstaller.State = CLIInstaller.symlinkState()
     @State private var cliInstallBusy = false
-    @State private var cliInstallError: String?
+    @State private var cliInstallError: CLIInstaller.CLIInstallerError?
+    @State private var cliCommandCopied = false
+    @State private var cliDetailsCopied = false
+    @State private var cliErrorDetailsExpanded = false
 
     private var bundledCLIBinaryPath: String? {
         CLIInstaller.bundledBinaryURL()?.path
@@ -134,64 +137,10 @@ struct SettingsView: View {
                 }
             }
 
-            // Row 2 — terminal install
+            // Row 2 — install
             VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Terminal command")
-                    Spacer()
-                    switch cliSymlinkState {
-                    case .installed:
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("Installed at \(CLIInstaller.symlinkPath)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    case .installedElsewhere:
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text("Different `clearly` on PATH")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    case .notInstalled:
-                        Image(systemName: "circle")
-                            .foregroundStyle(.secondary)
-                        Text("Not installed")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                HStack {
-                    switch cliSymlinkState {
-                    case .installed:
-                        Button("Uninstall") {
-                            Task { await runUninstall() }
-                        }
-                        .disabled(cliInstallBusy)
-                    case .installedElsewhere:
-                        Button("Install \u{2026}") {}
-                            .disabled(true)
-                        Text("Remove the existing `clearly` from /usr/local/bin manually before installing.")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    case .notInstalled:
-                        Button("Install \u{2026}") {
-                            Task { await runInstall() }
-                        }
-                        .disabled(cliInstallBusy || !cliBundledExecutable)
-                    }
-                    Spacer()
-                }
-
-                if let errorText = cliInstallError {
-                    Text(errorText)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-
-                Text("Opens Terminal and runs `sudo ln -sf` so `clearly` resolves on your shell PATH. Enter your admin password in Terminal when prompted, then switch back here — Clearly detects the install automatically.")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                cliStatusHeader
+                cliInstallUI
             }
 
             // Row 3 — MCP config copy
@@ -215,27 +164,176 @@ struct SettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private var cliStatusHeader: some View {
+        HStack {
+            Text("Terminal command")
+            Spacer()
+            switch cliSymlinkState {
+            case .installed:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text("Installed at \(CLIInstaller.symlinkPath)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .installedElsewhere:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Different `clearly` on PATH")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .notInstalled:
+                Image(systemName: "circle")
+                    .foregroundStyle(.secondary)
+                Text("Not installed")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var cliInstallUI: some View {
+        HStack {
+            switch cliSymlinkState {
+            case .installed:
+                Button("Uninstall") {
+                    Task { await runUninstall() }
+                }
+                .disabled(cliInstallBusy)
+            case .installedElsewhere:
+                Button("Install \u{2026}") {}
+                    .disabled(true)
+                Text("Remove the existing `clearly` from /usr/local/bin manually before installing.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            case .notInstalled:
+                Button("Install \u{2026}") {
+                    Task { await runInstall() }
+                }
+                .disabled(cliInstallBusy || !cliBundledExecutable)
+            }
+            Spacer()
+        }
+
+        if let error = cliInstallError {
+            cliErrorPanel(error)
+        }
+
+        Text("Opens Terminal and runs `sudo ln -sf` so `clearly` resolves on your shell PATH. Enter your admin password in Terminal when prompted, then switch back here — Clearly detects the install automatically.")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+    }
+
+    @ViewBuilder
+    private func cliErrorPanel(_ error: CLIInstaller.CLIInstallerError) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(error.errorDescription ?? "Install failed.")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                if case .terminalAutomationDenied = error {
+                    Button("Open Privacy Settings") { openPrivacySettings() }
+                        .controlSize(.small)
+                }
+                if let command = CLIInstaller.shellCommand {
+                    Button(cliCommandCopied ? "Copied!" : "Copy command") {
+                        copyCLIShellCommand(command)
+                    }
+                    .controlSize(.small)
+                }
+                if case .notInstalled = cliSymlinkState {
+                    Button("Try again") {
+                        Task { await runInstall() }
+                    }
+                    .controlSize(.small)
+                    .disabled(cliInstallBusy)
+                }
+                Spacer()
+            }
+
+            DisclosureGroup("Details", isExpanded: $cliErrorDetailsExpanded) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(cliErrorDetails(error))
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(cliDetailsCopied ? "Copied!" : "Copy details") {
+                        copyCLIErrorDetails(error)
+                    }
+                    .controlSize(.small)
+                }
+                .padding(.top, 4)
+            }
+            .font(.caption)
+        }
+        .padding(10)
+        .background(Color.red.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+    }
+
     private func runInstall() async {
         cliInstallBusy = true
         cliInstallError = nil
+        cliErrorDetailsExpanded = false
         defer { cliInstallBusy = false }
         do {
             try await CLIInstaller.install()
             cliSymlinkState = CLIInstaller.symlinkState()
+        } catch let error as CLIInstaller.CLIInstallerError {
+            cliInstallError = error
         } catch {
-            cliInstallError = error.localizedDescription
+            DiagnosticLog.log("[cli-install] unexpected error type: \(error)")
         }
     }
 
     private func runUninstall() async {
         cliInstallBusy = true
         cliInstallError = nil
+        cliErrorDetailsExpanded = false
         defer { cliInstallBusy = false }
         do {
             try await CLIInstaller.uninstall()
             cliSymlinkState = CLIInstaller.symlinkState()
+        } catch let error as CLIInstaller.CLIInstallerError {
+            cliInstallError = error
         } catch {
-            cliInstallError = error.localizedDescription
+            DiagnosticLog.log("[cli-install] unexpected error type: \(error)")
+        }
+    }
+
+    private func openPrivacySettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func copyCLIShellCommand(_ command: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+        cliCommandCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            cliCommandCopied = false
+        }
+    }
+
+    private func cliErrorDetails(_ error: CLIInstaller.CLIInstallerError) -> String {
+        var lines: [String] = []
+        lines.append("error:         \(error.diagnosticPayload)")
+        for (key, value) in CLIInstaller.diagnosticContext {
+            lines.append("\(key.padding(toLength: 14, withPad: " ", startingAt: 0)) \(value)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func copyCLIErrorDetails(_ error: CLIInstaller.CLIInstallerError) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(cliErrorDetails(error), forType: .string)
+        cliDetailsCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            cliDetailsCopied = false
         }
     }
 

--- a/Packages/ClearlyCore/Package.resolved
+++ b/Packages/ClearlyCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "564c09efb10a7f03a559fa7e1c2130f8384ddf1aa72d3668daa80157dcdbc645",
+  "originHash" : "be97a0487c65c270e247e6df0487b2f49a0ed9b8cb1b398e5b8d8dc92e478a0d",
   "pins" : [
     {
       "identity" : "cmark-gfm",


### PR DESCRIPTION
## Summary
- Replace the bare red error on Settings → Command Line → Install failure with a recovery panel: **Open Privacy Settings**, **Copy command**, **Try again**, and a collapsible **Details** section carrying raw error code + macOS/app/bundle context for bug reports.
- Expand `CLIInstallerError` with `terminalAutomationDenied(code:message:)` / `appleScriptCompileFailed` / `wrongOwner(existingTarget:)` so failures preserve their raw payload, and log every attempt to `DiagnosticLog` under `[cli-install]` so **Help → Export Diagnostic Log…** captures them.

Fixes #218.

## Test plan
- [ ] Deny path: \`tccutil reset AppleEvents com.sabotage.clearly.dev\`, click Install, click "Don't Allow". Verify the error panel, its three action buttons, and the Details disclosure (raw code, app/os/bundleId/paths).
- [ ] **Open Privacy Settings** lands in Privacy & Security; approving Automation for Clearly Dev + Terminal then **Try again** completes the install.
- [ ] **Copy command** copies a runnable \`sudo ln -sf …\` one-liner.
- [ ] **Help → Export Diagnostic Log…** contains \`[cli-install]\` entries for each attempt/failure.