### PR TITLE
[mac] Replace Terminal CLI install with ~/.local/bin symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,17 +106,19 @@ The app ships through two channels from the same codebase:
 
 When adding new Sparkle-dependent code, always wrap it in `#if canImport(Sparkle)`. The App Store build must compile cleanly without the Sparkle module.
 
-### Privileged ops from the sandboxed app
+### CLI install: user-local, no privileged ops
 
-Clearly is sandboxed, so any operation that needs root (`/usr/local/bin/` writes, privileged installs) can't route through `NSAppleScript … with administrator privileges` — that path is silently blocked and surfaces as a misleading **"The administrator user name or password was incorrect"** error with no SecurityAgent dialog ever appearing. Don't use it.
+Clearly is sandboxed. Historically, the CLI installer drove Terminal via AppleScript to run `sudo ln -sf … /usr/local/bin/clearly`. That path was fragile (required two separate AppleEvents entitlements on hardened runtime, broke silently on macOS 26 — see issue #241) and is no longer used.
 
-The working pattern (see `Clearly/CLIInstaller.swift`) is `tell application "Terminal" to do script "sudo …"`. Terminal's own inline sudo prompt handles authentication. Required pieces:
+The current installer (`Clearly/CLIInstaller.swift`) writes a symlink directly at `~/.local/bin/clearly` using `FileManager.createSymbolicLink`, requiring no sudo, no Terminal, no Apple Events. Required pieces:
 
-- `com.apple.security.temporary-exception.apple-events` with `com.apple.Terminal` as the only target in `Clearly.entitlements`.
-- `NSAppleEventsUsageDescription` in `Info.plist` with a user-visible reason. **Without it, TCC silently auto-denies — the consent prompt never appears.** This was the single most time-consuming debug step during Phase 5 of `local-mcp-cli`.
-- For ad-hoc-signed Debug builds iterating on AppleEvents, TCC can cache stale denials across rebuilds. Reset with `tccutil reset AppleEvents com.sabotage.clearly.dev`.
+- `com.apple.security.temporary-exception.files.home-relative-path.read-write = ["/.local/bin/"]` in `Clearly.entitlements`. Narrow-scope (only `~/.local/bin/`), mirroring the read-only variant already used for local-image previews.
+- **No** `NSAppleEventsUsageDescription`, **no** `temporary-exception.apple-events`. Do not reintroduce either unless a new feature actually sends Apple Events.
+- Legacy `/usr/local/bin/clearly` installs from Clearly ≤ 2.4.x are detected via `CLIInstaller.symlinkState()` and left alone. Removing a legacy symlink still requires sudo; the UI surfaces a copy-paste `sudo rm` command instead of attempting it.
 
-**Cross-channel warning:** the apple-events exception lives in `Clearly.entitlements` (direct/Sparkle) but **not** in `Clearly-AppStore.entitlements`, which strips temporary-exceptions to pass MAS review. That means the CLI install flow (and anything else that drives Terminal) won't work in the App Store build as-is. Either mirror the entitlement into the MAS file (review-risk) or gate the Install UI behind `#if canImport(Sparkle)` and ship a copy-paste fallback for MAS.
+**Cross-channel status:** the home-relative-path read-write exception is only in `Clearly.entitlements` (Sparkle). `Clearly-AppStore.entitlements` intentionally omits it — MAS review strips temporary-exceptions. MAS users get the `CLIInstaller.shellCommand` copy-paste fallback (no sudo either — still writes to `~/.local/bin`). Don't add the temporary-exception to the MAS entitlements file without weighing review risk.
+
+**Never reintroduce** `NSAppleScript … with administrator privileges` (silently blocked in sandbox, surfaces as a misleading "The administrator user name or password was incorrect" error) or `tell Terminal to do script sudo …` (the exact path #241 broke).
 
 ### iCloud (and any profile-requiring entitlement) breaks ad-hoc Debug signing
 

--- a/Clearly/CLIInstaller.swift
+++ b/Clearly/CLIInstaller.swift
@@ -1,34 +1,54 @@
 import Foundation
+import Darwin
 import ClearlyCore
 
 enum CLIInstaller {
-    static let symlinkPath = "/usr/local/bin/clearly"
+    static let legacySymlinkPath = "/usr/local/bin/clearly"
+
+    /// The user's *real* home directory. Inside a sandboxed app, both `FileManager.homeDirectoryForCurrentUser`
+    /// and `NSHomeDirectory()` return the container path (`~/Library/Containers/<bundle-id>/Data`).
+    /// Only `getpwuid(getuid())->pw_dir` bypasses the sandbox remap and returns the real home (`/Users/...`),
+    /// which is what the `home-relative-path` entitlement is scoped to.
+    static var realHomeDirectoryURL: URL {
+        if let pw = getpwuid(getuid()), let dir = pw.pointee.pw_dir {
+            return URL(fileURLWithPath: String(cString: dir), isDirectory: true)
+        }
+        return URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    }
+
+    static var primarySymlinkURL: URL {
+        realHomeDirectoryURL.appendingPathComponent(".local/bin/clearly", isDirectory: false)
+    }
+
+    static var primarySymlinkPath: String { primarySymlinkURL.path }
+
+    static var primaryBinDirectoryURL: URL {
+        primarySymlinkURL.deletingLastPathComponent()
+    }
 
     enum State: Equatable {
         case notInstalled
-        case installed
-        case installedElsewhere(URL)
+        case installed                          // symlink at ~/.local/bin/clearly points to bundled binary
+        case installedLegacy(path: String)      // /usr/local/bin/clearly points to bundled binary (pre-2.5 install)
+        case installedElsewhere(URL)            // something named `clearly` exists but points elsewhere
     }
 
     enum CLIInstallerError: LocalizedError {
         case notBundled
         case wrongOwner(existingTarget: URL?)
-        case appleScriptCompileFailed
-        case terminalAutomationDenied(code: Int, message: String)
-        case scriptFailed(code: Int, message: String)
+        case legacyRequiresManualRemoval(path: String)
+        case filesystemError(underlying: Error)
 
         var errorDescription: String? {
             switch self {
             case .notBundled:
                 return "The clearly binary isn't bundled with this build."
             case .wrongOwner:
-                return "/usr/local/bin/clearly points at a different tool — remove it manually first."
-            case .appleScriptCompileFailed:
-                return "Couldn't build the install command — please report this."
-            case .terminalAutomationDenied:
-                return "Clearly doesn't have permission to control Terminal. Open Privacy & Security → Automation and allow Clearly, or copy the command and run it yourself."
-            case .scriptFailed(let code, let message):
-                return "Terminal returned an error (code \(code)): \(message)"
+                return "A different `clearly` is already on your PATH — remove it manually before installing."
+            case .legacyRequiresManualRemoval:
+                return "This install lives in /usr/local/bin and needs sudo to remove. Copy the command below and run it in Terminal."
+            case .filesystemError(let underlying):
+                return "Couldn't write the symlink: \(underlying.localizedDescription)"
             }
         }
 
@@ -38,12 +58,10 @@ enum CLIInstaller {
                 return "notBundled"
             case .wrongOwner(let existingTarget):
                 return "wrongOwner existingTarget=\(existingTarget?.path ?? "<unreadable>")"
-            case .appleScriptCompileFailed:
-                return "appleScriptCompileFailed"
-            case .terminalAutomationDenied(let code, let message):
-                return "terminalAutomationDenied code=\(code) message=\(message)"
-            case .scriptFailed(let code, let message):
-                return "scriptFailed code=\(code) message=\(message)"
+            case .legacyRequiresManualRemoval(let path):
+                return "legacyRequiresManualRemoval path=\(path)"
+            case .filesystemError(let underlying):
+                return "filesystemError underlying=\(underlying)"
             }
         }
     }
@@ -55,43 +73,76 @@ enum CLIInstaller {
     static func symlinkState() -> State {
         let fm = FileManager.default
         guard let bundled = bundledBinaryURL() else {
-            if fm.fileExists(atPath: symlinkPath) {
-                return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
+            if fm.fileExists(atPath: primarySymlinkPath) {
+                return .installedElsewhere(primarySymlinkURL)
+            }
+            if fm.fileExists(atPath: legacySymlinkPath) {
+                return .installedElsewhere(URL(fileURLWithPath: legacySymlinkPath))
             }
             return .notInstalled
         }
         let bundledResolved = bundled.resolvingSymlinksInPath().path
 
-        do {
-            let target = try fm.destinationOfSymbolicLink(atPath: symlinkPath)
-            let targetURL: URL
-            if target.hasPrefix("/") {
-                targetURL = URL(fileURLWithPath: target, isDirectory: false)
-            } else {
-                let parent = (symlinkPath as NSString).deletingLastPathComponent
-                targetURL = URL(fileURLWithPath: parent).appendingPathComponent(target)
-            }
-            let targetResolved = targetURL.resolvingSymlinksInPath().path
-            if targetResolved == bundledResolved {
+        if let primary = resolvedSymlinkTarget(at: primarySymlinkPath) {
+            if primary.path == bundledResolved {
                 return .installed
             }
-            return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
-        } catch {
-            if fm.fileExists(atPath: symlinkPath) {
-                return .installedElsewhere(URL(fileURLWithPath: symlinkPath))
+            if fm.fileExists(atPath: primary.path) {
+                return .installedElsewhere(primarySymlinkURL)
             }
-            return .notInstalled
+            // Dangling symlink from a previous Clearly install (e.g. stale DerivedData path).
+            // Treat as not installed so the user can reinstall over it.
+        } else if fm.fileExists(atPath: primarySymlinkPath) {
+            // A non-symlink file is squatting on our target path — treat as foreign.
+            return .installedElsewhere(primarySymlinkURL)
         }
+
+        if let legacy = resolvedSymlinkTarget(at: legacySymlinkPath) {
+            if legacy.path == bundledResolved {
+                return .installedLegacy(path: legacySymlinkPath)
+            }
+            if fm.fileExists(atPath: legacy.path) {
+                return .installedElsewhere(URL(fileURLWithPath: legacySymlinkPath))
+            }
+            // Dangling legacy symlink — pretend it isn't there.
+        } else if fm.fileExists(atPath: legacySymlinkPath) {
+            return .installedElsewhere(URL(fileURLWithPath: legacySymlinkPath))
+        }
+
+        return .notInstalled
     }
 
-    /// The exact one-liner a user can copy and run in Terminal themselves.
+    private static func resolvedSymlinkTarget(at path: String) -> URL? {
+        let fm = FileManager.default
+        guard let destination = try? fm.destinationOfSymbolicLink(atPath: path) else {
+            return nil
+        }
+        let targetURL: URL
+        if destination.hasPrefix("/") {
+            targetURL = URL(fileURLWithPath: destination, isDirectory: false)
+        } else {
+            let parent = (path as NSString).deletingLastPathComponent
+            targetURL = URL(fileURLWithPath: parent).appendingPathComponent(destination)
+        }
+        return targetURL.resolvingSymlinksInPath()
+    }
+
+    /// One-liner a user can copy and run themselves. No sudo — writes into `$HOME/.local/bin`.
     /// Returns nil when the helper binary isn't bundled with this build.
     static var shellCommand: String? {
         guard let source = bundledBinaryURL() else { return nil }
         return
-            "sudo mkdir -p /usr/local/bin && " +
-            "sudo ln -sf '\(shellEscape(source.path))' '\(symlinkPath)'"
+            "mkdir -p \"$HOME/.local/bin\" && " +
+            "ln -sf '\(shellEscape(source.path))' \"$HOME/.local/bin/clearly\""
     }
+
+    /// Copy-paste command shown when uninstalling a legacy `/usr/local/bin/clearly` symlink.
+    static var legacyUninstallCommand: String {
+        "sudo rm '\(legacySymlinkPath)'"
+    }
+
+    /// The export line users add to their shell profile when `~/.local/bin` isn't on `PATH`.
+    static let pathExportLine = #"export PATH="$HOME/.local/bin:$PATH""#
 
     /// Ordered key/value pairs describing the current install environment.
     /// Surfaced in the Settings "Details" disclosure and copied into bug reports.
@@ -106,7 +157,8 @@ enum CLIInstaller {
             ("app", "\(version) (\(build))"),
             ("bundleId", bundleId),
             ("macOS", osString),
-            ("symlinkTarget", symlinkPath),
+            ("primaryTarget", primarySymlinkPath),
+            ("legacyTarget", legacySymlinkPath),
             ("bundledBinary", bundledBinaryURL()?.path ?? "<missing>"),
         ]
     }
@@ -121,64 +173,67 @@ enum CLIInstaller {
             DiagnosticLog.log("[cli-install] install aborted: wrongOwner existingTarget=\(url.path)")
             throw CLIInstallerError.wrongOwner(existingTarget: url)
         }
-        let scriptCommand =
-            "sudo mkdir -p /usr/local/bin && " +
-            "sudo ln -sf '\(shellEscape(source.path))' '\(symlinkPath)' && " +
-            "echo '' && " +
-            "echo '✓ Installed. You can close this window — clearly is on your PATH.'"
+
+        let fm = FileManager.default
         do {
-            try await runInTerminal(scriptCommand)
-            DiagnosticLog.log("[cli-install] install dispatched to Terminal")
-        } catch let error as CLIInstallerError {
-            DiagnosticLog.log("[cli-install] install failed: \(error.diagnosticPayload)")
-            throw error
+            try fm.createDirectory(at: primaryBinDirectoryURL, withIntermediateDirectories: true)
+            // Remove an existing matching symlink so createSymbolicLink doesn't error.
+            if (try? fm.destinationOfSymbolicLink(atPath: primarySymlinkPath)) != nil {
+                try fm.removeItem(at: primarySymlinkURL)
+            }
+            try fm.createSymbolicLink(at: primarySymlinkURL, withDestinationURL: source)
+            DiagnosticLog.log("[cli-install] install succeeded: \(primarySymlinkPath) -> \(source.path)")
+        } catch {
+            DiagnosticLog.log("[cli-install] install failed: filesystemError underlying=\(error)")
+            throw CLIInstallerError.filesystemError(underlying: error)
         }
     }
 
     static func uninstall() async throws {
         DiagnosticLog.log("[cli-install] uninstall requested")
-        guard symlinkState() == .installed else {
-            DiagnosticLog.log("[cli-install] uninstall aborted: wrongOwner")
-            throw CLIInstallerError.wrongOwner(existingTarget: URL(fileURLWithPath: symlinkPath))
-        }
-        let scriptCommand =
-            "sudo rm -f '\(symlinkPath)' && " +
-            "echo '' && " +
-            "echo '✓ Uninstalled. You can close this window.'"
-        do {
-            try await runInTerminal(scriptCommand)
-            DiagnosticLog.log("[cli-install] uninstall dispatched to Terminal")
-        } catch let error as CLIInstallerError {
-            DiagnosticLog.log("[cli-install] uninstall failed: \(error.diagnosticPayload)")
-            throw error
+        let state = symlinkState()
+        switch state {
+        case .installed:
+            do {
+                try FileManager.default.removeItem(at: primarySymlinkURL)
+                DiagnosticLog.log("[cli-install] uninstall succeeded: removed \(primarySymlinkPath)")
+            } catch {
+                DiagnosticLog.log("[cli-install] uninstall failed: filesystemError underlying=\(error)")
+                throw CLIInstallerError.filesystemError(underlying: error)
+            }
+        case .installedLegacy(let path):
+            DiagnosticLog.log("[cli-install] uninstall requires manual sudo: \(path)")
+            throw CLIInstallerError.legacyRequiresManualRemoval(path: path)
+        case .notInstalled, .installedElsewhere:
+            DiagnosticLog.log("[cli-install] uninstall aborted: not our symlink")
+            throw CLIInstallerError.wrongOwner(existingTarget: nil)
         }
     }
 
-    private static func runInTerminal(_ shellCommand: String) async throws {
-        let escapedForAS = shellCommand
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "\(escapedForAS)"
-        end tell
-        """
-        try await Task.detached(priority: .userInitiated) {
-            var errorDict: NSDictionary?
-            guard let apple = NSAppleScript(source: script) else {
-                throw CLIInstallerError.appleScriptCompileFailed
+    /// Best-effort check for whether `~/.local/bin` is on the shell PATH. Scans common rc files
+    /// plus the current process environment. False negatives are harmless — they just surface an
+    /// extra (safe) "Add to PATH" instruction.
+    static func localBinIsOnPath() -> Bool {
+        let home = realHomeDirectoryURL.path
+        let envPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        for component in envPath.split(separator: ":") {
+            if component == "\(home)/.local/bin" { return true }
+        }
+        let needleVariants = [
+            "\(home)/.local/bin",
+            "$HOME/.local/bin",
+            "~/.local/bin",
+            "${HOME}/.local/bin",
+        ]
+        let rcFiles = [".zprofile", ".zshrc", ".bash_profile", ".bashrc", ".profile"]
+        for name in rcFiles {
+            let url = realHomeDirectoryURL.appendingPathComponent(name)
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            for needle in needleVariants where contents.contains(needle) {
+                return true
             }
-            _ = apple.executeAndReturnError(&errorDict)
-            if let err = errorDict {
-                let code = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
-                let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "Unknown error"
-                if code == -1743 || code == -600 {
-                    throw CLIInstallerError.terminalAutomationDenied(code: code, message: msg)
-                }
-                throw CLIInstallerError.scriptFailed(code: code, message: msg)
-            }
-        }.value
+        }
+        return false
     }
 
     private static func shellEscape(_ path: String) -> String {

--- a/Clearly/Clearly.entitlements
+++ b/Clearly/Clearly.entitlements
@@ -20,6 +20,10 @@
 	<array>
 		<string>/</string>
 	</array>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
+	<array>
+		<string>/.local/bin/</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.print</key>
@@ -28,10 +32,6 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.Terminal</string>
 	</array>
 </dict>
 </plist>

--- a/Clearly/Info.plist
+++ b/Clearly/Info.plist
@@ -51,8 +51,6 @@
 	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
-	<key>NSAppleEventsUsageDescription</key>
-	<string>Clearly uses Terminal to install the clearly command-line tool on your PATH.</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.com.sabotage.clearly</key>

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -111,8 +111,9 @@ struct SettingsView: View {
     @State private var cliInstallBusy = false
     @State private var cliInstallError: CLIInstaller.CLIInstallerError?
     @State private var cliCommandCopied = false
-    @State private var cliDetailsCopied = false
-    @State private var cliErrorDetailsExpanded = false
+    @State private var cliLegacyCommandCopied = false
+    @State private var cliPathExportCopied = false
+    @State private var cliLocalBinOnPath: Bool = CLIInstaller.localBinIsOnPath()
 
     private var bundledCLIBinaryPath: String? {
         CLIInstaller.bundledBinaryURL()?.path
@@ -166,10 +167,10 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .onAppear {
-            cliSymlinkState = CLIInstaller.symlinkState()
+            refreshCLIState()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            cliSymlinkState = CLIInstaller.symlinkState()
+            refreshCLIState()
         }
     }
 
@@ -182,7 +183,13 @@ struct SettingsView: View {
             case .installed:
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.green)
-                Text("Installed at \(CLIInstaller.symlinkPath)")
+                Text("Installed at ~/.local/bin/clearly")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .installedLegacy(let path):
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text("Installed at \(path)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             case .installedElsewhere:
@@ -205,19 +212,19 @@ struct SettingsView: View {
     private var cliInstallUI: some View {
         HStack {
             switch cliSymlinkState {
-            case .installed:
+            case .installed, .installedLegacy:
                 Button("Uninstall") {
                     Task { await runUninstall() }
                 }
                 .disabled(cliInstallBusy)
-            case .installedElsewhere:
-                Button("Install \u{2026}") {}
+            case .installedElsewhere(let url):
+                Button("Install") {}
                     .disabled(true)
-                Text("Remove the existing `clearly` from /usr/local/bin manually before installing.")
+                Text("Remove the existing `clearly` at \(url.path) manually before installing.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             case .notInstalled:
-                Button("Install \u{2026}") {
+                Button("Install") {
                     Task { await runInstall() }
                 }
                 .disabled(cliInstallBusy || !cliBundledExecutable)
@@ -229,9 +236,51 @@ struct SettingsView: View {
             cliErrorPanel(error)
         }
 
-        Text("Opens Terminal and runs `sudo ln -sf` so `clearly` resolves on your shell PATH. Enter your admin password in Terminal when prompted, then switch back here — Clearly detects the install automatically.")
-            .font(.caption)
-            .foregroundStyle(.tertiary)
+        switch cliSymlinkState {
+        case .installed:
+            if !cliLocalBinOnPath {
+                cliPathHint
+            }
+            Text("`clearly` lives in your home folder, so no admin password is needed. Run `clearly --help` in a terminal to get started.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        case .installedLegacy:
+            Text("This copy was installed by an older version of Clearly. It will keep working — we'll leave it alone.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        case .installedElsewhere, .notInstalled:
+            Text("Installs `clearly` into `~/.local/bin` so it resolves on your shell PATH. No admin password needed — everything stays in your home folder.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private var cliPathHint: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("`~/.local/bin` isn't on your shell PATH yet. Add this line to your shell profile (e.g. `~/.zprofile`), then open a new terminal:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Text(CLIInstaller.pathExportLine)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 4))
+                Button(cliPathExportCopied ? "Copied!" : "Copy") {
+                    copyToPasteboard(CLIInstaller.pathExportLine)
+                    cliPathExportCopied = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        cliPathExportCopied = false
+                    }
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .background(Color.yellow.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
     }
 
     @ViewBuilder
@@ -243,13 +292,22 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             HStack(spacing: 8) {
-                if case .terminalAutomationDenied = error {
-                    Button("Open Privacy Settings") { openPrivacySettings() }
-                        .controlSize(.small)
-                }
-                if let command = CLIInstaller.shellCommand {
+                if case .legacyRequiresManualRemoval = error {
+                    Button(cliLegacyCommandCopied ? "Copied!" : "Copy uninstall command") {
+                        copyToPasteboard(CLIInstaller.legacyUninstallCommand)
+                        cliLegacyCommandCopied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            cliLegacyCommandCopied = false
+                        }
+                    }
+                    .controlSize(.small)
+                } else if let command = CLIInstaller.shellCommand {
                     Button(cliCommandCopied ? "Copied!" : "Copy command") {
-                        copyCLIShellCommand(command)
+                        copyToPasteboard(command)
+                        cliCommandCopied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            cliCommandCopied = false
+                        }
                     }
                     .controlSize(.small)
                 }
@@ -263,34 +321,32 @@ struct SettingsView: View {
                 Spacer()
             }
 
-            DisclosureGroup("Details", isExpanded: $cliErrorDetailsExpanded) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(cliErrorDetails(error))
-                        .font(.system(.caption, design: .monospaced))
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Button(cliDetailsCopied ? "Copied!" : "Copy details") {
-                        copyCLIErrorDetails(error)
-                    }
-                    .controlSize(.small)
-                }
-                .padding(.top, 4)
+            if case .legacyRequiresManualRemoval = error {
+                Text(CLIInstaller.legacyUninstallCommand)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 4))
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .font(.caption)
         }
         .padding(10)
         .background(Color.red.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
     }
 
+    private func refreshCLIState() {
+        cliSymlinkState = CLIInstaller.symlinkState()
+        cliLocalBinOnPath = CLIInstaller.localBinIsOnPath()
+    }
+
     private func runInstall() async {
         cliInstallBusy = true
         cliInstallError = nil
-        cliErrorDetailsExpanded = false
         defer { cliInstallBusy = false }
         do {
             try await CLIInstaller.install()
-            cliSymlinkState = CLIInstaller.symlinkState()
+            refreshCLIState()
         } catch let error as CLIInstaller.CLIInstallerError {
             cliInstallError = error
         } catch {
@@ -301,11 +357,10 @@ struct SettingsView: View {
     private func runUninstall() async {
         cliInstallBusy = true
         cliInstallError = nil
-        cliErrorDetailsExpanded = false
         defer { cliInstallBusy = false }
         do {
             try await CLIInstaller.uninstall()
-            cliSymlinkState = CLIInstaller.symlinkState()
+            refreshCLIState()
         } catch let error as CLIInstaller.CLIInstallerError {
             cliInstallError = error
         } catch {
@@ -313,47 +368,21 @@ struct SettingsView: View {
         }
     }
 
-    private func openPrivacySettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    private func copyCLIShellCommand(_ command: String) {
+    private func copyToPasteboard(_ string: String) {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(command, forType: .string)
-        cliCommandCopied = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            cliCommandCopied = false
-        }
-    }
-
-    private func cliErrorDetails(_ error: CLIInstaller.CLIInstallerError) -> String {
-        var lines: [String] = []
-        lines.append("error:         \(error.diagnosticPayload)")
-        for (key, value) in CLIInstaller.diagnosticContext {
-            lines.append("\(key.padding(toLength: 14, withPad: " ", startingAt: 0)) \(value)")
-        }
-        return lines.joined(separator: "\n")
-    }
-
-    private func copyCLIErrorDetails(_ error: CLIInstaller.CLIInstallerError) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(cliErrorDetails(error), forType: .string)
-        cliDetailsCopied = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            cliDetailsCopied = false
-        }
+        NSPasteboard.general.setString(string, forType: .string)
     }
 
     private func copyMCPConfig() {
         let command: String
-        if case .installed = cliSymlinkState {
-            command = CLIInstaller.symlinkPath
-        } else if let path = bundledCLIBinaryPath {
+        switch cliSymlinkState {
+        case .installed:
+            command = CLIInstaller.primarySymlinkPath
+        case .installedLegacy(let path):
             command = path
-        } else {
-            return
+        case .installedElsewhere, .notInstalled:
+            guard let path = bundledCLIBinaryPath else { return }
+            command = path
         }
         let config = """
         {

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Clearly/
 ├── FileExplorerView.swift          # Sidebar file browser with bookmarks and recents
 ├── FileParser.swift                # Parses frontmatter, wiki-links, tags from documents
 ├── VaultIndex.swift                # SQLite + FTS5 index for search, backlinks, tags
-├── CLIInstaller.swift              # Installs /usr/local/bin/clearly symlink from Settings
+├── CLIInstaller.swift              # Installs ~/.local/bin/clearly symlink from Settings
 ├── Theme.swift                     # Centralized colors (light/dark) and font constants
 └── Info.plist
 
@@ -219,9 +219,17 @@ The `clearly` command-line binary is bundled with Clearly.app and operates on th
 
 ### Install
 
-Open Clearly → **Settings → Command Line → Install**. A one-time Terminal prompt for `sudo` creates a symlink at `/usr/local/bin/clearly` pointing to the bundled binary inside `Clearly.app/Contents/Resources/Helpers/ClearlyCLI`. Reinstalling Clearly (Sparkle or App Store) keeps the symlink valid.
+Open Clearly → **Settings → Command Line → Install**. Creates a symlink at `~/.local/bin/clearly` pointing to the bundled binary inside `Clearly.app/Contents/Resources/Helpers/ClearlyCLI`. No admin password needed — everything stays in your home folder.
 
-Uninstall from the same Settings pane.
+If `~/.local/bin` isn't already on your shell `PATH`, add this to `~/.zprofile` (or your shell's equivalent) and open a new terminal:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Upgrades (Sparkle or App Store) keep the symlink valid. Uninstall from the same Settings pane.
+
+**Legacy `/usr/local/bin/clearly` installs** from Clearly ≤ 2.4.x keep working and are detected automatically — no action needed.
 
 ### Subcommand reference
 
@@ -296,7 +304,7 @@ Same binary, different arg — `clearly mcp` starts a stdio MCP server exposing 
 {
   "mcpServers": {
     "clearly": {
-      "command": "/usr/local/bin/clearly",
+      "command": "/Users/you/.local/bin/clearly",
       "args": ["mcp"]
     }
   }
@@ -309,7 +317,7 @@ Same binary, different arg — `clearly mcp` starts a stdio MCP server exposing 
 {
   "mcpServers": {
     "clearly": {
-      "command": "/usr/local/bin/clearly",
+      "command": "/Users/you/.local/bin/clearly",
       "args": ["mcp"]
     }
   }
@@ -322,14 +330,14 @@ Same binary, different arg — `clearly mcp` starts a stdio MCP server exposing 
 {
   "mcpServers": {
     "clearly": {
-      "command": "/usr/local/bin/clearly",
+      "command": "/Users/you/.local/bin/clearly",
       "args": ["mcp"]
     }
   }
 }
 ```
 
-Settings → Command Line → **Copy MCP config** in the Clearly app copies a ready-to-paste snippet (auto-flips to `/usr/local/bin/clearly` once the symlink is installed).
+Settings → Command Line → **Copy MCP config** in the Clearly app copies a ready-to-paste snippet with the correct path for your machine (flips to `~/.local/bin/clearly` once the symlink is installed, or the legacy `/usr/local/bin/clearly` path if you're on an older install).
 
 ### Tool reference
 


### PR DESCRIPTION
## Summary

- Replaces the AppleScript-to-Terminal `sudo ln -sf` install flow with a direct `FileManager.createSymbolicLink` into `~/.local/bin/clearly` — no admin password, no Terminal, no TCC/Automation dependency.
- Drops `temporary-exception.apple-events` + `NSAppleEventsUsageDescription`; adds `temporary-exception.files.home-relative-path.read-write = /.local/bin/`. Uses `getpwuid(getuid())->pw_dir` to reach the real home from inside the sandbox.
- Legacy `/usr/local/bin/clearly` installs from 2.4.x are detected and left alone; uninstall surfaces a copy-paste `sudo rm` (sandbox can't touch `/usr/local/bin`). Settings shows a yellow hint with a copy button for the shell-profile `export` line when `~/.local/bin` isn't on PATH.

Fixes #241

## Test plan

- [x] Build succeeds in Debug (xcodebuild -scheme Clearly)
- [x] `codesign -d --entitlements` on built app shows the new `home-relative-path.read-write` entitlement and no `apple-events` exception
- [x] Info.plist on built app has no `NSAppleEventsUsageDescription`
- [x] Install button creates `/Users/joshpigford/.local/bin/clearly` (verified via `ls -la` + `which clearly` + `clearly --help`)
- [x] PATH detection clears the yellow hint when `~/.local/bin` is present in a shell rc file
- [ ] Needs verification on macOS 26 beta (the original #241 repro environment)
- [ ] Needs verification that legacy `/usr/local/bin/clearly` installs show as `.installedLegacy` without offering reinstall