### PR TITLE
[shared] Fix inline LaTeX false positives on currency (#200)

### DIFF
--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -2,6 +2,10 @@ import Foundation
 import cmark
 
 public enum MarkdownRenderer {
+    private static let escapedMathBackslashToken = "\u{E100}"
+    private static let escapedMathDollarToken = "\u{E101}"
+    private static let escapedMathPaddingToken = "\u{E102}"
+
     public static func renderHTML(_ markdown: String, appLinkURLs: Bool = false, includeFrontmatter: Bool = true) -> String {
         guard !markdown.isEmpty else { return "" }
 
@@ -9,14 +13,15 @@ public enum MarkdownRenderer {
 
         let rawBody = frontmatter?.body ?? markdown
         let (body, codeFilenames) = extractCodeFilenames(rawBody)
-        let len = body.utf8.count
+        let protectedBody = protectEscapedMathDelimiters(in: body)
+        let len = protectedBody.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)
         var html: String
         // Try GFM renderer first (tables, strikethrough, task lists, autolinks)
-        if let buf = cmark_gfm_markdown_to_html(body, len, options) {
+        if let buf = cmark_gfm_markdown_to_html(protectedBody, len, options) {
             html = String(cString: buf)
             free(buf)
-        } else if let buf = cmark_markdown_to_html(body, len, options) {
+        } else if let buf = cmark_markdown_to_html(protectedBody, len, options) {
             // Fallback to basic CommonMark
             html = String(cString: buf)
             free(buf)
@@ -24,6 +29,7 @@ public enum MarkdownRenderer {
             return ""
         }
         html = processMath(html)
+        html = restoreEscapedMathDelimiters(in: html)
         html = processHighlightMarks(html)
         html = processSuperSub(html)
         html = processEmoji(html)
@@ -88,6 +94,48 @@ public enum MarkdownRenderer {
         return result
     }
 
+    private static func protectEscapedMathDelimiters(in markdown: String) -> String {
+        var result = ""
+        var index = markdown.startIndex
+
+        while index < markdown.endIndex {
+            guard markdown[index] == "\\" else {
+                result.append(markdown[index])
+                index = markdown.index(after: index)
+                continue
+            }
+
+            var slashEnd = index
+            while slashEnd < markdown.endIndex, markdown[slashEnd] == "\\" {
+                slashEnd = markdown.index(after: slashEnd)
+            }
+
+            guard slashEnd < markdown.endIndex, markdown[slashEnd] == "$" else {
+                result += markdown[index..<slashEnd]
+                index = slashEnd
+                continue
+            }
+
+            let slashCount = markdown.distance(from: index, to: slashEnd)
+            let literalSlashCount = slashCount / 2
+            let paddingCount = slashCount - literalSlashCount
+
+            result += String(repeating: escapedMathBackslashToken, count: literalSlashCount)
+            result += escapedMathDollarToken
+            result += String(repeating: escapedMathPaddingToken, count: paddingCount)
+            index = markdown.index(after: slashEnd)
+        }
+
+        return result
+    }
+
+    private static func restoreEscapedMathDelimiters(in html: String) -> String {
+        html
+            .replacingOccurrences(of: escapedMathBackslashToken, with: "\\")
+            .replacingOccurrences(of: escapedMathDollarToken, with: "$")
+            .replacingOccurrences(of: escapedMathPaddingToken, with: "")
+    }
+
     /// Convert $...$ and $$...$$ in rendered HTML to KaTeX-compatible spans/divs.
     /// Only transforms text nodes outside protected <code>/<pre> regions.
     private static func processMath(_ html: String) -> String {
@@ -123,14 +171,14 @@ public enum MarkdownRenderer {
 
     private static func processMathText(_ text: String) -> String {
         var result = text
-        if let blockRegex = try? NSRegularExpression(pattern: #"\$\$(.+?)\$\$"#, options: .dotMatchesLineSeparators) {
+        if let blockRegex = try? NSRegularExpression(pattern: MathSupport.displayMathPattern, options: .dotMatchesLineSeparators) {
             result = blockRegex.stringByReplacingMatches(
                 in: result,
                 range: NSRange(result.startIndex..., in: result),
                 withTemplate: #"<div class="math-block">$1</div>"#
             )
         }
-        if let inlineRegex = try? NSRegularExpression(pattern: #"(?<![\\$])\$(?!\$)(.+?)(?<![\\$])\$"#) {
+        if let inlineRegex = try? NSRegularExpression(pattern: MathSupport.inlineMathPattern) {
             result = inlineRegex.stringByReplacingMatches(
                 in: result,
                 range: NSRange(result.startIndex..., in: result),

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -63,7 +63,7 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         }
 
         // Inline math: $...$
-        add("(?<!\\$)\\$(?!\\$)([^\n$]+?)(?<!\\$)\\$(?!\\$)", .mathInline)
+        add(MathSupport.inlineMathPattern, .mathInline)
 
         // Headings: # Heading
         add("^(#{1,6}\\s+)(.+)$", .heading, options: .anchorsMatchLines)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MermaidSupport.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MermaidSupport.swift
@@ -49,6 +49,12 @@ public enum MermaidSupport {
 }
 
 public enum MathSupport {
+    // MathJax/Obsidian whitespace rule + markdown-it-katex "no digit after close" — blocks currency like `$5.12 on soda and $4.42`.
+    public static let inlineMathPattern =
+        #"(?<![\\$])\$(?![\s$])([^\n$]+?)(?<![\s\\$])\$(?![\d$])"#
+
+    public static let displayMathPattern = #"\$\$(.+?)\$\$"#
+
     public static func scriptHTML(for htmlBody: String) -> String {
         guard htmlBody.contains("math-inline") || htmlBody.contains("math-block") else {
             return ""

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownMathTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownMathTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import ClearlyCore
+
+final class MarkdownMathTests: XCTestCase {
+    // MARK: - Currency-like prose must NOT render as math (issue #200)
+
+    func testGroceryCurrencyIsNotMath() {
+        let html = MarkdownRenderer.renderHTML(
+            "They went to a grocery store and spent $5.12 on soda and $4.42 on sweets."
+        )
+        XCTAssertFalse(html.contains("math-inline"), "currency sentence rendered as math: \(html)")
+        XCTAssertTrue(html.contains("$5.12"))
+        XCTAssertTrue(html.contains("$4.42"))
+    }
+
+    func testPandocTwentyThousandExampleIsNotMath() {
+        let html = MarkdownRenderer.renderHTML("I paid $20,000 for it and $30,000 for repairs.")
+        XCTAssertFalse(html.contains("math-inline"), html)
+    }
+
+    func testAsymmetricCurrencyIsNotMath() {
+        let html = MarkdownRenderer.renderHTML("I paid $5 and got $3 back.")
+        XCTAssertFalse(html.contains("math-inline"), html)
+    }
+
+    func testLoneDollarSignIsNotMath() {
+        let html = MarkdownRenderer.renderHTML("Just a $ sign alone.")
+        XCTAssertFalse(html.contains("math-inline"), html)
+    }
+
+    func testEscapedInlineMathDelimiterStaysLiteral() {
+        let html = MarkdownRenderer.renderHTML(#"Escaped inline math: \$x$ should stay literal."#)
+        XCTAssertFalse(html.contains("math-inline"), html)
+        XCTAssertTrue(html.contains("$x$"), html)
+    }
+
+    func testBackslashEscapedCurrencyStaysLiteral() {
+        let html = MarkdownRenderer.renderHTML(#"Price: \$5 and \$10."#)
+        XCTAssertFalse(html.contains("math-inline"), html)
+        XCTAssertTrue(html.contains("$5"), html)
+        XCTAssertTrue(html.contains("$10"), html)
+    }
+
+    // MARK: - Legitimate inline math MUST still render
+
+    func testSimpleInlineMathRenders() {
+        let html = MarkdownRenderer.renderHTML("$x^2$")
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+    }
+
+    func testEulerIdentityRenders() {
+        let html = MarkdownRenderer.renderHTML(#"$e^{i\pi} + 1 = 0$"#)
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+    }
+
+    func testFractionRenders() {
+        let html = MarkdownRenderer.renderHTML(#"$\frac{a}{b}$"#)
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+    }
+
+    func testQuadraticFormulaFromDemoRenders() {
+        let html = MarkdownRenderer.renderHTML(
+            #"$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$"#
+        )
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+    }
+
+    func testInlineMathInProseRenders() {
+        let html = MarkdownRenderer.renderHTML(
+            #"Inline math flows with your prose: $e^{i\pi} + 1 = 0$ still feels like magic."#
+        )
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+    }
+
+    // MARK: - Display math and code protection
+
+    func testDisplayMathBlockRenders() {
+        let html = MarkdownRenderer.renderHTML(
+            """
+            $$
+            \\int_{-\\infty}^{\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}
+            $$
+            """
+        )
+        XCTAssertTrue(html.contains(#"<div class="math-block">"#), html)
+    }
+
+    func testDollarsInsideInlineCodeStayLiteral() {
+        let html = MarkdownRenderer.renderHTML("`I paid $5 and $10.`")
+        XCTAssertFalse(html.contains("math-inline"), html)
+        XCTAssertTrue(html.contains("$5"))
+        XCTAssertTrue(html.contains("$10"))
+    }
+
+    func testDollarsInsideFencedCodeBlockStayLiteral() {
+        let html = MarkdownRenderer.renderHTML(
+            """
+            ```
+            price = $5.12 + $4.42
+            ```
+            """
+        )
+        XCTAssertFalse(html.contains("math-inline"), html)
+    }
+}


### PR DESCRIPTION
## Summary
- Inline `$…$` detection now uses the MathJax/Obsidian whitespace rule plus markdown-it-katex's "no digit after closing `$`" clause, so prose like `$5.12 on soda and $4.42 on sweets` stays plain text instead of rendering as math. Same regex is shared by the editor syntax highlighter and the preview renderer via `MathSupport.inlineMathPattern`.
- CommonMark `\\\$` escapes are pre-tokenized before cmark so explicitly escaped dollars survive the math pass and render as literal `$`.
- Adds `MarkdownMathTests` (13 cases) pinning the fix on the issue-#200 repro line, Pandoc's `\$20,000` example, asymmetric currency, demo.md's quadratic formula, Euler's identity, display math, and dollars inside inline/fenced code.

## Test plan
- [ ] `swift test --package-path Packages/ClearlyCore` — 36 pass
- [ ] `xcodebuild -scheme Clearly -configuration Debug build` — succeeds
- [ ] In the Debug app, paste `They went to a grocery store and spent $5.12 on soda and $4.42 on sweets.` and verify the editor shows no purple highlight and the preview shows plain text
- [ ] Open **Help → Sample Document** and verify the quadratic formula / Euler's identity / the display integral still render through KaTeX