### PR TITLE
[mac] Fix pasted text disappearing in editor until scroll

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -601,6 +601,7 @@ struct EditorView: NSViewRepresentable {
                         sv.contentView.scroll(to: origin)
                         sv.reflectScrolledClipView(sv.contentView)
                     }
+                    self.invalidateVisibleRegion(of: textView)
                     self.restoreFindHighlightsIfNeeded()
                 }
                 pendingFullHighlightWork = work
@@ -612,6 +613,11 @@ struct EditorView: NSViewRepresentable {
                 scrollView.contentView.scroll(to: savedOrigin)
                 scrollView.reflectScrolledClipView(scrollView.contentView)
             }
+
+            // Attribute-only highlighting doesn't invalidate display, so mark
+            // the viewport dirty after restoring scroll. Limit invalidation to
+            // the visible rect so large documents don't repaint end-to-end.
+            invalidateVisibleRegion(of: textView)
 
             // Re-apply find highlights after syntax highlighting
             restoreFindHighlightsIfNeeded()
@@ -748,6 +754,11 @@ struct EditorView: NSViewRepresentable {
             ScrollBridge.setFraction(fraction, for: parent.positionSyncID)
 
             gutterView?.scrollOrFrameDidChange()
+        }
+
+        private func invalidateVisibleRegion(of textView: NSTextView) {
+            let visibleRect = textView.enclosingScrollView?.contentView.documentVisibleRect ?? textView.visibleRect
+            textView.setNeedsDisplay(visibleRect, avoidAdditionalLayout: true)
         }
 
         // MARK: - Find


### PR DESCRIPTION
## Summary
- Large pastes (~1000 words) rendered blank in the editor view until a tiny scroll event forced a redraw.
- With `allowsNonContiguousLayout` enabled, `NSLayoutManager` defers work for regions that aren't proactively drawn, and `textDidChange`'s attribute-only syntax highlighting never marked the view dirty.
- Added `invalidateVisibleRegion(of:)` helper that calls `setNeedsDisplay(_:avoidAdditionalLayout:)` on the visible rect after highlighting (both the main path and the deferred full-highlight path), so NSTextView repaints the restored viewport.

## Test plan
- [x] Build succeeds (Debug)
- [ ] Paste ~1000 words into a document — text stays visible, no scroll required
- [ ] Small edits and typing still render normally
- [ ] Code-fence edits (triggering the deferred full-highlight path) also redraw correctly