### PR TITLE
[mac] Add Copy Path / Relative Path / Wiki Link to sidebar context menus

### DIFF
--- a/Clearly/CopyActions.swift
+++ b/Clearly/CopyActions.swift
@@ -14,6 +14,29 @@ enum CopyActions {
         pb.setString(url.lastPathComponent, forType: .string)
     }
 
+    static func copyRelativePath(_ url: URL, vaultRoot: URL) {
+        let target = url.standardizedFileURL.path
+        let root = vaultRoot.standardizedFileURL.path
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        let relative: String
+        if target == root {
+            relative = ""
+        } else if target.hasPrefix(prefix) {
+            relative = String(target.dropFirst(prefix.count))
+        } else {
+            relative = url.lastPathComponent
+        }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(relative, forType: .string)
+    }
+
+    static func copyWikiLink(_ target: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString("[[\(target)]]", forType: .string)
+    }
+
     static func copyMarkdown(_ text: String) {
         let pb = NSPasteboard.general
         pb.clearContents()

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -99,6 +99,12 @@ struct MacDetailToolbar: ToolbarContent {
                 if let url = workspace.currentFileURL {
                     Button("Copy File Path") { CopyActions.copyFilePath(url) }
                     Button("Copy File Name") { CopyActions.copyFileName(url) }
+                    if let root = workspace.containingVaultRoot(for: url) {
+                        Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
+                    }
+                    if let target = workspace.wikiLinkTarget(for: url) {
+                        Button("Copy Wiki Link") { CopyActions.copyWikiLink(target) }
+                    }
                     Divider()
                 }
                 Button("Copy Markdown") { CopyActions.copyMarkdown(workspace.currentFileText) }

--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -109,6 +109,14 @@ struct MacFolderSidebar: View {
                         Button("Reveal in Finder", systemImage: "folder") {
                             NSWorkspace.shared.activateFileViewerSelecting([url])
                         }
+                        Divider()
+                        Button("Copy Path") { CopyActions.copyFilePath(url) }
+                        if let root = workspace.containingVaultRoot(for: url) {
+                            Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
+                        }
+                        if let target = workspace.wikiLinkTarget(for: url) {
+                            Button("Copy Wiki Link") { CopyActions.copyWikiLink(target) }
+                        }
                     }
                 }
             }
@@ -140,6 +148,14 @@ struct MacFolderSidebar: View {
                             Divider()
                             Button("Reveal in Finder", systemImage: "folder") {
                                 NSWorkspace.shared.activateFileViewerSelecting([url])
+                            }
+                            Divider()
+                            Button("Copy Path") { CopyActions.copyFilePath(url) }
+                            if let root = workspace.containingVaultRoot(for: url) {
+                                Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
+                            }
+                            if let target = workspace.wikiLinkTarget(for: url) {
+                                Button("Copy Wiki Link") { CopyActions.copyWikiLink(target) }
                             }
                         }
                 }
@@ -179,6 +195,7 @@ struct MacFolderSidebar: View {
                 Button("Reveal in Finder", systemImage: "folder") {
                     NSWorkspace.shared.activateFileViewerSelecting([location.url])
                 }
+                Button("Copy Path") { CopyActions.copyFilePath(location.url) }
                 if !location.isWiki {
                     Button("Convert to LLM Wiki…", systemImage: "book.closed") {
                         convertToWiki(location)
@@ -377,6 +394,11 @@ struct MacFolderSidebar: View {
         Button("Reveal in Finder", systemImage: "folder") {
             NSWorkspace.shared.activateFileViewerSelecting([url])
         }
+        Divider()
+        Button("Copy Path") { CopyActions.copyFilePath(url) }
+        if let root = workspace.containingVaultRoot(for: url) {
+            Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
+        }
     }
 
     private func createNewFile(in folder: URL) {
@@ -423,6 +445,14 @@ struct MacFolderSidebar: View {
         Divider()
         Button("Reveal in Finder", systemImage: "folder") {
             NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+        Divider()
+        Button("Copy Path") { CopyActions.copyFilePath(url) }
+        if let root = workspace.containingVaultRoot(for: url) {
+            Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
+        }
+        if let target = workspace.wikiLinkTarget(for: url) {
+            Button("Copy Wiki Link") { CopyActions.copyWikiLink(target) }
         }
     }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -1508,8 +1508,49 @@ final class WorkspaceManager {
         return nil
     }
 
-    private func containingVaultRoot(for url: URL) -> URL? {
+    func containingVaultRoot(for url: URL) -> URL? {
         containingLocationAndRoot(for: url)?.rootURL
+    }
+
+    /// Wiki-link target string for a file URL — bare basename when unique in
+    /// the vault, otherwise vault-relative path (without `.md`) for
+    /// disambiguation, mirroring `BacklinksState.linkTarget`. Returns nil when
+    /// the URL is not inside any registered vault or refers to the vault root.
+    func wikiLinkTarget(for url: URL) -> String? {
+        guard let vaultRoot = containingVaultRoot(for: url) else { return nil }
+        let standardized = url.standardizedFileURL.path
+        let rootPath = vaultRoot.standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard standardized.hasPrefix(prefix) else { return nil }
+        let relativePath = String(standardized.dropFirst(prefix.count))
+        guard !relativePath.isEmpty else { return nil }
+        let basename = (relativePath as NSString).lastPathComponent
+        let basenameNoExt = (basename as NSString).deletingPathExtension
+
+        var allFiles: [(filename: String, path: String)] = []
+        for index in vaultIndexes.values {
+            for file in index.allFiles() {
+                allFiles.append((filename: file.filename, path: file.path))
+            }
+        }
+
+        let duplicateCount = allFiles.reduce(into: 0) { count, file in
+            if file.filename.localizedCaseInsensitiveCompare(basenameNoExt) == .orderedSame {
+                count += 1
+            }
+        }
+
+        if duplicateCount > 1 {
+            let pathWithoutExtension = (relativePath as NSString).deletingPathExtension
+            let pathDuplicateCount = allFiles.reduce(into: 0) { count, file in
+                if ((file.path as NSString).deletingPathExtension).localizedCaseInsensitiveCompare(pathWithoutExtension) == .orderedSame {
+                    count += 1
+                }
+            }
+            return pathDuplicateCount > 1 ? relativePath : pathWithoutExtension
+        }
+
+        return basenameNoExt
     }
 
     private func containingLocationAndRoot(for url: URL) -> (location: BookmarkedLocation, rootURL: URL)? {


### PR DESCRIPTION
## Summary

- Right-click on files and folders in the Mac sidebar now exposes **Copy Path** (absolute), **Copy Relative Path** (vault-relative, hidden when the item lives outside any registered vault), and **Copy Wiki Link** (file-only, hidden when not in a vault). Wired into all five sidebar surfaces — file tree rows, folder tree rows, Pinned section, Recents section, and the location/vault-root header — plus the toolbar Copy menu in the detail column for parity with the active document.
- **Copy Wiki Link** uses `WorkspaceManager.wikiLinkTarget(for:)`, which mirrors `BacklinksState.linkTarget` to disambiguate duplicate basenames (emits `[[subfolder/note]]` when a bare `[[note]]` would collide), so copied links round-trip to the file the user actually right-clicked.

Fixes #251, #266.

## Test plan

- [ ] Right-click a file in the main tree, Pinned, and Recents → all three new items appear; paste each into Terminal / another note.
- [ ] Right-click a folder → Copy Path + Copy Relative Path (no Wiki Link).
- [ ] Right-click a file *outside* any registered vault → Copy Path only (Relative Path and Wiki Link hidden).
- [ ] Toolbar Copy menu (top-right doc icon) → Copy Relative Path / Copy Wiki Link present when a vault doc is open.
- [ ] Wiki-link round-trip: copy `[[note]]`, paste into another note, switch to Preview, click → navigates to the file.
- [ ] Collision case: with two `note.md` files in different folders, Copy Wiki Link from each should produce different `[[subfolder/note]]` strings.