### PR TITLE
[mac] Fix ⌘+H removing Dock icon instead of hiding windows (#204)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -618,6 +618,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     }
 
     private func updateActivationPolicy() {
+        // ⌘+H sets isVisible = false on every window. Treating that as
+        // "no documents open" would demote us to .accessory and strip the
+        // Dock icon + ⌘+Tab entry. Bug #204.
+        if NSApp.isHidden { return }
+
         if hasDocumentWindows() || !showMenuBarIcon {
             if NSApp.activationPolicy() != .regular {
                 NSApp.setActivationPolicy(.regular)


### PR DESCRIPTION
## Summary
- `NSApp.hide(_:)` (the target of ⌘+H) sets `isVisible = false` on every window, so the deferred `updateActivationPolicy()` saw "no visible documents" and demoted the app to `.accessory` — stripping the Dock icon and ⌘+Tab entry. Users had to relaunch from Spotlight to get back in.
- Added a `guard !NSApp.isHidden` early-return in `updateActivationPolicy()` so policy changes only run when the app is actually foregrounded or deactivated, not merely hidden. The existing close-last-window path to `.accessory` (menu-bar-only mode) is unaffected.

Fixes #204

## Test plan
- [x] ⌘+H with "Show menu bar icon" enabled → window hides, Dock icon stays, app remains in ⌘+Tab
- [x] Close last document window with menu-bar icon enabled → Dock icon disappears (accessory mode preserved)
- [x] ⌘+H with menu-bar icon disabled → window hides, Dock icon stays (unchanged)