### PR TITLE
[mac] fix: Cmd+W closes Settings, not the active document (#257)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -134,12 +134,16 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             return nil
         }
 
-        closeTabMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        closeTabMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
             guard chars == "w" && mods == [.command] else { return event }
             guard let window = event.window,
                   WindowRouter.isUserFacingDocumentWindow(window) else { return event }
+            // The Settings window is an AXStandardWindow that passes the document-window
+            // heuristic. Let SwiftUI's default Cmd+W close it instead of routing the event
+            // here (which would close the active document — issue #257).
+            if window === self?.trackedSettingsWindow { return event }
             let workspace = WorkspaceManager.shared
             if let activeID = workspace.activeDocumentID {
                 workspace.closeDocument(activeID)

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
     @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @AppStorage("sidebarSize") private var sidebarSize: String = "medium"
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         TabView {
@@ -51,6 +52,13 @@ struct SettingsView: View {
         .frame(width: 460)
         .fixedSize(horizontal: false, vertical: true)
         .background(SettingsWindowObserver())
+        .background {
+            Button("") { dismiss() }
+                .keyboardShortcut("w", modifiers: .command)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .accessibilityHidden(true)
+        }
     }
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled


### PR DESCRIPTION
## Summary
- The Cmd+W local event monitor treated the SwiftUI `Settings { }` window as a document window (it has `AXStandardWindow` role and clears the size threshold), so it consumed the event and closed the active document while Settings stayed open.
- Skip the tracked Settings window in `closeTabMonitor` and add a hidden `dismiss()` button inside `SettingsView` so SwiftUI can route Cmd+W to close Settings.
- Verified end-to-end via AppleScript: Cmd+W with Settings key (General/Sync/Wiki tabs) closes Settings and preserves the doc; Cmd+W with the doc key still closes the doc; reopen via Cmd+, works.

Fixes #257

## Test plan
- [ ] Open a markdown doc, open Settings (Cmd+,), press Cmd+W — Settings closes, doc stays.
- [ ] Switch to a non-default Settings tab (Sync, Wiki, Command Line, About), press Cmd+W — Settings closes.
- [ ] With Settings closed, press Cmd+W on the doc — doc closes via existing path.
- [ ] Reopen Settings (Cmd+,) after dismissal — opens cleanly.