### PR TITLE
[ios] Fix vault picker flashing briefly on launch

### DIFF
--- a/Clearly/iOS/FolderListView_iOS.swift
+++ b/Clearly/iOS/FolderListView_iOS.swift
@@ -344,7 +344,7 @@ struct FolderListView_iOS: View {
 
     private var shouldShowWelcomeBinding: Binding<Bool> {
         Binding(
-            get: { session.currentVault == nil || showWelcome },
+            get: { session.shouldPresentWelcome || showWelcome },
             set: { if !$0 { showWelcome = false } }
         )
     }

--- a/Clearly/iOS/IPadRootView.swift
+++ b/Clearly/iOS/IPadRootView.swift
@@ -349,7 +349,7 @@ struct IPadRootView: View {
 
     private var shouldShowWelcomeBinding: Binding<Bool> {
         Binding(
-            get: { session.currentVault == nil || showWelcome },
+            get: { session.shouldPresentWelcome || showWelcome },
             set: { newValue in
                 if !newValue { showWelcome = false }
             }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -26,6 +26,15 @@ public final class VaultSession {
     public private(set) var isLoading: Bool = false
     public private(set) var error: VaultSessionError?
 
+    /// UserDefaults presence at launch — lets views gate the welcome picker before async restoration runs.
+    public let hadPersistedVaultOnLaunch: Bool
+
+    public private(set) var hasAttemptedRestore: Bool = false
+
+    public var shouldPresentWelcome: Bool {
+        currentVault == nil && !(hadPersistedVaultOnLaunch && !hasAttemptedRestore)
+    }
+
     /// 0.0…1.0 while a full vault re-index is running. `nil` when idle. Drives the
     /// sidebar progress bar.
     public private(set) var indexProgress: Double?
@@ -66,6 +75,7 @@ public final class VaultSession {
 
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        self.hadPersistedVaultOnLaunch = defaults.data(forKey: Self.persistenceKey) != nil
     }
 
     // MARK: - Attach / detach
@@ -165,6 +175,7 @@ public final class VaultSession {
     }
 
     public func restoreFromPersistence() async {
+        defer { hasAttemptedRestore = true }
         guard let data = defaults.data(forKey: Self.persistenceKey) else { return }
         guard let stored = try? JSONDecoder().decode(StoredVaultLocation.self, from: data) else {
             clearPersistence()


### PR DESCRIPTION
## Summary

`VaultSession` was constructed synchronously with `currentVault = nil`, but persistence was restored asynchronously via `.task`. The picker's gate (`currentVault == nil`) couldn't distinguish "no vault ever picked" from "restoration is pending," so it rendered on frame 0 and dismissed once `attach()` landed.

This snapshots UserDefaults presence at init and adds a `hasAttemptedRestore` flag flipped via `defer` in `restoreFromPersistence()`. Both iPhone (`FolderListView_iOS`) and iPad (`IPadRootView`) gates now read `session.shouldPresentWelcome`, which suppresses the picker during the async resolve window without changing first-launch or failure-case behavior.

Fixes #265

## Test plan

- [ ] Build clean: `xcodebuild -scheme Clearly-iOS -configuration Debug` ✓ (verified locally)
- [ ] Pick a vault on iPhone simulator, force-quit, relaunch — confirm no picker flash
- [ ] Same on iPad (regular size class) via `IPadRootView`
- [ ] First launch (no persistence) — picker still appears immediately on frame 0
- [ ] Bookmark-invalidation case (e.g. disable iCloud Drive) — picker appears with error after resolve fails