### PR TITLE
[mac] Restore v2.5.0 user state lost in v2.6.0 unsandboxed move

### DIFF
--- a/Clearly/UserDefaultsMigrator.swift
+++ b/Clearly/UserDefaultsMigrator.swift
@@ -1,0 +1,116 @@
+import Foundation
+import ClearlyCore
+
+/// One-shot migration of `UserDefaults` from the v2.5.0 sandboxed container
+/// path back into the standard preferences path used by the unsandboxed
+/// v2.6.0+ build.
+///
+/// macOS stores `UserDefaults` for sandboxed apps under
+/// `~/Library/Containers/<bundle-id>/Data/Library/Preferences/<bundle-id>.plist`
+/// and for unsandboxed apps under `~/Library/Preferences/<bundle-id>.plist`.
+/// When the App Sandbox flag flipped between v2.5.0 (sandboxed) and v2.6.0
+/// (unsandboxed), `UserDefaults.standard` silently swapped backing files and
+/// the user's existing prefs became invisible to the new app — vault list,
+/// recents, sidebar state, theme, every `@AppStorage` key.
+///
+/// On first launch of any build that includes this migrator, read the v2.5.0
+/// plist directly off disk and copy the known keys into `UserDefaults.standard`,
+/// but only where the destination is unset. That preserves anything the user
+/// changed under v2.6.0 (where they re-picked a vault from the welcome screen)
+/// and fills in everything else from their v2.5.0 state.
+///
+/// Bookmark blobs are copied verbatim. The existing `restoreLocations` /
+/// `restoreRecents` / `restorePinnedFiles` / `restoreLastFile` /
+/// `restoreDocumentSession` paths in `WorkspaceManager` already detect stale
+/// security-scoped bookmarks and refresh them — that handles the
+/// sandbox-extension token going dead in the unsandboxed binary.
+enum UserDefaultsMigrator {
+
+    private static let migratedFlagKey = "didMigrateFromContainer_2_6_1"
+
+    /// Keys to copy from the old container plist into the standard plist.
+    /// Includes every primitive pref, every `@AppStorage` key in the app,
+    /// and every bookmark-blob key the workspace persists.
+    private static let migratableKeys: [String] = [
+        // Workspace / sidebar state
+        "hasEverAddedLocation",
+        "hasDeliveredGettingStarted",
+        "sidebarVisible",
+        "showHiddenFiles",
+        "launchBehavior",
+        "folderIcons",
+        "folderColors",
+        "expandedFolderPaths",
+        "collapsedLocationIDs",
+        // Editor / preview / UI prefs (@AppStorage)
+        "themePreference",
+        "editorFontSize",
+        "previewFontFamily",
+        "contentWidth",
+        "hideFrontmatterInPreview",
+        "showLineNumbers",
+        "showMenuBarIcon",
+        "sidebarSize",
+        "sidebarTagsExpanded",
+        "sidebarPinnedExpanded",
+        "sidebarRecentsExpanded",
+        "wikiAgentRunner",
+        "wikiAgentModel",
+        "wikiChatPanelWidth",
+        // Editor / detail toggles persisted outside @AppStorage
+        "continuousSpellCheckingEnabled",
+        "grammarCheckingEnabled",
+        "automaticSpellingCorrectionEnabled",
+        "outlineVisible",
+        "backlinksVisible",
+        // Bookmark blobs — Data and arrays of Data. Restore* call sites
+        // refresh stale bookmarks automatically.
+        "locationBookmarks",
+        "recentBookmarks",
+        "pinnedBookmarks",
+        "lastOpenFileURL",
+        "documentSession",
+    ]
+
+    /// Run the migration if it hasn't run yet. Idempotent. Cheap when
+    /// already migrated (single bool read).
+    static func runIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: migratedFlagKey) else {
+            return
+        }
+        defer {
+            UserDefaults.standard.set(true, forKey: migratedFlagKey)
+        }
+
+        guard let containerPlist = readContainerPlist() else {
+            DiagnosticLog.log("UserDefaultsMigrator: no v2.5.0 container plist; nothing to migrate")
+            return
+        }
+
+        var copied = 0
+        for key in migratableKeys {
+            // Don't overwrite values the user has set under v2.6.0+.
+            guard UserDefaults.standard.object(forKey: key) == nil else { continue }
+            guard let value = containerPlist[key] else { continue }
+            UserDefaults.standard.set(value, forKey: key)
+            copied += 1
+        }
+        DiagnosticLog.log("UserDefaultsMigrator: copied \(copied) of \(migratableKeys.count) keys from v2.5.0 container")
+    }
+
+    /// Reads the v2.5.0 sandboxed prefs file directly off disk via the
+    /// user's REAL home directory. Uses `getpwuid` so this still works if a
+    /// future build re-enables the sandbox (`NSHomeDirectory()` would
+    /// redirect to the new container in that case).
+    private static func readContainerPlist() -> [String: Any]? {
+        guard let pw = getpwuid(geteuid()), let dirPtr = pw.pointee.pw_dir else {
+            return nil
+        }
+        let home = String(cString: dirPtr)
+        let path = "\(home)/Library/Containers/com.sabotage.clearly/Data/Library/Preferences/com.sabotage.clearly.plist"
+        guard FileManager.default.fileExists(atPath: path) else {
+            return nil
+        }
+        return NSDictionary(contentsOf: URL(fileURLWithPath: path)) as? [String: Any]
+    }
+}

--- a/Clearly/Wiki/AgentDiscovery.swift
+++ b/Clearly/Wiki/AgentDiscovery.swift
@@ -4,7 +4,9 @@ import Foundation
 /// user's existing auth. Checks well-known install paths first (faster than
 /// shelling out), then falls back to `which` via PATH. Sandboxed Mac builds
 /// still see the path because the Mach-O loader resolves absolute paths, not
-/// PATH entries.
+/// PATH entries — but the home prefix has to be read from OpenDirectory
+/// (`getpwuid`) instead of `NSHomeDirectory()`, which under sandbox returns
+/// the container path (`~/Library/Containers/<bundle-id>/Data`).
 enum AgentDiscovery {
 
     /// Candidate for a concrete runner. Absolute path is guaranteed so the
@@ -42,7 +44,7 @@ enum AgentDiscovery {
     // MARK: - Private
 
     private static var claudeCandidatePaths: [String] {
-        let home = NSHomeDirectory()
+        let home = realUserHome() ?? NSHomeDirectory()
         return [
             "\(home)/.local/bin/claude",
             "\(home)/Library/Application Support/com.anthropic.claude/bin/claude",
@@ -52,13 +54,23 @@ enum AgentDiscovery {
     }
 
     private static var codexCandidatePaths: [String] {
-        let home = NSHomeDirectory()
+        let home = realUserHome() ?? NSHomeDirectory()
         return [
             "\(home)/.codex/bin/codex",
             "\(home)/.local/bin/codex",
             "/usr/local/bin/codex",
             "/opt/homebrew/bin/codex",
         ]
+    }
+
+    /// Resolve the user's REAL home directory, bypassing the sandbox redirect.
+    /// `NSHomeDirectory()` returns the container path under App Sandbox; we
+    /// need the original `/Users/<name>` so candidate-path lookups for
+    /// user-installed CLIs (`~/.local/bin/claude`) succeed. Mirrors the same
+    /// helper in `ClaudeCLIAgentRunner`.
+    private static func realUserHome() -> String? {
+        guard let pw = getpwuid(geteuid()), let dir = pw.pointee.pw_dir else { return nil }
+        return String(cString: dir)
     }
 
     private static func firstExisting(at paths: [String]) -> URL? {

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -127,6 +127,11 @@ final class WorkspaceManager {
     // MARK: - Init
 
     init() {
+        // Bridge prefs from the v2.5.0 sandbox container to the unsandboxed
+        // standard plist. Must run before any UserDefaults read in this init
+        // or anywhere else in the launch path. See UserDefaultsMigrator.swift.
+        UserDefaultsMigrator.runIfNeeded()
+
         isSidebarVisible = UserDefaults.standard.bool(forKey: Self.sidebarVisibleKey)
         showHiddenFiles = UserDefaults.standard.bool(forKey: Self.showHiddenFilesKey)
         folderIcons = UserDefaults.standard.dictionary(forKey: Self.folderIconsKey) as? [String: String] ?? [:]


### PR DESCRIPTION
## Summary
- v2.6.0 dropped the App Sandbox entitlement so Wiki's claude/codex CLI subprocesses work, but that silently moved the `UserDefaults` backing file from the sandbox container to `~/Library/Preferences/`, making every v2.5.0 user's vault list, recents, sidebar state, theme, and `@AppStorage` keys disappear on upgrade.
- New `UserDefaultsMigrator` runs once on first launch, copies the known keys (primitives + bookmark blobs) from the v2.5.0 container plist into `UserDefaults.standard` only where the destination is unset, then sets a "migrated" flag — bookmark blobs ride the existing stale-bookmark refresh paths in `WorkspaceManager`.
- `AgentDiscovery` picks up the `realUserHome()` getpwuid trick already proven in `ClaudeCLIAgentRunner` so `~/.local/bin/claude` lookups work even if a future build re-enables the sandbox.

## Test plan
- [ ] Install v2.5.0, populate state (add a vault, customize sidebar, change theme), quit.
- [ ] Replace `/Applications/Clearly.app` with a v2.6.1 build of this branch and launch.
- [ ] Welcome screen does NOT appear; previously-added vault shows in sidebar; sidebar/theme/font prefs match the v2.5.0 state.
- [ ] `tail ~/Library/Application\ Support/Clearly/diagnostic.log` shows `UserDefaultsMigrator: copied N of 30 keys from v2.5.0 container`.
- [ ] Wiki → Capture (⌃⌘I) and Chat (⌃⌘A) end-to-end against the unsandboxed CLI subprocess path.
- [ ] Re-launch — migrator does not run again (flag short-circuits).