### PR TITLE
[mac] Add setting to hide menu bar icon (#220)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -67,6 +67,14 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         isOpeningSettingsFromMenuBar || (trackedSettingsWindow != nil && trackedSettingsWindow?.isMiniaturized == false)
     }
 
+    /// Mirrors the `@AppStorage("showMenuBarIcon")` value the SwiftUI side reads.
+    /// Reads via `object(forKey:)` so the unset state resolves to the same `true`
+    /// default the App/SettingsView declare; `bool(forKey:)` would return `false`
+    /// for an unset key and silently flip the app into "no menu bar" mode on first launch.
+    private var showMenuBarIcon: Bool {
+        (UserDefaults.standard.object(forKey: "showMenuBarIcon") as? Bool) ?? true
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         Self.shared = self
 
@@ -75,7 +83,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         // menubar-only only in that state instead of guessing from parent PID.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self else { return }
-            if !NSApp.isActive && !self.hasDocumentWindows() {
+            if !NSApp.isActive && !self.hasDocumentWindows() && self.showMenuBarIcon {
                 NSApp.setActivationPolicy(.accessory)
             }
         }
@@ -265,7 +273,15 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        WorkspaceManager.shared.prepareForAppTermination() ? .terminateNow : .terminateCancel
+        guard WorkspaceManager.shared.prepareForAppTermination() else { return .terminateCancel }
+        if !showMenuBarIcon {
+            WorkspaceManager.shared.persistDocumentSession()
+        }
+        return .terminateNow
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        !showMenuBarIcon
     }
 
     // MARK: - Save on termination
@@ -602,7 +618,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     private func updateActivationPolicy() {
-        if hasDocumentWindows() {
+        if hasDocumentWindows() || !showMenuBarIcon {
             if NSApp.activationPolicy() != .regular {
                 NSApp.setActivationPolicy(.regular)
             }
@@ -643,6 +659,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     func shouldCloseToMenuBar(for event: NSEvent) -> Bool {
+        guard showMenuBarIcon else { return false }
         guard event.type == .keyDown else { return false }
         guard event.charactersIgnoringModifiers?.lowercased() == "q" else { return false }
 
@@ -671,6 +688,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 struct ClearlyApp: App {
     @NSApplicationDelegateAdaptor(ClearlyAppDelegate.self) var appDelegate
     @AppStorage("themePreference") private var themePreference = "system"
+    @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @State private var scratchpadManager = ScratchpadManager.shared
     private let workspace = WorkspaceManager.shared
     #if canImport(Sparkle)
@@ -921,7 +939,7 @@ struct ClearlyApp: App {
             #endif
         }
 
-        MenuBarExtra("Scratchpads", image: "ScratchpadMenuBarIcon") {
+        MenuBarExtra("Scratchpads", image: "ScratchpadMenuBarIcon", isInserted: $showMenuBarIcon) {
             ScratchpadMenuBar(manager: scratchpadManager)
         }
     }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @AppStorage("launchBehavior") private var launchBehavior = "lastFile"
     @AppStorage("contentWidth") private var contentWidth = "off"
     @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
+    @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
 
     var body: some View {
         TabView {
@@ -78,6 +79,7 @@ struct SettingsView: View {
                 Text("Wide").tag("wide")
             }
             Toggle("Hide frontmatter in Preview", isOn: $hideFrontmatterInPreview)
+            Toggle("Show icon in menu bar", isOn: $showMenuBarIcon)
             KeyboardShortcuts.Recorder("New Scratchpad:", name: .newScratchpad)
             Toggle("Launch at Login", isOn: $launchAtLogin)
                 .onChange(of: launchAtLogin) { _, newValue in

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -61,6 +61,7 @@ final class WorkspaceManager {
     private static let locationBookmarksKey = "locationBookmarks"
     private static let recentBookmarksKey = "recentBookmarks"
     private static let lastOpenFileKey = "lastOpenFileURL"
+    private static let documentSessionKey = "documentSession"
     private static let sidebarVisibleKey = "sidebarVisible"
     private static let launchBehaviorKey = "launchBehavior"
     private static let folderIconsKey = "folderIcons"
@@ -93,6 +94,20 @@ final class WorkspaceManager {
         case cancel
     }
 
+    private struct PersistedDocumentSession: Codable {
+        let documents: [PersistedDocumentState]
+        let activeDocumentID: UUID?
+    }
+
+    private struct PersistedDocumentState: Codable {
+        let id: UUID
+        let bookmarkData: Data?
+        let text: String?
+        let lastSavedText: String?
+        let untitledNumber: Int?
+        let viewModeRawValue: String
+    }
+
     // MARK: - Init
 
     init() {
@@ -111,11 +126,13 @@ final class WorkspaceManager {
             UserDefaults.standard.set(true, forKey: Self.hasEverAddedLocationKey)
         }
 
-        let launchBehavior = UserDefaults.standard.string(forKey: Self.launchBehaviorKey) ?? "lastFile"
-        if launchBehavior == "newDocument" {
-            createUntitledDocument()
-        } else {
-            restoreLastFile()
+        if !restoreDocumentSession() {
+            let launchBehavior = UserDefaults.standard.string(forKey: Self.launchBehaviorKey) ?? "lastFile"
+            if launchBehavior == "newDocument" {
+                createUntitledDocument()
+            } else {
+                restoreLastFile()
+            }
         }
     }
 
@@ -269,7 +286,7 @@ final class WorkspaceManager {
             case .save:
                 guard saveDocument(at: idx, treatCancelAsFailure: true) else { return false }
             case .discard:
-                break
+                discardChanges(to: id)
             case .cancel:
                 return false
             }
@@ -309,7 +326,7 @@ final class WorkspaceManager {
             case .save:
                 guard saveDocument(at: idx, treatCancelAsFailure: true) else { return false }
             case .discard:
-                break
+                discardChanges(to: docID)
             case .cancel:
                 return false
             }
@@ -1639,6 +1656,37 @@ final class WorkspaceManager {
         openFile(at: url)
     }
 
+    private func restoreDocumentSession() -> Bool {
+        guard let data = UserDefaults.standard.data(forKey: Self.documentSessionKey) else { return false }
+        clearPersistedDocumentSession()
+
+        guard let session = try? JSONDecoder().decode(PersistedDocumentSession.self, from: data) else {
+            DiagnosticLog.log("Failed to decode persisted document session")
+            return false
+        }
+
+        let restoredDocuments = session.documents.compactMap(restoreDocument(from:))
+        guard !restoredDocuments.isEmpty else { return false }
+
+        openDocuments = restoredDocuments
+        nextUntitledNumber = (restoredDocuments.compactMap(\.untitledNumber).max() ?? 0) + 1
+
+        if let activeDocumentID = session.activeDocumentID,
+           restoredDocuments.contains(where: { $0.id == activeDocumentID }) {
+            self.activeDocumentID = activeDocumentID
+        } else {
+            self.activeDocumentID = restoredDocuments.first?.id
+        }
+
+        restoreActiveDocument()
+        if let currentFileURL {
+            persistLastOpenFile(currentFileURL)
+        }
+
+        DiagnosticLog.log("Restored document session: \(restoredDocuments.count) tabs")
+        return true
+    }
+
     // MARK: - Vault Index
 
     private func openVaultIndex(for location: BookmarkedLocation) {
@@ -1820,10 +1868,109 @@ final class WorkspaceManager {
         }
     }
 
+    func persistDocumentSession() {
+        snapshotActiveDocument()
+
+        let documents = openDocuments.compactMap(persistedDocumentState(for:))
+        guard !documents.isEmpty else {
+            clearPersistedDocumentSession()
+            return
+        }
+
+        let session = PersistedDocumentSession(documents: documents, activeDocumentID: activeDocumentID)
+
+        do {
+            let data = try JSONEncoder().encode(session)
+            UserDefaults.standard.set(data, forKey: Self.documentSessionKey)
+            DiagnosticLog.log("Persisted document session: \(documents.count) tabs")
+        } catch {
+            DiagnosticLog.log("Failed to persist document session: \(error.localizedDescription)")
+        }
+    }
+
+    func clearPersistedDocumentSession() {
+        UserDefaults.standard.removeObject(forKey: Self.documentSessionKey)
+    }
+
     private func persistLastOpenFile(_ url: URL) {
         if let bookmarkData = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil) {
             UserDefaults.standard.set(bookmarkData, forKey: Self.lastOpenFileKey)
         }
+    }
+
+    private func persistedDocumentState(for document: OpenDocument) -> PersistedDocumentState? {
+        if let fileURL = document.fileURL {
+            guard let bookmarkData = try? fileURL.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil) else {
+                DiagnosticLog.log("Failed to bookmark open document: \(fileURL.lastPathComponent)")
+                return nil
+            }
+
+            return PersistedDocumentState(
+                id: document.id,
+                bookmarkData: bookmarkData,
+                text: nil,
+                lastSavedText: nil,
+                untitledNumber: nil,
+                viewModeRawValue: document.viewMode.rawValue
+            )
+        }
+
+        return PersistedDocumentState(
+            id: document.id,
+            bookmarkData: nil,
+            text: document.text,
+            lastSavedText: document.lastSavedText,
+            untitledNumber: document.untitledNumber,
+            viewModeRawValue: document.viewMode.rawValue
+        )
+    }
+
+    private func restoreDocument(from state: PersistedDocumentState) -> OpenDocument? {
+        let viewMode = ViewMode(rawValue: state.viewModeRawValue) ?? .edit
+
+        if let bookmarkData = state.bookmarkData {
+            var isStale = false
+            guard let resolvedURL = try? URL(
+                resolvingBookmarkData: bookmarkData,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            ) else {
+                return nil
+            }
+
+            let normalizedURL = resolvedURL.standardizedFileURL
+            if !hasActiveAccess(to: normalizedURL) {
+                guard normalizedURL.startAccessingSecurityScopedResource() else { return nil }
+                accessedURLs.insert(normalizedURL)
+            }
+
+            guard FileManager.default.fileExists(atPath: normalizedURL.path),
+                  let data = try? Data(contentsOf: normalizedURL),
+                  let text = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+
+            return OpenDocument(
+                id: state.id,
+                fileURL: normalizedURL,
+                text: text,
+                lastSavedText: text,
+                untitledNumber: nil,
+                viewMode: viewMode,
+                conflictOutcome: nil
+            )
+        }
+
+        return OpenDocument(
+            id: state.id,
+            fileURL: nil,
+            text: state.text ?? "",
+            lastSavedText: state.lastSavedText ?? "",
+            untitledNumber: state.untitledNumber,
+            viewMode: viewMode,
+            conflictOutcome: nil
+        )
     }
 
     private func promptToSaveChanges(for doc: OpenDocument) -> DirtyDocumentDisposition {


### PR DESCRIPTION
## Summary

- Adds a "Show icon in menu bar" toggle in Settings → General (default on, preserves current behavior). When off, the scratchpad `MenuBarExtra` is removed via SwiftUI's `isInserted:` binding.
- When the icon is hidden, Clearly behaves like a standard Mac app: ⌘Q quits, closing the last window quits, and the Dock icon stays visible. With the icon shown, the existing menu-bar-app behavior is preserved.
- Open documents are now persisted to UserDefaults on termination and restored on next launch (security-scoped bookmarks for file-backed tabs, raw text for unsaved/untitled), so quitting on last-window-close doesn't lose tab context.

Closes #220.

## Test plan

- [ ] Default state: scratchpad icon visible; closing the main window collapses to menu bar; ⌘Q intercepted (no quit)
- [ ] Toggle off in Settings → General: icon disappears live; Dock icon remains; closing the window quits the app; ⌘Q quits
- [ ] Reopen with icon hidden: previously-open tabs restore, including unsaved/untitled tabs
- [ ] Toggle back on: icon reappears; close-to-menu-bar and ⌘Q-intercept behavior returns
- [ ] `⌃⌥⌘N` global "New Scratchpad" shortcut still works in both states (intentional — independent of menu bar)