### PR TITLE
[shared] Paste and drop images into editor

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -41,6 +41,39 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
     var onShowFind: (() -> Void)?
     var onWikiLinkClicked: ((String, String?) -> Void)?
 
+    /// Invoked when the user pastes/drops an image into an unsaved document.
+    /// Implementer shows the NSSavePanel, returning the saved URL on success
+    /// or `nil` on cancel. Called synchronously from `paste(_:)` /
+    /// `performDragOperation(_:)`, so the panel's modal run is fine.
+    var onPasteRequiresSave: (() -> URL?)?
+
+    /// SwiftUI's `.dropDestination` routes Finder file drops to the focused
+    /// editor via this notification. Carries `[URL]` in `userInfo["urls"]`.
+    static let insertDroppedImagesNotification = Notification.Name("ClearlyTextView.insertDroppedImages")
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleDroppedImagesNotification(_:)),
+            name: Self.insertDroppedImagesNotification, object: nil
+        )
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil {
+            NotificationCenter.default.removeObserver(self, name: Self.insertDroppedImagesNotification, object: nil)
+        }
+    }
+
+    @objc private func handleDroppedImagesNotification(_ note: Notification) {
+        guard window?.isKeyWindow == true else { return }
+        guard let urls = note.userInfo?["urls"] as? [URL] else { return }
+        DiagnosticLog.log("ClearlyTextView received drop notification for \(urls.count) URL(s)")
+        handleDroppedImageFileURLs(urls)
+    }
+
     // MARK: - Wiki-Link Cmd+Click
 
     private static let wikiLinkRegex = try! NSRegularExpression(
@@ -129,33 +162,35 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     // MARK: - Paste
 
-    private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "svg", "tiff", "tif", "bmp", "heic"]
-
-    private static func encodeImagePath(_ path: String) -> String {
-        path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
-    }
-
     override func paste(_ sender: Any?) {
         let pasteboard = NSPasteboard.general
 
-        // Check for file URLs on the pasteboard
+        // 1. File URLs — if any are images, copy each to a sibling PNG.
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
             .urlReadingFileURLsOnly: true
-        ]) as? [URL], !urls.isEmpty {
-            let imageURLs = urls.filter { Self.imageExtensions.contains($0.pathExtension.lowercased()) }
+        ]) as? [URL] {
+            let imageURLs = urls.filter {
+                ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
+            }
             if !imageURLs.isEmpty {
-                let markdown = imageURLs.map { "![](\(Self.encodeImagePath($0.path)))" }.joined(separator: "\n")
-                insertText(markdown, replacementRange: selectedRange())
+                handleImageFileURLs(imageURLs)
                 return
             }
         }
 
-        // Fallback: check if pasted string looks like an image file path
+        // 2. Raw image on the pasteboard (screenshot, copied from Preview, etc.).
+        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) {
+            if let image = NSImage(pasteboard: pasteboard), let png = Self.pngData(from: image) {
+                insertPastedPNG(png)
+                return
+            }
+        }
+
+        // 3. HTTP(S) URL string that looks like an image — async download.
         if let text = pasteboard.string(forType: .string)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           text.hasPrefix("/"),
-           !text.contains("\n"),
-           Self.imageExtensions.contains((text as NSString).pathExtension.lowercased()) {
-            insertText("![](\(Self.encodeImagePath(text)))", replacementRange: selectedRange())
+           !text.contains("\n"), !text.contains(" "),
+           let url = URL(string: text), ImagePasteService.isLikelyImageURL(url) {
+            beginImageDownload(from: url)
             return
         }
 
@@ -164,6 +199,178 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         } else {
             super.paste(sender)
         }
+    }
+
+    // MARK: - Drag-and-drop
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        let typeNames = sender.draggingPasteboard.types?.map(\.rawValue).joined(separator: ",") ?? "nil"
+        let op = Self.imageDragOperation(for: sender) ?? super.draggingEntered(sender)
+        DiagnosticLog.log("draggingEntered types=\(typeNames) op=\(op.rawValue)")
+        return op
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        if let op = Self.imageDragOperation(for: sender) {
+            moveCaret(toDropPoint: sender.draggingLocation)
+            return op
+        }
+        return super.draggingUpdated(sender)
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        moveCaret(toDropPoint: sender.draggingLocation)
+        let pb = sender.draggingPasteboard
+        let pbTypeNames = pb.types?.map(\.rawValue).joined(separator: ",") ?? "nil"
+        DiagnosticLog.log("performDragOperation types=\(pbTypeNames)")
+
+        // Prefer file URLs — drops from Finder, Photos.
+        if let urls = pb.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true
+        ]) as? [URL], !urls.isEmpty {
+            let urlNames = urls.map(\.lastPathComponent).joined(separator: ",")
+            DiagnosticLog.log("performDragOperation file URLs: \(urlNames)")
+            let imageURLs = urls.filter {
+                ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
+            }
+            if !imageURLs.isEmpty {
+                return handleImageFileURLs(imageURLs)
+            }
+        }
+
+        // Fallback: raw image bytes on the pasteboard (drag from Preview, Safari image).
+        if let image = NSImage(pasteboard: pb), let png = Self.pngData(from: image) {
+            return insertPastedPNG(png)
+        }
+
+        DiagnosticLog.log("performDragOperation: falling through to super")
+        return super.performDragOperation(sender)
+    }
+
+    private static func imageDragOperation(for info: any NSDraggingInfo) -> NSDragOperation? {
+        let pb = info.draggingPasteboard
+        if let urls = pb.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true
+        ]) as? [URL], urls.contains(where: {
+            ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
+        }) {
+            return .copy
+        }
+        if pb.canReadObject(forClasses: [NSImage.self], options: nil) {
+            return .copy
+        }
+        return nil
+    }
+
+    private func moveCaret(toDropPoint windowPoint: NSPoint) {
+        let viewPoint = convert(windowPoint, from: nil)
+        let charIndex = characterIndexForInsertion(at: viewPoint)
+        setSelectedRange(NSRange(location: charIndex, length: 0))
+    }
+
+    // MARK: - Image-paste helpers
+
+    /// Public entry for SwiftUI's `.dropDestination` to route Finder file
+    /// drops into the editor. Writes each image as a sibling PNG and
+    /// inserts markdown at the current cursor.
+    @discardableResult
+    func handleDroppedImageFileURLs(_ urls: [URL]) -> Bool {
+        let imageURLs = urls.filter {
+            ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
+        }
+        guard !imageURLs.isEmpty else { return false }
+        return handleImageFileURLs(imageURLs)
+    }
+
+    @discardableResult
+    private func handleImageFileURLs(_ urls: [URL]) -> Bool {
+        guard let docURL = resolveDocumentURLForPaste() else {
+            DiagnosticLog.log("handleImageFileURLs: no document URL, aborting")
+            return false
+        }
+        var tokens: [String] = []
+        for url in urls {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+
+            do {
+                let data = try Data(contentsOf: url)
+                guard let png = Self.pngData(from: data) else {
+                    DiagnosticLog.log("handleImageFileURLs: decode failed for \(url.lastPathComponent)")
+                    continue
+                }
+                let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+                tokens.append(result.markdown)
+            } catch {
+                DiagnosticLog.log("handleImageFileURLs: \(url.lastPathComponent) error: \(error.localizedDescription)")
+            }
+        }
+        guard !tokens.isEmpty else { return false }
+        insertText(tokens.joined(separator: "\n"), replacementRange: selectedRange())
+        return true
+    }
+
+    @discardableResult
+    private func insertPastedPNG(_ png: Data) -> Bool {
+        guard let docURL = resolveDocumentURLForPaste() else { return false }
+        do {
+            let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+            insertText(result.markdown, replacementRange: selectedRange())
+            return true
+        } catch {
+            DiagnosticLog.log("Paste: failed to write sibling PNG: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    @discardableResult
+    private func beginImageDownload(from url: URL) -> Bool {
+        guard let docURL = resolveDocumentURLForPaste() else { return false }
+        let token = UUID().uuidString
+        let placeholder = "![](downloading…)<!--clearly-paste:\(token)-->"
+        insertText(placeholder, replacementRange: selectedRange())
+        Task { @MainActor [weak self] in
+            do {
+                let png = try await ImageDownloader.fetchImagePNG(from: url)
+                guard let self else { return }
+                let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+                self.replacePlaceholder(placeholder, with: result.markdown)
+            } catch {
+                DiagnosticLog.log("Paste: image download failed for \(url): \(error.localizedDescription)")
+                self?.replacePlaceholder(placeholder, with: "![](failed-download)")
+            }
+        }
+        return true
+    }
+
+    private func replacePlaceholder(_ placeholder: String, with replacement: String) {
+        let ns = string as NSString
+        let range = ns.range(of: placeholder)
+        guard range.location != NSNotFound else { return }
+        insertText(replacement, replacementRange: range)
+    }
+
+    private func resolveDocumentURLForPaste() -> URL? {
+        if let documentURL { return documentURL }
+        if let saved = onPasteRequiresSave?() {
+            documentURL = saved
+            return saved
+        }
+        NSSound.beep()
+        return nil
+    }
+
+    private static func pngData(from image: NSImage) -> Data? {
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    private static func pngData(from data: Data) -> Data? {
+        // Route through NSImage so ImageIO handles HEIC, WebP, GIF, etc. —
+        // NSBitmapImageRep's direct decode has narrower format support.
+        guard let image = NSImage(data: data) else { return nil }
+        return pngData(from: image)
     }
 
     // MARK: - Find

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -47,33 +47,6 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
     /// `performDragOperation(_:)`, so the panel's modal run is fine.
     var onPasteRequiresSave: (() -> URL?)?
 
-    /// SwiftUI's `.dropDestination` routes Finder file drops to the focused
-    /// editor via this notification. Carries `[URL]` in `userInfo["urls"]`.
-    static let insertDroppedImagesNotification = Notification.Name("ClearlyTextView.insertDroppedImages")
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        guard window != nil else { return }
-        NotificationCenter.default.addObserver(
-            self, selector: #selector(handleDroppedImagesNotification(_:)),
-            name: Self.insertDroppedImagesNotification, object: nil
-        )
-    }
-
-    override func viewWillMove(toWindow newWindow: NSWindow?) {
-        super.viewWillMove(toWindow: newWindow)
-        if newWindow == nil {
-            NotificationCenter.default.removeObserver(self, name: Self.insertDroppedImagesNotification, object: nil)
-        }
-    }
-
-    @objc private func handleDroppedImagesNotification(_ note: Notification) {
-        guard window?.isKeyWindow == true else { return }
-        guard let urls = note.userInfo?["urls"] as? [URL] else { return }
-        DiagnosticLog.log("ClearlyTextView received drop notification for \(urls.count) URL(s)")
-        handleDroppedImageFileURLs(urls)
-    }
-
     // MARK: - Wiki-Link Cmd+Click
 
     private static let wikiLinkRegex = try! NSRegularExpression(
@@ -164,35 +137,7 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     override func paste(_ sender: Any?) {
         let pasteboard = NSPasteboard.general
-
-        // 1. File URLs — if any are images, copy each to a sibling PNG.
-        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
-            .urlReadingFileURLsOnly: true
-        ]) as? [URL] {
-            let imageURLs = urls.filter {
-                ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
-            }
-            if !imageURLs.isEmpty {
-                handleImageFileURLs(imageURLs)
-                return
-            }
-        }
-
-        // 2. Raw image on the pasteboard (screenshot, copied from Preview, etc.).
-        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) {
-            if let image = NSImage(pasteboard: pasteboard), let png = Self.pngData(from: image) {
-                insertPastedPNG(png)
-                return
-            }
-        }
-
-        // 3. HTTP(S) URL string that looks like an image — async download.
-        if let text = pasteboard.string(forType: .string)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !text.contains("\n"), !text.contains(" "),
-           let url = URL(string: text), ImagePasteService.isLikelyImageURL(url) {
-            beginImageDownload(from: url)
-            return
-        }
+        if handleIncomingPasteboard(pasteboard) { return }
 
         if let plainText = pasteboard.string(forType: .string) {
             insertText(plainText, replacementRange: selectedRange())
@@ -201,35 +146,15 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         }
     }
 
-    // MARK: - Drag-and-drop
-
-    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        let typeNames = sender.draggingPasteboard.types?.map(\.rawValue).joined(separator: ",") ?? "nil"
-        let op = Self.imageDragOperation(for: sender) ?? super.draggingEntered(sender)
-        DiagnosticLog.log("draggingEntered types=\(typeNames) op=\(op.rawValue)")
-        return op
-    }
-
-    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        if let op = Self.imageDragOperation(for: sender) {
-            moveCaret(toDropPoint: sender.draggingLocation)
-            return op
-        }
-        return super.draggingUpdated(sender)
-    }
-
-    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-        moveCaret(toDropPoint: sender.draggingLocation)
-        let pb = sender.draggingPasteboard
-        let pbTypeNames = pb.types?.map(\.rawValue).joined(separator: ",") ?? "nil"
-        DiagnosticLog.log("performDragOperation types=\(pbTypeNames)")
-
-        // Prefer file URLs — drops from Finder, Photos.
-        if let urls = pb.readObjects(forClasses: [NSURL.self], options: [
+    @discardableResult
+    private func handleIncomingPasteboard(
+        _ pasteboard: NSPasteboard
+    ) -> Bool {
+        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
             .urlReadingFileURLsOnly: true
         ]) as? [URL], !urls.isEmpty {
             let urlNames = urls.map(\.lastPathComponent).joined(separator: ",")
-            DiagnosticLog.log("performDragOperation file URLs: \(urlNames)")
+            DiagnosticLog.log("handleIncomingPasteboard file URLs: \(urlNames)")
             let imageURLs = urls.filter {
                 ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
             }
@@ -238,49 +163,22 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
             }
         }
 
-        // Fallback: raw image bytes on the pasteboard (drag from Preview, Safari image).
-        if let image = NSImage(pasteboard: pb), let png = Self.pngData(from: image) {
+        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil),
+           let image = NSImage(pasteboard: pasteboard),
+           let png = Self.pngData(from: image) {
             return insertPastedPNG(png)
         }
 
-        DiagnosticLog.log("performDragOperation: falling through to super")
-        return super.performDragOperation(sender)
-    }
-
-    private static func imageDragOperation(for info: any NSDraggingInfo) -> NSDragOperation? {
-        let pb = info.draggingPasteboard
-        if let urls = pb.readObjects(forClasses: [NSURL.self], options: [
-            .urlReadingFileURLsOnly: true
-        ]) as? [URL], urls.contains(where: {
-            ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
-        }) {
-            return .copy
+        if let text = pasteboard.string(forType: .string)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !text.contains("\n"), !text.contains(" "),
+           let url = URL(string: text), ImagePasteService.isLikelyImageURL(url) {
+            return beginImageDownload(from: url)
         }
-        if pb.canReadObject(forClasses: [NSImage.self], options: nil) {
-            return .copy
-        }
-        return nil
-    }
 
-    private func moveCaret(toDropPoint windowPoint: NSPoint) {
-        let viewPoint = convert(windowPoint, from: nil)
-        let charIndex = characterIndexForInsertion(at: viewPoint)
-        setSelectedRange(NSRange(location: charIndex, length: 0))
+        return false
     }
 
     // MARK: - Image-paste helpers
-
-    /// Public entry for SwiftUI's `.dropDestination` to route Finder file
-    /// drops into the editor. Writes each image as a sibling PNG and
-    /// inserts markdown at the current cursor.
-    @discardableResult
-    func handleDroppedImageFileURLs(_ urls: [URL]) -> Bool {
-        let imageURLs = urls.filter {
-            ImagePasteService.imageFileExtensions.contains($0.pathExtension.lowercased())
-        }
-        guard !imageURLs.isEmpty else { return false }
-        return handleImageFileURLs(imageURLs)
-    }
 
     @discardableResult
     private func handleImageFileURLs(_ urls: [URL]) -> Bool {
@@ -295,11 +193,13 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
             do {
                 let data = try Data(contentsOf: url)
-                guard let png = Self.pngData(from: data) else {
-                    DiagnosticLog.log("handleImageFileURLs: decode failed for \(url.lastPathComponent)")
-                    continue
-                }
-                let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+                let ext = url.pathExtension.lowercased()
+                let result = try ImagePasteService.writeImageData(
+                    data,
+                    ext: ext,
+                    besidesDocumentAt: docURL,
+                    presenter: nil
+                )
                 tokens.append(result.markdown)
             } catch {
                 DiagnosticLog.log("handleImageFileURLs: \(url.lastPathComponent) error: \(error.localizedDescription)")

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -35,7 +35,7 @@ struct EditorView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         DiagnosticLog.log("makeNSView: creating EditorView (\(text.count) chars)")
-        let scrollView = NSScrollView()
+        let scrollView = DragForwardingScrollView()
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
@@ -103,6 +103,19 @@ struct EditorView: NSViewRepresentable {
                 userInfo: ["target": target, "heading": heading as Any]
             )
         }
+        textView.onPasteRequiresSave = {
+            let ws = WorkspaceManager.shared
+            _ = ws.saveCurrentFile()
+            return ws.currentFileURL
+        }
+        // NSTextView's `registeredDraggedTypes` is empty until it moves to a
+        // window, so append-based registration loses `.fileURL`. Register the
+        // union explicitly so Finder drags route to our override.
+        let existing = Set(textView.registeredDraggedTypes)
+        let required: Set<NSPasteboard.PasteboardType> = [.fileURL, .tiff, .png, .string, .rtf, .rtfd, .html]
+        textView.registerForDraggedTypes(Array(existing.union(required)))
+        let dragTypeNames = textView.registeredDraggedTypes.map(\.rawValue).joined(separator: ",")
+        DiagnosticLog.log("EditorView drag types registered: \(dragTypeNames)")
 
         scrollView.documentView = textView
 
@@ -842,5 +855,43 @@ struct EditorView: NSViewRepresentable {
             matchRanges = []
             currentMatchIdx = 0
         }
+    }
+}
+
+/// Forwards drag events from the scroll view onto its `ClearlyTextView`
+/// document view so drops on scroll-padding/empty-area also insert images.
+/// NSTextView only receives drag events when the drop lands directly on it;
+/// short documents leave a large background region that would otherwise
+/// reject drops even though the editor is the visible target.
+final class DragForwardingScrollView: NSScrollView {
+
+    private var imageTypes: [NSPasteboard.PasteboardType] {
+        [.fileURL, .tiff, .png]
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes(imageTypes)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes(imageTypes)
+    }
+
+    private var imageTextView: ClearlyTextView? { documentView as? ClearlyTextView }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        DiagnosticLog.log("DragForwardingScrollView draggingEntered")
+        return imageTextView?.draggingEntered(sender) ?? []
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        imageTextView?.draggingUpdated(sender) ?? []
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        DiagnosticLog.log("DragForwardingScrollView performDragOperation")
+        return imageTextView?.performDragOperation(sender) ?? false
     }
 }

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -35,7 +35,7 @@ struct EditorView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         DiagnosticLog.log("makeNSView: creating EditorView (\(text.count) chars)")
-        let scrollView = DragForwardingScrollView()
+        let scrollView = NSScrollView()
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
@@ -108,15 +108,6 @@ struct EditorView: NSViewRepresentable {
             _ = ws.saveCurrentFile()
             return ws.currentFileURL
         }
-        // NSTextView's `registeredDraggedTypes` is empty until it moves to a
-        // window, so append-based registration loses `.fileURL`. Register the
-        // union explicitly so Finder drags route to our override.
-        let existing = Set(textView.registeredDraggedTypes)
-        let required: Set<NSPasteboard.PasteboardType> = [.fileURL, .tiff, .png, .string, .rtf, .rtfd, .html]
-        textView.registerForDraggedTypes(Array(existing.union(required)))
-        let dragTypeNames = textView.registeredDraggedTypes.map(\.rawValue).joined(separator: ",")
-        DiagnosticLog.log("EditorView drag types registered: \(dragTypeNames)")
-
         scrollView.documentView = textView
 
         // Line number gutter (plain NSView, not NSRulerView)
@@ -365,7 +356,7 @@ struct EditorView: NSViewRepresentable {
         var highlighter: MarkdownSyntaxHighlighter?
         var lastEditedRange: NSRange?
         var lastReplacementLength: Int = 0
-        weak var textView: NSTextView?
+        weak var textView: ClearlyTextView?
         weak var gutterView: LineNumberGutterView?
         var lastMode: ViewMode?
         var lastPositionSyncID: String?
@@ -464,7 +455,7 @@ struct EditorView: NSViewRepresentable {
 
         @objc func flushEditorBuffer(_ notification: Notification) {
             guard let textView else { return }
-            parent.text = textView.string
+            commitTextViewContents(textView)
         }
 
         @objc func textViewFrameDidChange(_ notification: Notification) {
@@ -648,8 +639,13 @@ struct EditorView: NSViewRepresentable {
                 guard gen == self.editGeneration else { return }
                 guard self.lastPositionSyncID == scheduledPositionSyncID else { return }
                 guard let textView = self.textView else { return }
-                self.parent.text = textView.string
+                self.commitTextViewContents(textView)
             }
+        }
+
+        private func commitTextViewContents(_ textView: NSTextView) {
+            parent.text = textView.string
+            WorkspaceManager.shared.contentDidChange()
         }
 
         // MARK: - Wiki-Link Auto-Complete
@@ -855,43 +851,5 @@ struct EditorView: NSViewRepresentable {
             matchRanges = []
             currentMatchIdx = 0
         }
-    }
-}
-
-/// Forwards drag events from the scroll view onto its `ClearlyTextView`
-/// document view so drops on scroll-padding/empty-area also insert images.
-/// NSTextView only receives drag events when the drop lands directly on it;
-/// short documents leave a large background region that would otherwise
-/// reject drops even though the editor is the visible target.
-final class DragForwardingScrollView: NSScrollView {
-
-    private var imageTypes: [NSPasteboard.PasteboardType] {
-        [.fileURL, .tiff, .png]
-    }
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        registerForDraggedTypes(imageTypes)
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        registerForDraggedTypes(imageTypes)
-    }
-
-    private var imageTextView: ClearlyTextView? { documentView as? ClearlyTextView }
-
-    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        DiagnosticLog.log("DragForwardingScrollView draggingEntered")
-        return imageTextView?.draggingEntered(sender) ?? []
-    }
-
-    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        imageTextView?.draggingUpdated(sender) ?? []
-    }
-
-    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-        DiagnosticLog.log("DragForwardingScrollView performDragOperation")
-        return imageTextView?.performDragOperation(sender) ?? false
     }
 }

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 import ClearlyCore
 
 // MARK: - Toolbar (root-attached)

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
 import ClearlyCore
 
 /// Root view for the native macOS shell — two-column `NavigationSplitView`:
@@ -25,14 +24,6 @@ struct MacRootView: View {
             WelcomeView(workspace: workspace)
         } else {
             splitView
-                .background(AppKitDropCatcher { urls in
-                    DiagnosticLog.log("AppKitDropCatcher handling \(urls.count) URL(s)")
-                    NotificationCenter.default.post(
-                        name: ClearlyTextView.insertDroppedImagesNotification,
-                        object: nil, userInfo: ["urls": urls]
-                    )
-                })
-                .onDrop(of: ["public.file-url"], delegate: ImageFileDropDelegate())
         }
     }
 
@@ -101,121 +92,5 @@ struct MacRootView: View {
             return "Clearly"
         }
         return workspace.isDirty ? "\u{2022} \(doc.displayName)" : doc.displayName
-    }
-}
-
-/// Routes Finder file drops anywhere in the main window to the currently
-/// focused `ClearlyTextView`. SwiftUI's `.onDrop(of:delegate:)` is the
-/// canonical macOS pattern; `.dropDestination(for:URL.self)` and `.onDrop`
-/// on NSViewRepresentable both proved unreliable under `NavigationSplitView`.
-struct ImageFileDropDelegate: DropDelegate {
-
-    func validateDrop(info: DropInfo) -> Bool {
-        let ok = info.hasItemsConforming(to: ["public.file-url"])
-        DiagnosticLog.log("DROP validateDrop ok=\(ok) loc=\(info.location)")
-        return ok
-    }
-
-    func dropEntered(info: DropInfo) {
-        DiagnosticLog.log("DROP dropEntered loc=\(info.location)")
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DiagnosticLog.log("DROP dropUpdated loc=\(info.location)")
-        return DropProposal(operation: .copy)
-    }
-
-    func dropExited(info: DropInfo) {
-        DiagnosticLog.log("DROP dropExited loc=\(info.location)")
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        DiagnosticLog.log("DROP performDrop ENTERED loc=\(info.location)")
-        let providers = info.itemProviders(for: ["public.file-url"])
-        DiagnosticLog.log("DROP performDrop providers=\(providers.count)")
-        guard !providers.isEmpty else { return false }
-
-        Task { @MainActor in
-            var urls: [URL] = []
-            for provider in providers {
-                if let url = await Self.loadFileURL(from: provider) { urls.append(url) }
-            }
-            DiagnosticLog.log("DROP resolved \(urls.count) URLs: \(urls.map(\.lastPathComponent).joined(separator: ","))")
-            guard !urls.isEmpty else { return }
-            NotificationCenter.default.post(
-                name: ClearlyTextView.insertDroppedImagesNotification,
-                object: nil, userInfo: ["urls": urls]
-            )
-        }
-        return true
-    }
-
-    private static func loadFileURL(from provider: NSItemProvider) async -> URL? {
-        await withCheckedContinuation { cont in
-            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, _ in
-                if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
-                    cont.resume(returning: url)
-                } else if let url = item as? URL {
-                    cont.resume(returning: url)
-                } else {
-                    cont.resume(returning: nil)
-                }
-            }
-        }
-    }
-}
-
-/// Fallback AppKit drop catcher placed as a SwiftUI `.background`. Registers
-/// directly with `NSView`'s drag machinery so we get definitive diagnostics
-/// even when SwiftUI's drop chain misbehaves inside a `NavigationSplitView`.
-struct AppKitDropCatcher: NSViewRepresentable {
-    let onDrop: ([URL]) -> Void
-
-    func makeNSView(context: Context) -> DropCatcherView {
-        let v = DropCatcherView()
-        v.onDrop = onDrop
-        v.registerForDraggedTypes([.fileURL, .tiff, .png, .URL])
-        DiagnosticLog.log("AppKitDropCatcher makeNSView registered=\(v.registeredDraggedTypes.map(\.rawValue).joined(separator: ","))")
-        return v
-    }
-
-    func updateNSView(_ nsView: DropCatcherView, context: Context) {
-        nsView.onDrop = onDrop
-    }
-
-    final class DropCatcherView: NSView {
-        var onDrop: (([URL]) -> Void)?
-
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            // Don't intercept mouse events — only drag events.
-            return nil
-        }
-
-        override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-            DiagnosticLog.log("DropCatcherView draggingEntered")
-            return .copy
-        }
-
-        override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
-            return .copy
-        }
-
-        override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-            DiagnosticLog.log("DropCatcherView prepareForDragOperation")
-            return true
-        }
-
-        override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-            DiagnosticLog.log("DropCatcherView performDragOperation")
-            let pb = sender.draggingPasteboard
-            guard let urls = pb.readObjects(forClasses: [NSURL.self], options: [
-                .urlReadingFileURLsOnly: true
-            ]) as? [URL], !urls.isEmpty else {
-                DiagnosticLog.log("DropCatcherView no file URLs on pasteboard")
-                return false
-            }
-            onDrop?(urls)
-            return true
-        }
     }
 }

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 import ClearlyCore
 
 /// Root view for the native macOS shell — two-column `NavigationSplitView`:
@@ -24,6 +25,14 @@ struct MacRootView: View {
             WelcomeView(workspace: workspace)
         } else {
             splitView
+                .background(AppKitDropCatcher { urls in
+                    DiagnosticLog.log("AppKitDropCatcher handling \(urls.count) URL(s)")
+                    NotificationCenter.default.post(
+                        name: ClearlyTextView.insertDroppedImagesNotification,
+                        object: nil, userInfo: ["urls": urls]
+                    )
+                })
+                .onDrop(of: ["public.file-url"], delegate: ImageFileDropDelegate())
         }
     }
 
@@ -92,5 +101,121 @@ struct MacRootView: View {
             return "Clearly"
         }
         return workspace.isDirty ? "\u{2022} \(doc.displayName)" : doc.displayName
+    }
+}
+
+/// Routes Finder file drops anywhere in the main window to the currently
+/// focused `ClearlyTextView`. SwiftUI's `.onDrop(of:delegate:)` is the
+/// canonical macOS pattern; `.dropDestination(for:URL.self)` and `.onDrop`
+/// on NSViewRepresentable both proved unreliable under `NavigationSplitView`.
+struct ImageFileDropDelegate: DropDelegate {
+
+    func validateDrop(info: DropInfo) -> Bool {
+        let ok = info.hasItemsConforming(to: ["public.file-url"])
+        DiagnosticLog.log("DROP validateDrop ok=\(ok) loc=\(info.location)")
+        return ok
+    }
+
+    func dropEntered(info: DropInfo) {
+        DiagnosticLog.log("DROP dropEntered loc=\(info.location)")
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DiagnosticLog.log("DROP dropUpdated loc=\(info.location)")
+        return DropProposal(operation: .copy)
+    }
+
+    func dropExited(info: DropInfo) {
+        DiagnosticLog.log("DROP dropExited loc=\(info.location)")
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        DiagnosticLog.log("DROP performDrop ENTERED loc=\(info.location)")
+        let providers = info.itemProviders(for: ["public.file-url"])
+        DiagnosticLog.log("DROP performDrop providers=\(providers.count)")
+        guard !providers.isEmpty else { return false }
+
+        Task { @MainActor in
+            var urls: [URL] = []
+            for provider in providers {
+                if let url = await Self.loadFileURL(from: provider) { urls.append(url) }
+            }
+            DiagnosticLog.log("DROP resolved \(urls.count) URLs: \(urls.map(\.lastPathComponent).joined(separator: ","))")
+            guard !urls.isEmpty else { return }
+            NotificationCenter.default.post(
+                name: ClearlyTextView.insertDroppedImagesNotification,
+                object: nil, userInfo: ["urls": urls]
+            )
+        }
+        return true
+    }
+
+    private static func loadFileURL(from provider: NSItemProvider) async -> URL? {
+        await withCheckedContinuation { cont in
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, _ in
+                if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                    cont.resume(returning: url)
+                } else if let url = item as? URL {
+                    cont.resume(returning: url)
+                } else {
+                    cont.resume(returning: nil)
+                }
+            }
+        }
+    }
+}
+
+/// Fallback AppKit drop catcher placed as a SwiftUI `.background`. Registers
+/// directly with `NSView`'s drag machinery so we get definitive diagnostics
+/// even when SwiftUI's drop chain misbehaves inside a `NavigationSplitView`.
+struct AppKitDropCatcher: NSViewRepresentable {
+    let onDrop: ([URL]) -> Void
+
+    func makeNSView(context: Context) -> DropCatcherView {
+        let v = DropCatcherView()
+        v.onDrop = onDrop
+        v.registerForDraggedTypes([.fileURL, .tiff, .png, .URL])
+        DiagnosticLog.log("AppKitDropCatcher makeNSView registered=\(v.registeredDraggedTypes.map(\.rawValue).joined(separator: ","))")
+        return v
+    }
+
+    func updateNSView(_ nsView: DropCatcherView, context: Context) {
+        nsView.onDrop = onDrop
+    }
+
+    final class DropCatcherView: NSView {
+        var onDrop: (([URL]) -> Void)?
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            // Don't intercept mouse events — only drag events.
+            return nil
+        }
+
+        override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+            DiagnosticLog.log("DropCatcherView draggingEntered")
+            return .copy
+        }
+
+        override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+            return .copy
+        }
+
+        override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+            DiagnosticLog.log("DropCatcherView prepareForDragOperation")
+            return true
+        }
+
+        override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+            DiagnosticLog.log("DropCatcherView performDragOperation")
+            let pb = sender.draggingPasteboard
+            guard let urls = pb.readObjects(forClasses: [NSURL.self], options: [
+                .urlReadingFileURLsOnly: true
+            ]) as? [URL], !urls.isEmpty else {
+                DiagnosticLog.log("DropCatcherView no file URLs on pasteboard")
+                return false
+            }
+            onDrop?(urls)
+            return true
+        }
     }
 }

--- a/Clearly/iOS/ClearlyUITextView.swift
+++ b/Clearly/iOS/ClearlyUITextView.swift
@@ -7,6 +7,10 @@ import ClearlyCore
 /// where highlighting is driven by the delegate rather than the view.
 final class ClearlyUITextView: UITextView {
 
+    /// Path of the open `.md` document. Set by `EditorView_iOS` each update
+    /// pass so paste/drop handlers can compute sibling image URLs.
+    var documentURL: URL?
+
     init() {
         let storage = NSTextStorage()
         let manager = NSLayoutManager()
@@ -54,5 +58,99 @@ final class ClearlyUITextView: UITextView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Paste
+
+    override func paste(_ sender: Any?) {
+        let pb = UIPasteboard.general
+
+        // 1. Raw image on pasteboard — normalize HEIC/JPEG/etc. to PNG.
+        if pb.hasImages, let image = pb.image, let png = image.pngData() {
+            insertPastedPNG(png)
+            return
+        }
+
+        // 2. URL object on pasteboard that looks like an image — download.
+        if pb.hasURLs, let url = pb.urls?.first, ImagePasteService.isLikelyImageURL(url) {
+            beginImageDownload(from: url)
+            return
+        }
+
+        // 3. Plain string that parses into an http(s) image URL — download.
+        if pb.hasStrings,
+           let raw = pb.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.contains("\n"), !raw.contains(" "),
+           let url = URL(string: raw), ImagePasteService.isLikelyImageURL(url) {
+            beginImageDownload(from: url)
+            return
+        }
+
+        super.paste(sender)
+    }
+
+    /// Public entry for the drop delegate in `EditorView_iOS` — inserts the
+    /// image at the currently-selected range after writing a sibling PNG.
+    func handleDroppedImageData(_ data: Data) {
+        guard let image = UIImage(data: data), let png = image.pngData() else {
+            DiagnosticLog.log("iOS drop: failed to decode image data")
+            return
+        }
+        insertPastedPNG(png)
+    }
+
+    // MARK: - Image-paste helpers
+
+    private func insertPastedPNG(_ png: Data) {
+        guard let docURL = documentURL else {
+            DiagnosticLog.log("iOS paste: documentURL not set, cannot write sibling PNG")
+            return
+        }
+        do {
+            let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+            insertMarkdown(result.markdown)
+        } catch {
+            DiagnosticLog.log("iOS paste: failed to write sibling PNG: \(error.localizedDescription)")
+        }
+    }
+
+    private func beginImageDownload(from url: URL) {
+        guard let docURL = documentURL else {
+            DiagnosticLog.log("iOS paste: documentURL not set, cannot download")
+            return
+        }
+        let token = UUID().uuidString
+        let placeholder = "![](downloading…)<!--clearly-paste:\(token)-->"
+        insertMarkdown(placeholder)
+        Task { @MainActor [weak self] in
+            do {
+                let png = try await ImageDownloader.fetchImagePNG(from: url)
+                guard let self else { return }
+                let result = try ImagePasteService.writePNG(png, besidesDocumentAt: docURL, presenter: nil)
+                self.replacePlaceholder(placeholder, with: result.markdown)
+            } catch {
+                DiagnosticLog.log("iOS paste: image download failed for \(url): \(error.localizedDescription)")
+                self?.replacePlaceholder(placeholder, with: "![](failed-download)")
+            }
+        }
+    }
+
+    private func insertMarkdown(_ markdown: String) {
+        let range = selectedRange
+        let current = (text ?? "") as NSString
+        let updated = current.replacingCharacters(in: range, with: markdown)
+        text = updated
+        let caret = range.location + (markdown as NSString).length
+        selectedRange = NSRange(location: caret, length: 0)
+        delegate?.textViewDidChange?(self)
+    }
+
+    private func replacePlaceholder(_ placeholder: String, with replacement: String) {
+        let current = (text ?? "") as NSString
+        let range = current.range(of: placeholder)
+        guard range.location != NSNotFound else { return }
+        let updated = current.replacingCharacters(in: range, with: replacement)
+        text = updated
+        delegate?.textViewDidChange?(self)
     }
 }

--- a/Clearly/iOS/DocumentDetailBody.swift
+++ b/Clearly/iOS/DocumentDetailBody.swift
@@ -148,6 +148,7 @@ struct DocumentDetailBody: View {
                         get: { session.text },
                         set: { session.text = $0 }
                     ),
+                    documentURL: file.url,
                     outlineState: outlineState,
                     findState: findState
                 )

--- a/Clearly/iOS/EditorView_iOS.swift
+++ b/Clearly/iOS/EditorView_iOS.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 import ClearlyCore
 
 /// Writable iOS markdown editor. Binding writes back inside
@@ -10,6 +11,7 @@ import ClearlyCore
 struct EditorView_iOS: UIViewRepresentable {
 
     @Binding var text: String
+    var documentURL: URL? = nil
     var outlineState: OutlineState? = nil
     var findState: FindState? = nil
 
@@ -18,6 +20,8 @@ struct EditorView_iOS: UIViewRepresentable {
     func makeUIView(context: Context) -> ClearlyUITextView {
         let textView = ClearlyUITextView()
         textView.delegate = context.coordinator
+        textView.documentURL = documentURL
+        textView.addInteraction(UIDropInteraction(delegate: context.coordinator))
         context.coordinator.textView = textView
         context.coordinator.applyExternalText(text)
         context.coordinator.attachOutlineState(outlineState)
@@ -37,6 +41,7 @@ struct EditorView_iOS: UIViewRepresentable {
 
     func updateUIView(_ textView: ClearlyUITextView, context: Context) {
         context.coordinator.parent = self
+        textView.documentURL = documentURL
         context.coordinator.attachOutlineState(outlineState)
         context.coordinator.attachFindState(findState)
         guard context.coordinator.pendingBindingUpdates == 0 else { return }
@@ -275,6 +280,60 @@ struct EditorView_iOS: UIViewRepresentable {
                 guard let self, self.pendingBindingUpdateToken == token else { return }
                 self.pendingBindingUpdateToken = nil
                 self.pendingBindingUpdates = 0
+            }
+        }
+    }
+}
+
+// MARK: - UIDropInteractionDelegate
+
+extension EditorView_iOS.Coordinator: UIDropInteractionDelegate {
+
+    func dropInteraction(_ interaction: UIDropInteraction,
+                         canHandle session: any UIDropSession) -> Bool {
+        return session.hasItemsConforming(toTypeIdentifiers: [UTType.image.identifier])
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction,
+                         sessionDidUpdate session: any UIDropSession) -> UIDropProposal {
+        if let textView, let pos = textView.closestPosition(to: session.location(in: textView)) {
+            let caret = textView.offset(from: textView.beginningOfDocument, to: pos)
+            textView.selectedRange = NSRange(location: caret, length: 0)
+        }
+        return UIDropProposal(operation: .copy)
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction,
+                         performDrop session: any UIDropSession) {
+        guard let textView else { return }
+        let providers: [NSItemProvider] = session.items
+            .map { $0.itemProvider }
+            .filter { $0.hasItemConformingToTypeIdentifier(UTType.image.identifier) }
+        guard !providers.isEmpty else { return }
+
+        // Load all items in parallel, then apply inserts on the main actor in
+        // the order items appeared so drop order is preserved.
+        Task { @MainActor [weak textView] in
+            var datas: [Data?] = Array(repeating: nil, count: providers.count)
+            await withTaskGroup(of: (Int, Data?).self) { group in
+                for (idx, provider) in providers.enumerated() {
+                    group.addTask {
+                        let data: Data? = await withCheckedContinuation { cont in
+                            provider.loadDataRepresentation(
+                                forTypeIdentifier: UTType.image.identifier
+                            ) { data, _ in
+                                cont.resume(returning: data)
+                            }
+                        }
+                        return (idx, data)
+                    }
+                }
+                for await (idx, data) in group { datas[idx] = data }
+            }
+            guard let textView else { return }
+            for data in datas {
+                guard let data else { continue }
+                textView.handleDroppedImageData(data)
             }
         }
     }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImageDownloader.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImageDownloader.swift
@@ -1,0 +1,58 @@
+import Foundation
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+public enum ImageDownloadError: Error {
+    case invalidResponse
+    case notAnImage
+    case tooLarge
+    case decodeFailed
+}
+
+public enum ImageDownloader {
+
+    /// Cap downloaded image bytes so a giant URL can't wedge the paste.
+    public static let maxBytes: Int64 = 20 * 1024 * 1024
+
+    /// Fetches `url` and returns PNG-encoded bytes. Validates the response's
+    /// `Content-Type` starts with `image/`, enforces a 20 MB cap, and
+    /// re-encodes via the platform image decoder so HEIC/WebP/etc. all
+    /// normalize to PNG for cross-platform rendering in WKWebView.
+    public static func fetchImagePNG(from url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ImageDownloadError.invalidResponse
+        }
+        if let mime = http.mimeType, !mime.lowercased().hasPrefix("image/") {
+            throw ImageDownloadError.notAnImage
+        }
+        if Int64(data.count) > maxBytes {
+            throw ImageDownloadError.tooLarge
+        }
+        return try encodePNG(from: data)
+    }
+
+    #if os(macOS)
+    private static func encodePNG(from data: Data) throws -> Data {
+        // Route through NSImage so ImageIO decodes HEIC/WebP/etc., then
+        // NSBitmapImageRep re-encodes from TIFF.
+        guard let image = NSImage(data: data),
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            throw ImageDownloadError.decodeFailed
+        }
+        return png
+    }
+    #else
+    private static func encodePNG(from data: Data) throws -> Data {
+        guard let image = UIImage(data: data), let png = image.pngData() else {
+            throw ImageDownloadError.decodeFailed
+        }
+        return png
+    }
+    #endif
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
@@ -77,12 +77,23 @@ public enum ImagePasteService {
     /// Writes PNG bytes to a sibling file next to `docURL` via coordinated
     /// I/O, returning the resulting URL and the relative-path markdown
     /// token (`![](slug-N.png)`) to insert into the editor.
+    public static func writeImageData(_ data: Data,
+                                      ext: String,
+                                      besidesDocumentAt docURL: URL,
+                                      presenter: NSFilePresenter?) throws -> WriteResult {
+        let normalizedExt = ext.lowercased().isEmpty ? "png" : ext.lowercased()
+        let url = nextImageURL(besidesDocumentAt: docURL, ext: normalizedExt)
+        try CoordinatedFileIO.write(data, to: url, presenter: presenter)
+        let encoded = url.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url.lastPathComponent
+        return WriteResult(url: url, markdown: "![](\(encoded))")
+    }
+
+    /// Writes PNG bytes to a sibling file next to `docURL` via coordinated
+    /// I/O, returning the resulting URL and the relative-path markdown
+    /// token (`![](slug-N.png)`) to insert into the editor.
     public static func writePNG(_ pngData: Data,
                                 besidesDocumentAt docURL: URL,
                                 presenter: NSFilePresenter?) throws -> WriteResult {
-        let url = nextImageURL(besidesDocumentAt: docURL, ext: "png")
-        try CoordinatedFileIO.write(pngData, to: url, presenter: presenter)
-        let encoded = url.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url.lastPathComponent
-        return WriteResult(url: url, markdown: "![](\(encoded))")
+        try writeImageData(pngData, ext: "png", besidesDocumentAt: docURL, presenter: presenter)
     }
 }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Writes pasted/dropped images to disk next to the open `.md` document.
+/// Filenames follow `<slug>-<N>.<ext>` with a linear counter derived from
+/// sibling files in the same directory. Always coordinated through
+/// `CoordinatedFileIO` so the iCloud presenter dance works on iOS.
+public enum ImagePasteService {
+
+    public struct WriteResult {
+        public let url: URL
+        public let markdown: String
+    }
+
+    /// Extensions Clearly treats as pastable/droppable image files. Used on
+    /// both platforms to filter incoming pasteboard / drop items.
+    public static let imageFileExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "gif", "webp", "svg", "tiff", "tif", "bmp", "heic"
+    ]
+
+    /// URL is worth attempting to download as an image when it's HTTP(S) and
+    /// either its path ends in a known image extension OR it has no
+    /// extension (common for CDN / signed URLs — MIME check decides later).
+    public static func isLikelyImageURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return false }
+        let ext = url.pathExtension.lowercased()
+        if ext.isEmpty { return true }
+        return imageFileExtensions.contains(ext)
+    }
+
+    /// Derive a URL-safe slug from the document's filename stem. Lowercased,
+    /// non-alphanumerics collapsed to `-`, capped at 40 chars so the final
+    /// image filename stays well under APFS's 255-byte limit even with a
+    /// high counter. Falls back to `"image"` for empty input.
+    public static func imageSlug(fromDocumentStem stem: String) -> String {
+        let sanitized = UntitledRename.sanitizeFilename(stem).lowercased()
+        var chars: [Character] = []
+        var lastWasDash = false
+        for char in sanitized {
+            if char.isLetter || char.isNumber {
+                chars.append(char)
+                lastWasDash = false
+            } else if !lastWasDash {
+                chars.append("-")
+                lastWasDash = true
+            }
+        }
+        var slug = String(chars)
+        while slug.hasPrefix("-") { slug.removeFirst() }
+        while slug.hasSuffix("-") { slug.removeLast() }
+        if slug.count > 40 {
+            slug = String(slug.prefix(40))
+            while slug.hasSuffix("-") { slug.removeLast() }
+        }
+        return slug.isEmpty ? "image" : slug
+    }
+
+    /// Next collision-free URL of the form `<slug>-<N>.<ext>` in the same
+    /// directory as `docURL`. Scans existing siblings for the highest N
+    /// matching the prefix and returns N+1.
+    public static func nextImageURL(besidesDocumentAt docURL: URL, ext: String = "png") -> URL {
+        let parent = docURL.deletingLastPathComponent()
+        let stem = (docURL.lastPathComponent as NSString).deletingPathExtension
+        let slug = imageSlug(fromDocumentStem: stem)
+        let prefix = "\(slug)-"
+        let siblings = (try? FileManager.default.contentsOfDirectory(atPath: parent.path)) ?? []
+        var maxN = 0
+        for name in siblings {
+            guard name.hasPrefix(prefix) else { continue }
+            guard (name as NSString).pathExtension.lowercased() == ext.lowercased() else { continue }
+            let nameStem = (name as NSString).deletingPathExtension
+            let suffix = String(nameStem.dropFirst(prefix.count))
+            if let n = Int(suffix), n > maxN { maxN = n }
+        }
+        return parent.appendingPathComponent("\(prefix)\(maxN + 1).\(ext)")
+    }
+
+    /// Writes PNG bytes to a sibling file next to `docURL` via coordinated
+    /// I/O, returning the resulting URL and the relative-path markdown
+    /// token (`![](slug-N.png)`) to insert into the editor.
+    public static func writePNG(_ pngData: Data,
+                                besidesDocumentAt docURL: URL,
+                                presenter: NSFilePresenter?) throws -> WriteResult {
+        let url = nextImageURL(besidesDocumentAt: docURL, ext: "png")
+        try CoordinatedFileIO.write(pngData, to: url, presenter: presenter)
+        let encoded = url.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url.lastPathComponent
+        return WriteResult(url: url, markdown: "![](\(encoded))")
+    }
+}


### PR DESCRIPTION
## Summary
- Mac and iOS editors now accept pasted clipboard images, dragged image files, and HTTP(S) image URLs, writing each next to the `.md` as `<slug>-N.png` (or original extension for file drops) and inserting `![](…)` at the caret.
- Shared `ImagePasteService` + `ImageDownloader` in `ClearlyCore` handle slug derivation, collision counters, coordinated writes, and async URL downloads with HEIC/WebP normalization to PNG.
- Mac untitled documents prompt to save before the first image lands, so sibling paths always resolve.

## Test plan
- [ ] Copy a screenshot → paste into a saved Mac doc → sibling PNG written, preview renders.
- [ ] Drag a PNG from Finder into the editor → sibling copy, `![](…)` inserted.
- [ ] Paste an HTTPS image URL → placeholder appears, swaps when download completes.
- [ ] iOS: paste a HEIC from Photos → normalizes to PNG on disk.
- [ ] iOS: drag an image from Files/Photos onto the editor → sibling PNG written.

Fixes #198