### PR TITLE
[mac] Fix preview outline navigation (#260)

### DIFF
--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -249,7 +249,10 @@ struct MacDetailColumn: View {
             .frame(maxWidth: .infinity)
 
             if outlineState.isVisible {
-                OutlineView(outlineState: outlineState)
+                OutlineView(
+                    outlineState: outlineState,
+                    isEditorVisible: workspace.currentViewMode == .edit
+                )
                     .frame(width: 240)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }

--- a/Clearly/OutlineView.swift
+++ b/Clearly/OutlineView.swift
@@ -3,6 +3,7 @@ import ClearlyCore
 
 struct OutlineView: View {
     @ObservedObject var outlineState: OutlineState
+    var isEditorVisible: Bool
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -37,8 +38,10 @@ struct OutlineView: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(outlineState.headings) { heading in
                             HeadingRow(heading: heading) {
-                                outlineState.scrollToRange?(heading.range)
-                                outlineState.scrollToPreviewAnchor?(heading.previewAnchor)
+                                if isEditorVisible {
+                                    outlineState.scrollToRange?(heading.range)
+                                }
+                                outlineState.scrollToHeading?(heading)
                             }
                         }
                     }

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -86,8 +86,8 @@ struct PreviewView: NSViewRepresentable {
         if let findState {
             context.coordinator.observeFindState(findState, webView: webView)
         }
-        outlineState?.scrollToPreviewAnchor = { [weak coordinator = context.coordinator] anchor in
-            coordinator?.scrollToHeading(anchor: anchor)
+        outlineState?.scrollToHeading = { [weak coordinator = context.coordinator] heading in
+            coordinator?.scrollToHeading(heading)
         }
         NotificationCenter.default.addObserver(
             context.coordinator,
@@ -196,6 +196,8 @@ struct PreviewView: NSViewRepresentable {
         mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
         mark.clearly-mode-highlight { background: rgba(255, 210, 50, 0.5); border-radius: 3px; padding: 0 1px; transition: background 1.5s ease; }
         mark.clearly-mode-highlight.fade { background: transparent; }
+        mark.clearly-outline-flash { background-color: rgba(255, 245, 100, 0.95); color: inherit; border-radius: 3px; padding: 0 2px; box-shadow: 0 0 0 1px rgba(220, 180, 0, 0.5); transition: background-color 1.2s ease, box-shadow 1.2s ease; }
+        mark.clearly-outline-flash.fade { background-color: transparent; box-shadow: 0 0 0 1px transparent; }
         mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
         @media (prefers-color-scheme: dark) {
             mark.clearly-find { background-color: rgba(180, 150, 0, 0.4); }
@@ -394,23 +396,70 @@ struct PreviewView: NSViewRepresentable {
                 .store(in: &findCancellables)
         }
 
-        func scrollToHeading(anchor: PreviewSourceAnchor) {
+        func scrollToHeading(_ heading: HeadingItem) {
+            guard let titleData = try? JSONSerialization.data(
+                withJSONObject: heading.title,
+                options: .fragmentsAllowed
+            ),
+            let titleJSON = String(data: titleData, encoding: .utf8) else { return }
+            let anchor = heading.previewAnchor
             let js = """
             (function() {
-                var headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6');
+                var sl = \(anchor.startLine), sc = \(anchor.startColumn);
+                var title = \(titleJSON);
+                var headings = Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6'));
+                var re = /^(\\d+):(\\d+)-(\\d+):(\\d+)$/;
+                function unwrapFlash(m) {
+                    var p = m.parentNode;
+                    if (!p) return;
+                    while (m.firstChild) p.insertBefore(m.firstChild, m);
+                    p.removeChild(m);
+                    p.normalize();
+                }
+                function flash(el) {
+                    el.scrollIntoView({behavior:'smooth',block:'start'});
+                    document.querySelectorAll('mark.clearly-outline-flash').forEach(unwrapFlash);
+                    var nodes = [];
+                    el.childNodes.forEach(function(n) {
+                        if (n.nodeType === 1 && n.classList && n.classList.contains('heading-anchor')) return;
+                        nodes.push(n);
+                    });
+                    if (nodes.length === 0) return;
+                    var mark = document.createElement('mark');
+                    mark.className = 'clearly-outline-flash';
+                    el.insertBefore(mark, nodes[0]);
+                    nodes.forEach(function(n) { mark.appendChild(n); });
+                    setTimeout(function() { mark.classList.add('fade'); }, 350);
+                    setTimeout(function() { unwrapFlash(mark); }, 1700);
+                }
                 for (var i = 0; i < headings.length; i++) {
-                    var sp = headings[i].getAttribute('data-sourcepos');
-                    if (!sp) continue;
-                    var match = /^(\\d+):(\\d+)-(\\d+):(\\d+)$/.exec(sp);
-                    if (!match) continue;
-                    if (
-                        parseInt(match[1], 10) === \(anchor.startLine) &&
-                        parseInt(match[2], 10) === \(anchor.startColumn)
-                    ) {
-                        headings[i].scrollIntoView({behavior:'smooth', block:'start'});
+                    var m = re.exec(headings[i].getAttribute('data-sourcepos') || '');
+                    if (m && parseInt(m[1],10)===sl && parseInt(m[2],10)===sc) {
+                        flash(headings[i]);
                         return;
                     }
                 }
+                for (var i = 0; i < headings.length; i++) {
+                    var m = re.exec(headings[i].getAttribute('data-sourcepos') || '');
+                    if (m && parseInt(m[1],10)===sl) {
+                        flash(headings[i]);
+                        return;
+                    }
+                }
+                var norm = title.trim().toLowerCase();
+                var best = null, bestDist = Infinity;
+                function headingText(el) {
+                    var copy = el.cloneNode(true);
+                    copy.querySelectorAll('.heading-anchor').forEach(function(a) { a.remove(); });
+                    return copy.textContent.trim().toLowerCase();
+                }
+                for (var i = 0; i < headings.length; i++) {
+                    if (headingText(headings[i]) !== norm) continue;
+                    var m = re.exec(headings[i].getAttribute('data-sourcepos') || '');
+                    var dist = m ? Math.abs(parseInt(m[1],10) - sl) : Infinity;
+                    if (dist < bestDist) { best = headings[i]; bestDist = dist; }
+                }
+                if (best) flash(best);
             })();
             """
             webView?.evaluateJavaScript(js)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/OutlineState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/OutlineState.swift
@@ -24,7 +24,7 @@ public final class OutlineState: ObservableObject {
     /// Set by EditorView coordinator, called when user clicks a heading (editor scroll)
     public var scrollToRange: ((NSRange) -> Void)?
     /// Set by PreviewView coordinator, called when user clicks a heading (preview scroll)
-    public var scrollToPreviewAnchor: ((PreviewSourceAnchor) -> Void)?
+    public var scrollToHeading: ((HeadingItem) -> Void)?
 
     private static let atxHeadingRegex = try! NSRegularExpression(
         pattern: "^(#{1,6})\\s+(.+)$",


### PR DESCRIPTION
## Summary
- Outline clicks in preview now do a 3-tier scroll lookup (exact line+col → line-only → closest-by-line text match with anchor-link stripped), so the outline always finds a sensible target even when the regex parser and cmark-gfm disagree.
- Skip the editor's `showFindIndicator` when the editor isn't the visible pane — fixes the yellow rectangle that was bleeding through SwiftUI's opacity-0 layer onto the preview.
- Adds a brief in-preview flash on the matched heading text that mirrors the edit-mode find indicator (bright yellow mark wrapping just the text, ~1.3s fade).

Fixes #260

## Test plan
- [ ] Preview mode: click outline entries — preview scrolls and the heading text flashes yellow; no stray rectangle on a different line.
- [ ] Edit mode: outline click still scrolls + shows the find indicator on the heading line.
- [ ] Doc with two headings sharing the same text — clicking each in the outline lands on the corresponding instance.
- [ ] Doc with a heading whose `data-sourcepos` column doesn't match Swift's column 1 (e.g. 1–3 leading spaces) — tier 2 line-only match takes over.
- [ ] Heading with double-quotes in the title — JSON-escaped injection doesn't break the JS.