### PR TITLE
[mac] Fix sidebar click-to-open by swapping .onDrag for .draggable

### DIFF
--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -259,9 +259,7 @@ struct MacFolderSidebar: View {
             .popover(isPresented: popoverBinding(for: node.url), arrowEdge: .trailing) {
                 FolderCustomizerView(url: node.url, workspace: workspace)
             }
-            .onDrag {
-                NSItemProvider(object: node.url as NSURL)
-            } preview: {
+            .draggable(node.url) {
                 DragRowPreview(title: node.name, systemImage: folderIcon, iconTint: folderTint)
             }
             .dropDestination(for: URL.self) { urls, _ in
@@ -282,9 +280,7 @@ struct MacFolderSidebar: View {
             .tag(node.url)
             .listRowBackground(SelectionPill(tint: rowTint, isSelected: isSelected))
             .contextMenu { fileContextMenu(url: node.url) }
-            .onDrag {
-                NSItemProvider(object: node.url as NSURL)
-            } preview: {
+            .draggable(node.url) {
                 DragRowPreview(title: fileTitle, systemImage: "doc.text", iconTint: rowTint)
             }
         }
@@ -435,8 +431,8 @@ private struct SidebarRowLabel: View {
 }
 
 /// Finder-like drag preview: icon + filename on a rounded, translucent chip.
-/// Used as the `.onDrag(preview:)` so the cursor carries the full row during
-/// a drag instead of just the SF Symbol that `.onDrag` otherwise captures.
+/// Used as `.draggable(preview:)` so the cursor carries the full row during a
+/// drag instead of just the SF Symbol that the default preview captures.
 private struct DragRowPreview: View {
     let title: String
     let systemImage: String


### PR DESCRIPTION
## Summary

- Replaces `.onDrag` with `.draggable(URL)` on vault file and folder rows in the Mac sidebar. `.onDrag` installs an `NSDraggingSource` on each row that intercepts mouseDown inside `List(selection:)`, which silently swallows clicks — Pinned and Recents rows didn't have `.onDrag` and kept working, which is how the source was isolated.
- `.draggable` (macOS 13+) cooperates with `List(selection:)` hit-testing, so click-to-open is restored while intra-sidebar drag-to-move, drag-to-Finder, and Finder-to-sidebar imports all continue to work.
- No behavior change for Finder drops: they copy, same as before — true move-to-Finder would require `NSFilePromiseProvider` via AppKit and is out of scope here.

## Test plan

- [ ] Click a file nested inside a vault folder → selects and opens.
- [ ] Click a collapsed folder → expands/collapses.
- [ ] Drag a file from one vault folder to another → moves (via `WorkspaceManager.handleSidebarDrop`).
- [ ] Drag a `.md` from Finder onto a folder row → imports with the usual collision-naming rules.
- [ ] Clicks in Pinned / Recents still work (regression check).