### PR TITLE
Add Support for Changedown Annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .context/
 __pycache__/
 ClearlyLiveEditorWeb/node_modules/
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ build/
 .context/
 __pycache__/
 ClearlyLiveEditorWeb/node_modules/
-tmp
+tmp/

--- a/Clearly/AnnotationCommand.swift
+++ b/Clearly/AnnotationCommand.swift
@@ -1,29 +1,230 @@
 import AppKit
 import ClearlyCore
 import Foundation
+import WebKit
 
 extension Notification.Name {
     static let previewAnnotationCommand = Notification.Name("ClearlyPreviewAnnotationCommand")
 }
 
+enum AnnotationAuthor {
+    static let usernameKey = "annotationUsername"
+
+    static var current: String {
+        let configured = UserDefaults.standard.string(forKey: usernameKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return configured.isEmpty ? NSUserName() : configured
+    }
+}
+
 enum AnnotationPrompt {
-    static func requestComment() -> String? {
-        let alert = NSAlert()
-        alert.messageText = "Add Annotation"
-        alert.informativeText = "Enter a note for the selected text."
-        alert.addButton(withTitle: "Add")
-        alert.addButton(withTitle: "Cancel")
-
-        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
-        input.placeholderString = "Note"
-        alert.accessoryView = input
-
-        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
-        return input.stringValue
+    static func requestComment(anchorScreenRect: NSRect? = nil) -> String? {
+        AnnotationCommentPanel(anchorScreenRect: anchorScreenRect).run()
     }
 
     static func present(error: Error) {
         NSAlert(error: error).runModal()
+    }
+}
+
+final class WebAnnotationContextMenuInstaller {
+    private weak var webView: WKWebView?
+    private let action: () -> Void
+
+    init(webView: WKWebView, action: @escaping () -> Void) {
+        self.webView = webView
+        self.action = action
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(menuWillOpen(_:)),
+            name: NSMenu.didBeginTrackingNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func menuWillOpen(_ notification: Notification) {
+        guard let menu = notification.object as? NSMenu,
+              let webView,
+              shouldAugmentMenu(for: webView),
+              !menu.items.contains(where: { $0.action == #selector(addAnnotation(_:)) }) else { return }
+
+        menu.insertItem(.separator(), at: 0)
+        let item = NSMenuItem(
+            title: "Add Annotation...",
+            action: #selector(addAnnotation(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        menu.insertItem(item, at: 0)
+    }
+
+    @objc private func addAnnotation(_ sender: Any?) {
+        action()
+    }
+
+    private func shouldAugmentMenu(for webView: WKWebView) -> Bool {
+        guard let window = webView.window, window.isKeyWindow else { return false }
+        let mouse = window.mouseLocationOutsideOfEventStream
+        let local = webView.convert(mouse, from: nil)
+        return webView.bounds.contains(local)
+    }
+}
+
+private final class AnnotationCommentPanel: NSObject {
+    private let panel: NSPanel
+    private let textView: NSTextView
+    private let errorLabel: NSTextField
+    private var result: String?
+
+    init(anchorScreenRect: NSRect?) {
+        let panelSize = NSSize(width: 380, height: 248)
+        panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: panelSize),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Add Annotation"
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .windowBackgroundColor
+
+        let contentView = NSView(frame: NSRect(origin: .zero, size: panelSize))
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        panel.contentView = contentView
+
+        let titleLabel = NSTextField(labelWithString: "Add Annotation")
+        titleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+
+        let subtitleLabel = NSTextField(labelWithString: "Comment on the selected text.")
+        subtitleLabel.font = .systemFont(ofSize: 12)
+        subtitleLabel.textColor = .secondaryLabelColor
+
+        let scrollView = NSScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = true
+
+        textView = NSTextView()
+        textView.minSize = NSSize(width: 0, height: 96)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: 340, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.textColor = .labelColor
+        textView.backgroundColor = .textBackgroundColor
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        TextCheckingPreferences.apply(to: textView)
+        scrollView.documentView = textView
+
+        errorLabel = NSTextField(labelWithString: "Enter a comment before adding.")
+        errorLabel.font = .systemFont(ofSize: 11)
+        errorLabel.textColor = .systemRed
+        errorLabel.isHidden = true
+
+        let cancelButton = NSButton(title: "Cancel", target: nil, action: nil)
+        cancelButton.bezelStyle = .rounded
+        cancelButton.keyEquivalent = "\u{1b}"
+
+        let addButton = NSButton(title: "Add", target: nil, action: nil)
+        addButton.bezelStyle = .rounded
+        addButton.keyEquivalent = "\r"
+
+        let buttonStack = NSStackView(views: [cancelButton, addButton])
+        buttonStack.orientation = .horizontal
+        buttonStack.spacing = 8
+        buttonStack.distribution = .fillEqually
+
+        let stack = NSStackView(views: [titleLabel, subtitleLabel, scrollView, errorLabel, buttonStack])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -18),
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 18),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
+            scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 104),
+            buttonStack.widthAnchor.constraint(equalTo: stack.widthAnchor)
+        ])
+
+        super.init()
+        cancelButton.target = self
+        cancelButton.action = #selector(cancel)
+        addButton.target = self
+        addButton.action = #selector(add)
+        position(anchorScreenRect: anchorScreenRect)
+    }
+
+    func run() -> String? {
+        panel.makeKeyAndOrderFront(nil)
+        panel.makeFirstResponder(textView)
+        _ = withExtendedLifetime(self) {
+            NSApp.runModal(for: panel)
+        }
+        panel.orderOut(nil)
+        return result
+    }
+
+    @objc private func add() {
+        let comment = textView.string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !comment.isEmpty else {
+            errorLabel.isHidden = false
+            NSSound.beep()
+            return
+        }
+        result = textView.string
+        NSApp.stopModal()
+    }
+
+    @objc private func cancel() {
+        result = nil
+        NSApp.stopModal()
+    }
+
+    private func position(anchorScreenRect: NSRect?) {
+        guard let screen = (anchorScreenRect.flatMap { screen(containing: $0) } ?? NSScreen.main) else {
+            panel.center()
+            return
+        }
+
+        let visible = screen.visibleFrame
+        let size = panel.frame.size
+        var origin: NSPoint
+
+        if let anchor = anchorScreenRect {
+            let belowY = anchor.minY - size.height - 10
+            let aboveY = anchor.maxY + 10
+            origin = NSPoint(x: anchor.midX - size.width / 2, y: belowY >= visible.minY ? belowY : aboveY)
+        } else if let window = NSApp.keyWindow {
+            origin = NSPoint(x: window.frame.midX - size.width / 2, y: window.frame.midY - size.height / 2)
+        } else {
+            origin = NSPoint(x: visible.midX - size.width / 2, y: visible.midY - size.height / 2)
+        }
+
+        origin.x = min(max(origin.x, visible.minX + 12), visible.maxX - size.width - 12)
+        origin.y = min(max(origin.y, visible.minY + 12), visible.maxY - size.height - 12)
+        panel.setFrameOrigin(origin)
+    }
+
+    private func screen(containing rect: NSRect) -> NSScreen? {
+        NSScreen.screens.first { $0.visibleFrame.intersects(rect) }
     }
 }
 

--- a/Clearly/AnnotationCommand.swift
+++ b/Clearly/AnnotationCommand.swift
@@ -1,0 +1,89 @@
+import AppKit
+import ClearlyCore
+import Foundation
+
+extension Notification.Name {
+    static let previewAnnotationCommand = Notification.Name("ClearlyPreviewAnnotationCommand")
+}
+
+enum AnnotationPrompt {
+    static func requestComment() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "Add Annotation"
+        alert.informativeText = "Enter a note for the selected text."
+        alert.addButton(withTitle: "Add")
+        alert.addButton(withTitle: "Cancel")
+
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+        input.placeholderString = "Note"
+        alert.accessoryView = input
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        return input.stringValue
+    }
+
+    static func present(error: Error) {
+        NSAlert(error: error).runModal()
+    }
+}
+
+enum PreviewAnnotationMapper {
+    enum Error: LocalizedError {
+        case emptySelection
+        case notFound
+        case ambiguous
+
+        var errorDescription: String? {
+            switch self {
+            case .emptySelection:
+                return "Select text before adding an annotation."
+            case .notFound:
+                return "The preview selection could not be matched back to the markdown source. Switch to the editor to annotate this selection."
+            case .ambiguous:
+                return "That selected text appears more than once in the markdown source. Switch to the editor to annotate the exact occurrence."
+            }
+        }
+    }
+
+    static func sourceRange(for selectedText: String, in markdown: String) throws -> Range<String.Index> {
+        let needle = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else {
+            throw Error.emptySelection
+        }
+
+        let ranges = markdown.ranges(of: needle)
+        guard !ranges.isEmpty else {
+            throw Error.notFound
+        }
+        guard ranges.count == 1 else {
+            throw Error.ambiguous
+        }
+        return ranges[0]
+    }
+}
+
+@MainActor
+func performAddAnnotationCommand() {
+    if LiveEditorCommandDispatcher.isActive {
+        LiveEditorCommandDispatcher.send(.addAnnotation)
+    } else if WorkspaceManager.shared.currentViewMode == .preview {
+        NotificationCenter.default.post(name: .previewAnnotationCommand, object: nil)
+    } else {
+        NSApp.sendAction(#selector(ClearlyTextView.addAnnotation(_:)), to: nil, from: nil)
+    }
+}
+
+private extension String {
+    func ranges(of needle: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var searchStart = startIndex
+
+        while searchStart < endIndex,
+              let range = self[searchStart...].range(of: needle) {
+            ranges.append(range)
+            searchStart = range.upperBound
+        }
+
+        return ranges
+    }
+}

--- a/Clearly/AnnotationCommand.swift
+++ b/Clearly/AnnotationCommand.swift
@@ -8,12 +8,8 @@ extension Notification.Name {
 }
 
 enum AnnotationAuthor {
-    static let usernameKey = "annotationUsername"
-
     static var current: String {
-        let configured = UserDefaults.standard.string(forKey: usernameKey)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return configured.isEmpty ? NSUserName() : configured
+        NSUserName()
     }
 }
 

--- a/Clearly/AnnotationCommentsView.swift
+++ b/Clearly/AnnotationCommentsView.swift
@@ -44,13 +44,9 @@ struct AnnotationCommentsView: View {
                 Spacer()
             } else {
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(commentsState.comments) { comment in
-                            AnnotationCommentRow(comment: comment) {
-                                outlineState.scrollToRange?(comment.sourceRange)
-                                outlineState.scrollToPreviewAnchor?(comment.previewAnchor)
-                            }
-                        }
+                    AnnotationCommentRows(comments: commentsState.comments) { comment in
+                        outlineState.scrollToRange?(comment.sourceRange)
+                        outlineState.scrollToPreviewAnchor?(comment.previewAnchor)
                     }
                     .padding(.vertical, 6)
                 }
@@ -58,6 +54,22 @@ struct AnnotationCommentsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Theme.outlinePanelBackgroundSwiftUI)
+    }
+}
+
+private struct AnnotationCommentRows: View {
+    let comments: [AnnotationCommentItem]
+    let onSelect: (AnnotationCommentItem) -> Void
+
+    var body: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(comments.indices, id: \.self) { index in
+                let comment = comments[index]
+                AnnotationCommentRow(comment: comment) {
+                    onSelect(comment)
+                }
+            }
+        }
     }
 }
 

--- a/Clearly/AnnotationCommentsView.swift
+++ b/Clearly/AnnotationCommentsView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import ClearlyCore
+
+struct AnnotationCommentsView: View {
+    @ObservedObject var commentsState: AnnotationCommentsState
+    @ObservedObject var outlineState: OutlineState
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Text("COMMENTS")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(1.5)
+
+                if !commentsState.comments.isEmpty {
+                    Text("\(commentsState.comments.count)")
+                        .font(.system(size: 10, weight: .semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+
+            Rectangle()
+                .fill(Color.primary.opacity(colorScheme == .dark ? Theme.separatorOpacityDark : Theme.separatorOpacity))
+                .frame(height: 1)
+                .padding(.horizontal, 12)
+
+            if commentsState.comments.isEmpty {
+                Spacer()
+                VStack(spacing: 8) {
+                    Text("No comments")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                    Text("Add annotations to selected text")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.quaternary)
+                }
+                .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(commentsState.comments) { comment in
+                            AnnotationCommentRow(comment: comment) {
+                                outlineState.scrollToRange?(comment.sourceRange)
+                                outlineState.scrollToPreviewAnchor?(comment.previewAnchor)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.outlinePanelBackgroundSwiftUI)
+    }
+}
+
+private struct AnnotationCommentRow: View {
+    let comment: AnnotationCommentItem
+    let onTap: () -> Void
+    @State private var isHovered = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(comment.highlightedText)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(comment.comment ?? "No comment text")
+                    .font(.system(size: 11))
+                    .foregroundStyle(comment.comment == nil ? .tertiary : .secondary)
+                    .lineLimit(3)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let metadata {
+                    Text(metadata)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered
+                    ? Color.primary.opacity(colorScheme == .dark ? Theme.hoverOpacityDark - 0.03 : 0.05)
+                    : Color.clear)
+                .padding(.horizontal, 4)
+        )
+        .onHover { hovering in
+            withAnimation(Theme.Motion.hover) {
+                isHovered = hovering
+            }
+        }
+    }
+
+    private var metadata: String? {
+        let parts = [comment.author, comment.date, comment.status]
+            .compactMap { value -> String? in
+                guard let value, !value.isEmpty else { return nil }
+                return value
+            }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -951,6 +951,13 @@ struct ClearlyApp: App {
                 Button("Page Break") {
                     performFormattingCommand(.pageBreak, selector: #selector(ClearlyTextView.insertPageBreak(_:)))
                 }
+
+                Divider()
+
+                Button("Add Annotation...") {
+                    performLiveEditorOnlyCommand(.addAnnotation)
+                }
+                .keyboardShortcut("m", modifiers: [.command, .shift])
             }
         }
 

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -955,7 +955,7 @@ struct ClearlyApp: App {
                 Divider()
 
                 Button("Add Annotation...") {
-                    performLiveEditorOnlyCommand(.addAnnotation)
+                    performAddAnnotationCommand()
                 }
                 .keyboardShortcut("m", modifiers: [.command, .shift])
             }

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -403,6 +403,9 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         outlineItem.keyEquivalentModifierMask = [.command, .shift]
         outlineItem.target = self
 
+        let commentsItem = NSMenuItem(title: "Toggle Comments", action: #selector(toggleCommentsAction(_:)), keyEquivalent: "")
+        commentsItem.target = self
+
         let backlinksItem = NSMenuItem(title: "Toggle Backlinks", action: #selector(toggleBacklinksAction(_:)), keyEquivalent: "b")
         backlinksItem.keyEquivalentModifierMask = [.command, .shift]
         backlinksItem.target = self
@@ -421,6 +424,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         // Insert right after Toggle Sidebar (index 0)
         var insertIndex = 1
         viewMenu.insertItem(outlineItem, at: insertIndex); insertIndex += 1
+        viewMenu.insertItem(commentsItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(backlinksItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(lineNumbersItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
@@ -456,6 +460,10 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
     @objc private func toggleOutlineAction(_ sender: Any?) {
         NotificationCenter.default.post(name: .init("ClearlyToggleOutline"), object: nil)
+    }
+
+    @objc private func toggleCommentsAction(_ sender: Any?) {
+        NotificationCenter.default.post(name: .toggleCommentsPanel, object: nil)
     }
 
     @objc private func toggleBacklinksAction(_ sender: Any?) {

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -472,14 +472,15 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
             AnnotationPrompt.present(error: ChangedownAnnotationWriterError.emptySelection)
             return
         }
-        guard let comment = AnnotationPrompt.requestComment() else { return }
+        let anchor = firstRect(forCharacterRange: range, actualRange: nil)
+        guard let comment = AnnotationPrompt.requestComment(anchorScreenRect: anchor.isEmpty ? nil : anchor) else { return }
 
         do {
             let updated = try ChangedownAnnotationWriter.addAnnotation(
                 to: string,
                 utf16Range: range,
                 comment: comment,
-                author: NSUserName()
+                author: AnnotationAuthor.current
             )
             insertText(updated, replacementRange: NSRange(location: 0, length: (string as NSString).length))
         } catch {

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -466,10 +466,38 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         insertText(snippet, replacementRange: range)
     }
 
+    @objc func addAnnotation(_ sender: Any?) {
+        let range = selectedRange()
+        guard range.length > 0 else {
+            AnnotationPrompt.present(error: ChangedownAnnotationWriterError.emptySelection)
+            return
+        }
+        guard let comment = AnnotationPrompt.requestComment() else { return }
+
+        do {
+            let updated = try ChangedownAnnotationWriter.addAnnotation(
+                to: string,
+                utf16Range: range,
+                comment: comment,
+                author: NSUserName()
+            )
+            insertText(updated, replacementRange: NSRange(location: 0, length: (string as NSString).length))
+        } catch {
+            AnnotationPrompt.present(error: error)
+        }
+    }
+
     // MARK: - Context Menu
 
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = super.menu(for: event) ?? NSMenu()
+
+        let annotationItem = NSMenuItem(
+            title: "Add Annotation...",
+            action: #selector(addAnnotation(_:)),
+            keyEquivalent: ""
+        )
+        annotationItem.isEnabled = selectedRange().length > 0
 
         let formatMenu = NSMenu(title: "Text Format")
 
@@ -508,6 +536,8 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         let formatItem = NSMenuItem(title: "Text Format", action: nil, keyEquivalent: "")
         formatItem.submenu = formatMenu
 
+        menu.insertItem(.separator(), at: 0)
+        menu.insertItem(annotationItem, at: 0)
         menu.insertItem(.separator(), at: 0)
         menu.insertItem(formatItem, at: 0)
 

--- a/Clearly/EditorEngine.swift
+++ b/Clearly/EditorEngine.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum EditorEngine: String, CaseIterable, Identifiable {
@@ -54,6 +55,7 @@ enum LiveEditorCommand: String {
     case inlineMath
     case mathBlock
     case pageBreak
+    case addAnnotation
 }
 
 extension Notification.Name {
@@ -71,5 +73,14 @@ enum LiveEditorCommandDispatcher {
             object: nil,
             userInfo: ["command": command.rawValue]
         )
+    }
+}
+
+@MainActor
+func performLiveEditorOnlyCommand(_ command: LiveEditorCommand) {
+    if LiveEditorCommandDispatcher.isActive {
+        LiveEditorCommandDispatcher.send(command)
+    } else {
+        NSSound.beep()
     }
 }

--- a/Clearly/LiveEditorView.swift
+++ b/Clearly/LiveEditorView.swift
@@ -7,6 +7,9 @@ import ClearlyCore
 /// WKWebView subclass that re-focuses CodeMirror when macOS routes
 /// first-responder to this view (e.g. after clicking a toolbar button).
 final class LiveEditorWebView: WKWebView {
+    var annotationMenuAction: (() -> Void)?
+    private var annotationMenuInstaller: WebAnnotationContextMenuInstaller?
+
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result, allowsDOMFocusForwarding {
@@ -19,6 +22,12 @@ final class LiveEditorWebView: WKWebView {
     /// keep first-responder ownership without immediately forcing DOM focus back
     /// into CodeMirror.
     var allowsDOMFocusForwarding = true
+
+    func installAnnotationMenu() {
+        annotationMenuInstaller = WebAnnotationContextMenuInstaller(webView: self) { [weak self] in
+            self?.annotationMenuAction?()
+        }
+    }
 }
 
 struct LiveEditorView: NSViewRepresentable {
@@ -49,6 +58,10 @@ struct LiveEditorView: NSViewRepresentable {
 
         let webView = LiveEditorWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
+        webView.annotationMenuAction = {
+            performAddAnnotationCommand()
+        }
+        webView.installAnnotationMenu()
         webView.underPageBackgroundColor = Theme.backgroundColor
         // Publish the active host revision before any async callbacks from an
         // older web session can race with this view's setup.
@@ -437,7 +450,12 @@ struct LiveEditorView: NSViewRepresentable {
                       let markdown = body["markdown"] as? String,
                       let from = body["from"] as? NSNumber,
                       let to = body["to"] as? NSNumber else { return }
-                requestAnnotation(markdown: markdown, from: from.intValue, to: to.intValue)
+                requestAnnotation(
+                    markdown: markdown,
+                    from: from.intValue,
+                    to: to.intValue,
+                    anchorScreenRect: screenRect(from: body["selectionRect"])
+                )
 
             case "openLink":
                 guard LiveEditorSession.matches(documentID: parent.documentID) else { return }
@@ -471,7 +489,7 @@ struct LiveEditorView: NSViewRepresentable {
             }
         }
 
-        private func requestAnnotation(markdown: String, from: Int, to: Int) {
+        private func requestAnnotation(markdown: String, from: Int, to: Int, anchorScreenRect: NSRect?) {
             DispatchQueue.main.async { [weak self] in
                 guard let self, !self.isDismantled else { return }
                 guard from != to else {
@@ -480,14 +498,14 @@ struct LiveEditorView: NSViewRepresentable {
                     return
                 }
 
-                guard let comment = AnnotationPrompt.requestComment() else { return }
+                guard let comment = AnnotationPrompt.requestComment(anchorScreenRect: anchorScreenRect) else { return }
 
                 do {
                     let updated = try ChangedownAnnotationWriter.addAnnotation(
                         to: markdown,
                         utf16Range: NSRange(location: from, length: max(0, to - from)),
                         comment: comment,
-                        author: NSUserName()
+                        author: AnnotationAuthor.current
                     )
                     self.hasReceivedDocChanged = true
                     self.lastSyncedText = updated
@@ -500,6 +518,26 @@ struct LiveEditorView: NSViewRepresentable {
                     AnnotationPrompt.present(error: error)
                 }
             }
+        }
+
+        private func screenRect(from value: Any?) -> NSRect? {
+            guard let webView,
+                  let rect = value as? [String: Any],
+                  let x = (rect["x"] as? NSNumber)?.doubleValue,
+                  let y = (rect["y"] as? NSNumber)?.doubleValue,
+                  let width = (rect["width"] as? NSNumber)?.doubleValue,
+                  let height = (rect["height"] as? NSNumber)?.doubleValue,
+                  width > 0,
+                  height > 0 else { return nil }
+
+            let viewRect = NSRect(
+                x: x,
+                y: webView.isFlipped ? y : Double(webView.bounds.height) - y - height,
+                width: width,
+                height: height
+            )
+            guard let window = webView.window else { return nil }
+            return window.convertToScreen(webView.convert(viewRect, to: nil))
         }
 
         private func call(function: String, payload: [String: Any]? = nil) {

--- a/Clearly/LiveEditorView.swift
+++ b/Clearly/LiveEditorView.swift
@@ -480,23 +480,13 @@ struct LiveEditorView: NSViewRepresentable {
                     return
                 }
 
-                let alert = NSAlert()
-                alert.messageText = "Add Annotation"
-                alert.informativeText = "Enter a note for the selected text."
-                alert.addButton(withTitle: "Add")
-                alert.addButton(withTitle: "Cancel")
-
-                let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
-                input.placeholderString = "Note"
-                alert.accessoryView = input
-
-                guard alert.runModal() == .alertFirstButtonReturn else { return }
+                guard let comment = AnnotationPrompt.requestComment() else { return }
 
                 do {
                     let updated = try ChangedownAnnotationWriter.addAnnotation(
                         to: markdown,
                         utf16Range: NSRange(location: from, length: max(0, to - from)),
-                        comment: input.stringValue,
+                        comment: comment,
                         author: NSUserName()
                     )
                     self.hasReceivedDocChanged = true
@@ -507,8 +497,7 @@ struct LiveEditorView: NSViewRepresentable {
                         payload: ["markdown": updated, "epoch": self.parent.documentEpoch]
                     )
                 } catch {
-                    let errorAlert = NSAlert(error: error)
-                    errorAlert.runModal()
+                    AnnotationPrompt.present(error: error)
                 }
             }
         }

--- a/Clearly/LiveEditorView.swift
+++ b/Clearly/LiveEditorView.swift
@@ -431,6 +431,14 @@ struct LiveEditorView: NSViewRepresentable {
                     self.parent.findState?.currentIndex = currentIndex
                 }
 
+            case "addAnnotationRequested":
+                guard !isDismantled,
+                      LiveEditorSession.matches(documentID: parent.documentID),
+                      let markdown = body["markdown"] as? String,
+                      let from = body["from"] as? NSNumber,
+                      let to = body["to"] as? NSNumber else { return }
+                requestAnnotation(markdown: markdown, from: from.intValue, to: to.intValue)
+
             case "openLink":
                 guard LiveEditorSession.matches(documentID: parent.documentID) else { return }
                 let kind = body["kind"] as? String ?? "markdown"
@@ -460,6 +468,48 @@ struct LiveEditorView: NSViewRepresentable {
 
             default:
                 break
+            }
+        }
+
+        private func requestAnnotation(markdown: String, from: Int, to: Int) {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.isDismantled else { return }
+                guard from != to else {
+                    let errorAlert = NSAlert(error: ChangedownAnnotationWriterError.emptySelection)
+                    errorAlert.runModal()
+                    return
+                }
+
+                let alert = NSAlert()
+                alert.messageText = "Add Annotation"
+                alert.informativeText = "Enter a note for the selected text."
+                alert.addButton(withTitle: "Add")
+                alert.addButton(withTitle: "Cancel")
+
+                let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+                input.placeholderString = "Note"
+                alert.accessoryView = input
+
+                guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+                do {
+                    let updated = try ChangedownAnnotationWriter.addAnnotation(
+                        to: markdown,
+                        utf16Range: NSRange(location: from, length: max(0, to - from)),
+                        comment: input.stringValue,
+                        author: NSUserName()
+                    )
+                    self.hasReceivedDocChanged = true
+                    self.lastSyncedText = updated
+                    self.parent.text = updated
+                    self.call(
+                        function: "setDocument",
+                        payload: ["markdown": updated, "epoch": self.parent.documentEpoch]
+                    )
+                } catch {
+                    let errorAlert = NSAlert(error: error)
+                    errorAlert.runModal()
+                }
             }
         }
 

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -95,6 +95,17 @@ struct MacDetailToolbar: ToolbarContent {
             .menuIndicator(.hidden)
             .disabled(workspace.activeDocumentID == nil || workspace.currentViewMode != .edit)
 
+            Button {
+                performAddAnnotationCommand()
+            } label: {
+                Label("Add Annotation", systemImage: "text.bubble")
+            }
+            .help("Add annotation to selected text")
+            .disabled(
+                workspace.activeDocumentID == nil ||
+                    (editorEngine == .livePreviewExperimental && workspace.currentViewMode != .edit)
+            )
+
             Menu {
                 if let url = workspace.currentFileURL {
                     Button("Copy File Path") { CopyActions.copyFilePath(url) }
@@ -595,6 +606,9 @@ struct MacDetailColumn: View {
             outlineState: outlineState,
             onTaskToggle: { [workspace] line, checked in
                 toggleTask(at: line, checked: checked, workspace: workspace)
+            },
+            onAnnotationAdded: { [workspace] updated in
+                workspace.currentFileText = updated
             },
             onWikiLinkClicked: { target, heading in
                 navigateToWikiLink(target: target, heading: heading, destinationMode: .preview)

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -14,6 +14,7 @@ struct MacDetailToolbar: ToolbarContent {
     @Bindable var workspace: WorkspaceManager
     @ObservedObject var findState: FindState
     @ObservedObject var outlineState: OutlineState
+    @ObservedObject var commentsState: AnnotationCommentsState
     @ObservedObject var backlinksState: BacklinksState
     @Bindable var wikiController: WikiOperationController
     @Binding var showFormatPopover: Bool
@@ -98,7 +99,7 @@ struct MacDetailToolbar: ToolbarContent {
             Button {
                 performAddAnnotationCommand()
             } label: {
-                Label("Add Annotation", systemImage: "text.bubble")
+                Label("Add Annotation", systemImage: "plus.bubble")
             }
             .help("Add annotation to selected text")
             .disabled(
@@ -143,6 +144,14 @@ struct MacDetailToolbar: ToolbarContent {
                 Label("Outline", systemImage: "list.bullet.indent")
             }
             .help("Outline (⇧⌘O)")
+            .disabled(workspace.activeDocumentID == nil)
+
+            Button {
+                commentsState.toggle()
+            } label: {
+                Label("Comments", systemImage: "text.bubble")
+            }
+            .help("Comments")
             .disabled(workspace.activeDocumentID == nil)
 
             Button {
@@ -225,6 +234,7 @@ struct MacDetailColumn: View {
     @Bindable var workspace: WorkspaceManager
     @ObservedObject var findState: FindState
     @ObservedObject var outlineState: OutlineState
+    @ObservedObject var commentsState: AnnotationCommentsState
     @ObservedObject var backlinksState: BacklinksState
     @ObservedObject var jumpToLineState: JumpToLineState
     @Bindable var wikiController: WikiOperationController
@@ -268,6 +278,15 @@ struct MacDetailColumn: View {
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
 
+            if commentsState.isVisible {
+                AnnotationCommentsView(
+                    commentsState: commentsState,
+                    outlineState: outlineState
+                )
+                .frame(width: 280)
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+
             if wikiChat.isVisible {
                 WikiChatView(
                     chat: wikiChat,
@@ -307,6 +326,7 @@ struct MacDetailColumn: View {
             }
         }
         .animation(Theme.Motion.smooth, value: outlineState.isVisible)
+        .animation(Theme.Motion.smooth, value: commentsState.isVisible)
         .animation(Theme.Motion.smooth, value: wikiChat.isVisible)
         .animation(Theme.Motion.smooth, value: wikiLog.isVisible)
         .navigationTitle(documentTitle)
@@ -326,6 +346,11 @@ struct MacDetailColumn: View {
         .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleOutline"))) { _ in
             withAnimation(Theme.Motion.smooth) {
                 outlineState.toggle()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .toggleCommentsPanel)) { _ in
+            withAnimation(Theme.Motion.smooth) {
+                commentsState.toggle()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleBacklinks"))) { _ in
@@ -350,6 +375,7 @@ struct MacDetailColumn: View {
                 workspace.currentViewMode = .edit
             }
             outlineState.parseHeadings(from: workspace.currentFileText)
+            commentsState.parseComments(from: workspace.currentFileText)
             backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
             setupFileWatcher()
             applyPendingWikiNavigationIfNeeded()
@@ -378,6 +404,7 @@ struct MacDetailColumn: View {
             }
             fileWatcher.updateCurrentText(text)
             outlineState.parseHeadings(from: text)
+            commentsState.parseComments(from: text)
         }
         .onChange(of: workspace.currentFileURL) { _, _ in
             setupFileWatcher()
@@ -447,6 +474,7 @@ struct MacDetailColumn: View {
             workspace.currentViewMode = .edit
         }
         outlineState.parseHeadings(from: workspace.currentFileText)
+        commentsState.parseComments(from: workspace.currentFileText)
         backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
         isFullscreen = NSApp.mainWindow?.styleMask.contains(.fullScreen) ?? false
         setupFileWatcher()

--- a/Clearly/Native/MacFormatPopover.swift
+++ b/Clearly/Native/MacFormatPopover.swift
@@ -54,6 +54,17 @@ struct MacFormatPopover: View {
                     send(.table, #selector(ClearlyTextView.insertMarkdownTable(_:)))
                 }
             }
+
+            Divider()
+
+            Button {
+                performLiveEditorOnlyCommand(.addAnnotation)
+            } label: {
+                Label("Add Annotation", systemImage: "text.badge.plus")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.borderless)
+            .help("Add annotation to selected text")
         }
         .padding(16)
         .frame(width: 300)

--- a/Clearly/Native/MacFormatPopover.swift
+++ b/Clearly/Native/MacFormatPopover.swift
@@ -58,7 +58,7 @@ struct MacFormatPopover: View {
             Divider()
 
             Button {
-                performLiveEditorOnlyCommand(.addAnnotation)
+                performAddAnnotationCommand()
             } label: {
                 Label("Add Annotation", systemImage: "text.badge.plus")
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Clearly/Native/MacFormatPopover.swift
+++ b/Clearly/Native/MacFormatPopover.swift
@@ -60,7 +60,7 @@ struct MacFormatPopover: View {
             Button {
                 performAddAnnotationCommand()
             } label: {
-                Label("Add Annotation", systemImage: "text.badge.plus")
+                Label("Add Annotation", systemImage: "plus.bubble")
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .buttonStyle(.borderless)

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -16,6 +16,7 @@ struct MacRootView: View {
     @State private var lastSidebarClickTime: Date? = nil
     @StateObject private var findState = FindState()
     @StateObject private var outlineState = OutlineState()
+    @StateObject private var commentsState = AnnotationCommentsState()
     @StateObject private var backlinksState = BacklinksState()
     @StateObject private var jumpToLineState = JumpToLineState()
     @State private var wikiController = WikiOperationController()
@@ -50,6 +51,7 @@ struct MacRootView: View {
                     workspace: workspace,
                     findState: findState,
                     outlineState: outlineState,
+                    commentsState: commentsState,
                     backlinksState: backlinksState,
                     jumpToLineState: jumpToLineState,
                     wikiController: wikiController,
@@ -65,6 +67,7 @@ struct MacRootView: View {
                     workspace: workspace,
                     findState: findState,
                     outlineState: outlineState,
+                    commentsState: commentsState,
                     backlinksState: backlinksState,
                     wikiController: wikiController,
                     showFormatPopover: $showFormatPopover

--- a/Clearly/Native/NativeShellSupport.swift
+++ b/Clearly/Native/NativeShellSupport.swift
@@ -13,6 +13,7 @@ extension Notification.Name {
     static let navigateWikiLink = Notification.Name("navigateWikiLink")
     static let highlightTextInEditor = Notification.Name("highlightTextInEditor")
     static let highlightTextInPreview = Notification.Name("highlightTextInPreview")
+    static let toggleCommentsPanel = Notification.Name("ClearlyToggleComments")
 
     // Wiki (LLM) commands — published by Wiki menu items and observed by the
     // WikiAgentCoordinator.

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -8,6 +8,8 @@ import Combine
 /// This intercepts mouseDown in the top strip and calls `performDrag` instead.
 private final class DraggableWKWebView: WKWebView {
     static let dragHeight: CGFloat = 28
+    var annotationMenuAction: (() -> Void)?
+    private var annotationMenuInstaller: WebAnnotationContextMenuInstaller?
 
     override func mouseDown(with event: NSEvent) {
         let local = convert(event.locationInWindow, from: nil)
@@ -17,6 +19,12 @@ private final class DraggableWKWebView: WKWebView {
             return
         }
         super.mouseDown(with: event)
+    }
+
+    func installAnnotationMenu() {
+        annotationMenuInstaller = WebAnnotationContextMenuInstaller(webView: self) { [weak self] in
+            self?.annotationMenuAction?()
+        }
     }
 }
 
@@ -68,8 +76,13 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.addUserScript(Self.copyButtonUserScript())
         let webView = DraggableWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
+        webView.annotationMenuAction = {
+            NotificationCenter.default.post(name: .previewAnnotationCommand, object: nil)
+        }
+        webView.installAnnotationMenu()
         webView.underPageBackgroundColor = Theme.backgroundColor
         webView.alphaValue = 0 // hidden until content loads
+        context.coordinator.webView = webView
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID
         context.coordinator.markdown = markdown
@@ -196,10 +209,13 @@ struct PreviewView: NSViewRepresentable {
         document.addEventListener('selectionchange', function() {
             var sel = window.getSelection();
             var text = sel ? sel.toString() : '';
-            if (text !== _lastSelText) {
-                _lastSelText = text;
-                window.webkit.messageHandlers.selectionCapture.postMessage({ text: text });
+            _lastSelText = text;
+            var rect = null;
+            if (sel && sel.rangeCount > 0 && text.length > 0) {
+                var bounds = sel.getRangeAt(0).getBoundingClientRect();
+                rect = { x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height };
             }
+            window.webkit.messageHandlers.selectionCapture.postMessage({ text: text, rect: rect });
         });
         """
         let html = """
@@ -427,6 +443,7 @@ struct PreviewView: NSViewRepresentable {
         var isLoadingContent = false
         var pendingScrollLine: Int?
         var pendingHighlightText: String?
+        var selectionScreenRect: NSRect?
         weak var webView: WKWebView?
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
@@ -438,7 +455,7 @@ struct PreviewView: NSViewRepresentable {
                 AnnotationPrompt.present(error: PreviewAnnotationMapper.Error.emptySelection)
                 return
             }
-            guard let comment = AnnotationPrompt.requestComment() else { return }
+            guard let comment = AnnotationPrompt.requestComment(anchorScreenRect: selectionScreenRect) else { return }
 
             do {
                 let range = try PreviewAnnotationMapper.sourceRange(for: selectedText, in: markdown)
@@ -446,7 +463,7 @@ struct PreviewView: NSViewRepresentable {
                     to: markdown,
                     range: range,
                     comment: comment,
-                    author: NSUserName()
+                    author: AnnotationAuthor.current
                 )
                 onAnnotationAdded?(updated)
             } catch {
@@ -875,6 +892,7 @@ struct PreviewView: NSViewRepresentable {
                let body = message.body as? [String: Any],
                let text = body["text"] as? String {
                 SelectionBridge.setSelection(text, for: self.positionSyncID)
+                selectionScreenRect = screenRect(from: body["rect"])
                 return
             }
 
@@ -884,6 +902,26 @@ struct PreviewView: NSViewRepresentable {
 
             scrollFraction = fraction
             ScrollBridge.setFraction(fraction, for: self.positionSyncID)
+        }
+
+        private func screenRect(from value: Any?) -> NSRect? {
+            guard let webView,
+                  let rect = value as? [String: Any],
+                  let x = (rect["x"] as? NSNumber)?.doubleValue,
+                  let y = (rect["y"] as? NSNumber)?.doubleValue,
+                  let width = (rect["width"] as? NSNumber)?.doubleValue,
+                  let height = (rect["height"] as? NSNumber)?.doubleValue,
+                  width > 0,
+                  height > 0 else { return nil }
+
+            let viewRect = NSRect(
+                x: x,
+                y: webView.isFlipped ? y : Double(webView.bounds.height) - y - height,
+                width: width,
+                height: height
+            )
+            guard let window = webView.window else { return nil }
+            return window.convertToScreen(webView.convert(viewRect, to: nil))
         }
     }
 

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -152,7 +152,12 @@ struct PreviewView: NSViewRepresentable {
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
         context.coordinator.isLoadingContent = true
-        let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true, includeFrontmatter: !hideFrontmatterInPreview)
+        let rawBody = MarkdownRenderer.renderHTML(
+            markdown,
+            appLinkURLs: true,
+            includeFrontmatter: !hideFrontmatterInPreview,
+            renderAnnotations: true
+        )
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
         let wikiFilesJSON: String = {
             guard let names = wikiFileNames, !names.isEmpty else { return "[]" }
@@ -322,6 +327,53 @@ struct PreviewView: NSViewRepresentable {
             });
             a.addEventListener('mouseleave', function() {
                 if (popover) { popover.remove(); popover = null; }
+            });
+        });
+        // Annotation click popovers
+        document.querySelectorAll('.cd-annotation').forEach(function(annotation) {
+            annotation.addEventListener('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                document.querySelectorAll('.annotation-popover').forEach(function(existing) {
+                    existing.remove();
+                });
+
+                var popover = document.createElement('div');
+                popover.className = 'annotation-popover';
+
+                var title = document.createElement('div');
+                title.className = 'annotation-popover-title';
+                title.textContent = annotation.getAttribute('data-change-id') || 'Annotation';
+                popover.appendChild(title);
+
+                var metaParts = [];
+                var author = annotation.getAttribute('data-author');
+                var date = annotation.getAttribute('data-date');
+                var status = annotation.getAttribute('data-status');
+                if (author) metaParts.push(author);
+                if (date) metaParts.push(date);
+                if (status) metaParts.push(status);
+                if (metaParts.length) {
+                    var meta = document.createElement('div');
+                    meta.className = 'annotation-popover-meta';
+                    meta.textContent = metaParts.join(' • ');
+                    popover.appendChild(meta);
+                }
+
+                var comment = document.createElement('div');
+                comment.textContent = annotation.getAttribute('data-comment') || 'No note text.';
+                popover.appendChild(comment);
+
+                document.body.appendChild(popover);
+                var rect = annotation.getBoundingClientRect();
+                popover.style.top = (rect.bottom + window.scrollY + 8) + 'px';
+                popover.style.left = Math.max(8, Math.min(rect.left, window.innerWidth - 420)) + 'px';
+            });
+        });
+        document.addEventListener('click', function(e) {
+            if (e.target.closest && e.target.closest('.annotation-popover, .cd-annotation')) return;
+            document.querySelectorAll('.annotation-popover').forEach(function(existing) {
+                existing.remove();
             });
         });
         // Wiki-link broken detection

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -30,6 +30,7 @@ struct PreviewView: NSViewRepresentable {
     var findState: FindState?
     var outlineState: OutlineState?
     var onTaskToggle: ((Int, Bool) -> Void)?
+    var onAnnotationAdded: ((String) -> Void)?
     var onWikiLinkClicked: ((String, String?) -> Void)?
     var onTagClicked: ((String) -> Void)?
     var wikiFileNames: Set<String>?
@@ -71,9 +72,11 @@ struct PreviewView: NSViewRepresentable {
         webView.alphaValue = 0 // hidden until content loads
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID
+        context.coordinator.markdown = markdown
         context.coordinator.findState = findState
         context.coordinator.outlineState = outlineState
         context.coordinator.onTaskToggle = onTaskToggle
+        context.coordinator.onAnnotationAdded = onAnnotationAdded
         context.coordinator.onWikiLinkClicked = onWikiLinkClicked
         context.coordinator.onTagClicked = onTagClicked
         let coordinator = context.coordinator
@@ -101,6 +104,12 @@ struct PreviewView: NSViewRepresentable {
             name: .highlightTextInPreview,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleAddAnnotation(_:)),
+            name: .previewAnnotationCommand,
+            object: nil
+        )
 
         loadHTML(in: webView, context: context)
         return webView
@@ -111,6 +120,8 @@ struct PreviewView: NSViewRepresentable {
         webView.underPageBackgroundColor = Theme.backgroundColor
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID
+        context.coordinator.markdown = markdown
+        context.coordinator.onAnnotationAdded = onAnnotationAdded
 
         // Detect mode change: restore scroll position when becoming visible
         if mode == .preview && context.coordinator.lastMode != .preview {
@@ -405,9 +416,11 @@ struct PreviewView: NSViewRepresentable {
         var didInitialLoad = false
         var fileURL: URL?
         var positionSyncID = ""
+        var markdown = ""
         var findState: FindState?
         var outlineState: OutlineState?
         var onTaskToggle: ((Int, Bool) -> Void)?
+        var onAnnotationAdded: ((String) -> Void)?
         var onWikiLinkClicked: ((String, String?) -> Void)?
         var onTagClicked: ((String) -> Void)?
         var skipNextReload = false
@@ -418,6 +431,28 @@ struct PreviewView: NSViewRepresentable {
         private var findCancellables = Set<AnyCancellable>()
         private var matchCount = 0
         private var currentMatchIdx = 0
+
+        @objc func handleAddAnnotation(_ notification: Notification) {
+            guard lastMode == .preview else { return }
+            guard let selectedText = SelectionBridge.selection(for: positionSyncID) else {
+                AnnotationPrompt.present(error: PreviewAnnotationMapper.Error.emptySelection)
+                return
+            }
+            guard let comment = AnnotationPrompt.requestComment() else { return }
+
+            do {
+                let range = try PreviewAnnotationMapper.sourceRange(for: selectedText, in: markdown)
+                let updated = try ChangedownAnnotationWriter.addAnnotation(
+                    to: markdown,
+                    range: range,
+                    comment: comment,
+                    author: NSUserName()
+                )
+                onAnnotationAdded?(updated)
+            } catch {
+                AnnotationPrompt.present(error: error)
+            }
+        }
 
         func observeFindState(_ state: FindState, webView: WKWebView) {
             self.webView = webView

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -105,6 +105,9 @@ struct PreviewView: NSViewRepresentable {
         outlineState?.scrollToHeading = { [weak coordinator = context.coordinator] heading in
             coordinator?.scrollToHeading(heading)
         }
+        outlineState?.scrollToPreviewAnchor = { [weak coordinator = context.coordinator] anchor in
+            coordinator?.scrollToAnchor(anchor)
+        }
         NotificationCenter.default.addObserver(
             context.coordinator,
             selector: #selector(Coordinator.handleScrollToLine(_:)),
@@ -564,6 +567,42 @@ struct PreviewView: NSViewRepresentable {
                     if (dist < bestDist) { best = headings[i]; bestDist = dist; }
                 }
                 if (best) flash(best);
+            })();
+            """
+            webView?.evaluateJavaScript(js)
+        }
+
+        func scrollToAnchor(_ anchor: PreviewSourceAnchor) {
+            let js = """
+            (function() {
+                var targetLine = \(anchor.startLine);
+                var targetColumn = \(anchor.startColumn);
+                var candidates = Array.from(document.querySelectorAll('[data-sourcepos]'));
+                var best = null;
+                for (var i = 0; i < candidates.length; i++) {
+                    var sp = candidates[i].getAttribute('data-sourcepos');
+                    if (!sp) continue;
+                    var match = /^(\\d+):(\\d+)-(\\d+):(\\d+)$/.exec(sp);
+                    if (!match) continue;
+                    var startLine = parseInt(match[1], 10);
+                    var startColumn = parseInt(match[2], 10);
+                    var endLine = parseInt(match[3], 10);
+                    if (startLine <= targetLine && endLine >= targetLine) {
+                        best = candidates[i];
+                        break;
+                    }
+                    if (startLine < targetLine || (startLine === targetLine && startColumn <= targetColumn)) {
+                        best = candidates[i];
+                    } else if (best === null) {
+                        best = candidates[i];
+                        break;
+                    } else {
+                        break;
+                    }
+                }
+                if (best) {
+                    best.scrollIntoView({behavior:'smooth', block:'center'});
+                }
             })();
             """
             webView?.evaluateJavaScript(js)

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @AppStorage("sidebarSize") private var sidebarSize: String = "medium"
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("annotationUsername") private var annotationUsername = ""
 
     var body: some View {
         TabView {
@@ -70,6 +71,12 @@ struct SettingsView: View {
                     Text(engine.displayName).tag(engine.rawValue)
                 }
             }
+            LabeledContent("Annotation Username") {
+                TextField(NSUserName(), text: $annotationUsername)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 220)
+            }
+            .help("Used in annotation footnotes. Leave blank to use your macOS account name.")
             Picker("Appearance", selection: $themePreference) {
                 Text("System").tag("system")
                 Text("Light").tag("light")

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -21,7 +21,6 @@ struct SettingsView: View {
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @AppStorage("sidebarSize") private var sidebarSize: String = "medium"
     @Environment(\.dismiss) private var dismiss
-    @AppStorage("annotationUsername") private var annotationUsername = ""
 
     var body: some View {
         TabView {
@@ -71,12 +70,6 @@ struct SettingsView: View {
                     Text(engine.displayName).tag(engine.rawValue)
                 }
             }
-            LabeledContent("Annotation Username") {
-                TextField(NSUserName(), text: $annotationUsername)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 220)
-            }
-            .help("Used in annotation footnotes. Leave blank to use your macOS account name.")
             Picker("Appearance", selection: $themePreference) {
                 Text("System").tag("system")
                 Text("Light").tag("light")

--- a/Clearly/UserDefaultsMigrator.swift
+++ b/Clearly/UserDefaultsMigrator.swift
@@ -51,6 +51,7 @@ enum UserDefaultsMigrator {
         "showLineNumbers",
         "showMenuBarIcon",
         "sidebarSize",
+        "annotationUsername",
         "sidebarTagsExpanded",
         "sidebarPinnedExpanded",
         "sidebarRecentsExpanded",

--- a/Clearly/UserDefaultsMigrator.swift
+++ b/Clearly/UserDefaultsMigrator.swift
@@ -51,7 +51,6 @@ enum UserDefaultsMigrator {
         "showLineNumbers",
         "showMenuBarIcon",
         "sidebarSize",
-        "annotationUsername",
         "sidebarTagsExpanded",
         "sidebarPinnedExpanded",
         "sidebarRecentsExpanded",
@@ -63,6 +62,7 @@ enum UserDefaultsMigrator {
         "grammarCheckingEnabled",
         "automaticSpellingCorrectionEnabled",
         "outlineVisible",
+        "annotationCommentsVisible",
         "backlinksVisible",
         // Bookmark blobs — Data and arrays of Data. Restore* call sites
         // refresh stale bookmarks automatically.

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -907,6 +907,16 @@ function insertSnippet(view: EditorView, snippet: string, selectedRangeFrom?: nu
   view.focus();
 }
 
+function requestAddAnnotation(view: EditorView) {
+  const selection = view.state.selection.main;
+  postMessage({
+    type: "addAnnotationRequested",
+    markdown: view.state.doc.toString(),
+    from: selection.from,
+    to: selection.to
+  });
+}
+
 function applyFormattingCommand(command: string) {
   if (!editor) {
     return;
@@ -1007,13 +1017,7 @@ function applyFormattingCommand(command: string) {
       insertSnippet(editor, "\n\n<div class=\"page-break\"></div>\n\n");
       break;
     case "addAnnotation": {
-      const selection = editor.state.selection.main;
-      postMessage({
-        type: "addAnnotationRequested",
-        markdown: editor.state.doc.toString(),
-        from: selection.from,
-        to: selection.to
-      });
+      requestAddAnnotation(editor);
       break;
     }
     case "findNext":

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -909,11 +909,22 @@ function insertSnippet(view: EditorView, snippet: string, selectedRangeFrom?: nu
 
 function requestAddAnnotation(view: EditorView) {
   const selection = view.state.selection.main;
+  const fromRect = view.coordsAtPos(selection.from);
+  const toRect = view.coordsAtPos(selection.to);
+  const selectionRect = fromRect && toRect
+    ? {
+        x: Math.min(fromRect.left, toRect.left),
+        y: Math.min(fromRect.top, toRect.top),
+        width: Math.max(1, Math.abs(toRect.right - fromRect.left)),
+        height: Math.max(fromRect.bottom, toRect.bottom) - Math.min(fromRect.top, toRect.top)
+      }
+    : null;
   postMessage({
     type: "addAnnotationRequested",
     markdown: view.state.doc.toString(),
     from: selection.from,
-    to: selection.to
+    to: selection.to,
+    selectionRect
   });
 }
 

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -1006,6 +1006,16 @@ function applyFormattingCommand(command: string) {
     case "pageBreak":
       insertSnippet(editor, "\n\n<div class=\"page-break\"></div>\n\n");
       break;
+    case "addAnnotation": {
+      const selection = editor.state.selection.main;
+      postMessage({
+        type: "addAnnotationRequested",
+        markdown: editor.state.doc.toString(),
+        from: selection.from,
+        to: selection.to
+      });
+      break;
+    }
     case "findNext":
       findNext(editor);
       updateFindStatus(editor.state);
@@ -1071,6 +1081,13 @@ function buildDecorations(state: EditorState): DecorationSet {
     decorateWrapped(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/g, "cm-live-link", (match) => ({
       "data-live-link-kind": "markdown",
       "data-live-href": match[2] ?? ""
+    }));
+    decorateWrapped(/\{==(.+?)==\}\{>>\s*(.+?)\s*<<\}\[\^(cn-[A-Za-z0-9.-]+)\]/g, "cm-live-annotation", (match) => ({
+      "data-live-annotation-id": match[3] ?? "",
+      "data-live-annotation-comment": match[2] ?? ""
+    }));
+    decorateWrapped(/\{==(.+?)==\}\[\^(cn-[A-Za-z0-9.-]+)\]/g, "cm-live-annotation", (match) => ({
+      "data-live-annotation-id": match[2] ?? ""
     }));
     decorateWrapped(/\[\[([^\]#]+(?:#[^\]]+)?)\]\]/g, "cm-live-wiki-link", (match) => {
       const raw = match[1] ?? "";
@@ -1499,6 +1516,12 @@ function livePreviewTheme(appearance: "light" | "dark", fontSize: number): Exten
       borderRadius: "3px",
       padding: "1px 5px",
       fontSize: "0.9em"
+    },
+    ".cm-live-annotation": {
+      backgroundColor: isDark ? "rgba(255, 214, 0, 0.2)" : "rgba(255, 212, 0, 0.24)",
+      borderBottom: `1px solid ${isDark ? "rgba(255, 214, 0, 0.45)" : "rgba(191, 142, 0, 0.45)"}`,
+      borderRadius: "3px",
+      padding: "0.05em 0.15em"
     },
     ".cm-live-prefix": {
       display: "inline-flex",

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotation.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotation.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public struct ChangedownAnnotationEntry: Equatable, Sendable {
+    public var author: String?
+    public var date: String?
+    public var text: String
+
+    public init(author: String? = nil, date: String? = nil, text: String) {
+        self.author = author
+        self.date = date
+        self.text = text
+    }
+}
+
+public struct ChangedownAnnotationFootnote: Equatable, Sendable {
+    public var id: String
+    public var author: String?
+    public var date: String?
+    public var kind: String?
+    public var status: String?
+    public var entries: [ChangedownAnnotationEntry]
+    public var lineRange: ClosedRange<Int>
+
+    public init(
+        id: String,
+        author: String? = nil,
+        date: String? = nil,
+        kind: String? = nil,
+        status: String? = nil,
+        entries: [ChangedownAnnotationEntry] = [],
+        lineRange: ClosedRange<Int>
+    ) {
+        self.id = id
+        self.author = author
+        self.date = date
+        self.kind = kind
+        self.status = status
+        self.entries = entries
+        self.lineRange = lineRange
+    }
+
+    public var summary: String? {
+        entries.first?.text
+    }
+}
+
+public struct ChangedownAnnotation: Equatable, Sendable {
+    public var id: String
+    public var highlightedText: String
+    public var inlineComment: String?
+    public var footnote: ChangedownAnnotationFootnote?
+
+    public init(
+        id: String,
+        highlightedText: String,
+        inlineComment: String? = nil,
+        footnote: ChangedownAnnotationFootnote? = nil
+    ) {
+        self.id = id
+        self.highlightedText = highlightedText
+        self.inlineComment = inlineComment
+        self.footnote = footnote
+    }
+}
+
+public struct ChangedownAnnotationProjectionResult: Equatable, Sendable {
+    public var markdown: String
+    public var annotations: [String: ChangedownAnnotation]
+
+    public init(markdown: String, annotations: [String: ChangedownAnnotation]) {
+        self.markdown = markdown
+        self.annotations = annotations
+    }
+}
+

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationParser.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationParser.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public enum ChangedownAnnotationParser {
+    private static let headerRegex = try! NSRegularExpression(
+        pattern: #"^\[\^(cn-[A-Za-z0-9.-]+)\]:\s*(.*)$"#,
+        options: []
+    )
+
+    private static let discussionRegex = try! NSRegularExpression(
+        pattern: #"^\s*(@[^\s:]+)\s+(\d{4}-\d{2}-\d{2})(?:\s+\[[^\]]+\])?:\s*(.*)$"#,
+        options: []
+    )
+
+    public static func parseFootnotes(in markdown: String) -> [String: ChangedownAnnotationFootnote] {
+        let lines = markdown.components(separatedBy: "\n")
+        var result: [String: ChangedownAnnotationFootnote] = [:]
+        var lineIndex = 0
+
+        while lineIndex < lines.count {
+            let line = lines[lineIndex]
+            let fullRange = NSRange(location: 0, length: (line as NSString).length)
+
+            guard let match = headerRegex.firstMatch(in: line, range: fullRange) else {
+                lineIndex += 1
+                continue
+            }
+
+            let id = substring(in: line, match.range(at: 1))
+            let headerContent = substring(in: line, match.range(at: 2))
+            let headerParts = headerContent
+                .split(separator: "|", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+
+            let author = headerParts.indices.contains(0) && !headerParts[0].isEmpty ? headerParts[0] : nil
+            let date = headerParts.indices.contains(1) && !headerParts[1].isEmpty ? headerParts[1] : nil
+            let kind = headerParts.indices.contains(2) && !headerParts[2].isEmpty ? headerParts[2] : nil
+            let status = headerParts.indices.contains(3) && !headerParts[3].isEmpty ? headerParts[3] : nil
+
+            var endLine = lineIndex
+            var entries: [ChangedownAnnotationEntry] = []
+            var scanIndex = lineIndex + 1
+
+            while scanIndex < lines.count {
+                let candidate = lines[scanIndex]
+                let trimmed = candidate.trimmingCharacters(in: .whitespaces)
+
+                if trimmed.isEmpty {
+                    endLine = scanIndex
+                    scanIndex += 1
+                    continue
+                }
+
+                guard candidate.hasPrefix("    ") || candidate.hasPrefix("\t") else {
+                    break
+                }
+
+                if let entry = parseDiscussionEntry(from: candidate) {
+                    entries.append(entry)
+                } else if let fallback = parseFallbackEntry(from: trimmed) {
+                    entries.append(fallback)
+                }
+
+                endLine = scanIndex
+                scanIndex += 1
+            }
+
+            result[id] = ChangedownAnnotationFootnote(
+                id: id,
+                author: author,
+                date: date,
+                kind: kind,
+                status: status,
+                entries: entries,
+                lineRange: lineIndex...endLine
+            )
+
+            lineIndex = max(scanIndex, lineIndex + 1)
+        }
+
+        return result
+    }
+
+    private static func parseDiscussionEntry(from line: String) -> ChangedownAnnotationEntry? {
+        let range = NSRange(location: 0, length: (line as NSString).length)
+        guard let match = discussionRegex.firstMatch(in: line, range: range) else { return nil }
+        let text = substring(in: line, match.range(at: 3)).trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return nil }
+        return ChangedownAnnotationEntry(
+            author: substring(in: line, match.range(at: 1)),
+            date: substring(in: line, match.range(at: 2)),
+            text: text
+        )
+    }
+
+    private static func parseFallbackEntry(from trimmed: String) -> ChangedownAnnotationEntry? {
+        if let colonIndex = trimmed.firstIndex(of: ":") {
+            let text = trimmed[trimmed.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+            return text.isEmpty ? nil : ChangedownAnnotationEntry(text: text)
+        }
+        return trimmed.isEmpty ? nil : ChangedownAnnotationEntry(text: trimmed)
+    }
+
+    private static func substring(in string: String, _ range: NSRange) -> String {
+        guard let swiftRange = Range(range, in: string) else { return "" }
+        return String(string[swiftRange])
+    }
+}
+

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationProjection.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationProjection.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+public enum ChangedownAnnotationProjection {
+    private static let highlightWithCommentRegex = try! NSRegularExpression(
+        pattern: #"\{==([\s\S]+?)==\}\{>>\s*([\s\S]+?)\s*<<\}\[\^(cn-[A-Za-z0-9.-]+)\]"#,
+        options: []
+    )
+
+    private static let highlightWithFootnoteRegex = try! NSRegularExpression(
+        pattern: #"\{==([\s\S]+?)==\}\[\^(cn-[A-Za-z0-9.-]+)\]"#,
+        options: []
+    )
+
+    public static func project(_ markdown: String) -> ChangedownAnnotationProjectionResult {
+        let footnotes = ChangedownAnnotationParser.parseFootnotes(in: markdown)
+        var annotations: [String: ChangedownAnnotation] = [:]
+
+        var projected = replaceMatches(in: markdown, regex: highlightWithCommentRegex) { match, source in
+            let highlighted = substring(in: source, match.range(at: 1))
+            let inlineComment = substring(in: source, match.range(at: 2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            let id = substring(in: source, match.range(at: 3))
+            let footnote = footnotes[id]
+            annotations[id] = ChangedownAnnotation(
+                id: id,
+                highlightedText: highlighted,
+                inlineComment: inlineComment,
+                footnote: footnote
+            )
+            return annotationHTML(
+                id: id,
+                text: highlighted,
+                comment: footnote?.summary ?? (inlineComment.isEmpty ? nil : inlineComment),
+                footnote: footnote
+            )
+        }
+
+        projected = replaceMatches(in: projected, regex: highlightWithFootnoteRegex) { match, source in
+            let highlighted = substring(in: source, match.range(at: 1))
+            let id = substring(in: source, match.range(at: 2))
+
+            guard annotations[id] == nil else {
+                return substring(in: source, match.range)
+            }
+
+            let footnote = footnotes[id]
+            annotations[id] = ChangedownAnnotation(
+                id: id,
+                highlightedText: highlighted,
+                inlineComment: nil,
+                footnote: footnote
+            )
+            return annotationHTML(
+                id: id,
+                text: highlighted,
+                comment: footnote?.summary,
+                footnote: footnote
+            )
+        }
+
+        if !annotations.isEmpty {
+            projected = removeRenderedFootnotes(from: projected, renderedIds: Set(annotations.keys))
+        }
+
+        return ChangedownAnnotationProjectionResult(markdown: projected, annotations: annotations)
+    }
+
+    private static func replaceMatches(
+        in text: String,
+        regex: NSRegularExpression,
+        transform: (NSTextCheckingResult, String) -> String
+    ) -> String {
+        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        guard !matches.isEmpty else { return text }
+
+        var result = text
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: result) else { continue }
+            result.replaceSubrange(range, with: transform(match, text))
+        }
+        return result
+    }
+
+    private static func removeRenderedFootnotes(from markdown: String, renderedIds: Set<String>) -> String {
+        let lines = markdown.components(separatedBy: "\n")
+        let footnotes = ChangedownAnnotationParser.parseFootnotes(in: markdown)
+        let blockedLineIndices = Set(
+            footnotes.values
+                .filter { renderedIds.contains($0.id) }
+                .flatMap { Array($0.lineRange) }
+        )
+
+        guard !blockedLineIndices.isEmpty else { return markdown }
+
+        var filteredLines: [String] = []
+        filteredLines.reserveCapacity(lines.count)
+
+        for (index, line) in lines.enumerated() where !blockedLineIndices.contains(index) {
+            filteredLines.append(line)
+        }
+
+        while filteredLines.last?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+            filteredLines.removeLast()
+        }
+
+        return filteredLines.joined(separator: "\n")
+    }
+
+    private static func annotationHTML(
+        id: String,
+        text: String,
+        comment: String?,
+        footnote: ChangedownAnnotationFootnote?
+    ) -> String {
+        var attributes = [
+            #"class="cd-annotation""#,
+            #"data-change-id="\#(escapeAttribute(id))""#
+        ]
+
+        if let comment, !comment.isEmpty {
+            attributes.append(#"data-comment="\#(escapeAttribute(comment))""#)
+            attributes.append(#"title="\#(escapeAttribute(comment))""#)
+        }
+        if let author = footnote?.author, !author.isEmpty {
+            attributes.append(#"data-author="\#(escapeAttribute(author))""#)
+        }
+        if let date = footnote?.date, !date.isEmpty {
+            attributes.append(#"data-date="\#(escapeAttribute(date))""#)
+        }
+        if let status = footnote?.status, !status.isEmpty {
+            attributes.append(#"data-status="\#(escapeAttribute(status))""#)
+        }
+
+        return #"<span \#(attributes.joined(separator: " "))>\#(escapeHTML(text))</span>"#
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func escapeAttribute(_ text: String) -> String {
+        escapeHTML(text)
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "\n", with: "&#10;")
+    }
+
+    private static func substring(in string: String, _ range: NSRange) -> String {
+        guard let swiftRange = Range(range, in: string) else { return "" }
+        return String(string[swiftRange])
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationWriter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationWriter.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+public enum ChangedownAnnotationWriterError: Error, Equatable, LocalizedError {
+    case invalidRange
+    case emptySelection
+    case emptyComment
+    case multilineSelection
+    case unsupportedSelection(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRange:
+            return "The selected text is no longer available."
+        case .emptySelection:
+            return "Select text before adding an annotation."
+        case .emptyComment:
+            return "Enter a note before adding an annotation."
+        case .multilineSelection:
+            return "Annotations currently support selections within one paragraph or list item."
+        case .unsupportedSelection(let reason):
+            return reason
+        }
+    }
+}
+
+public enum ChangedownAnnotationWriter {
+    private static let idRegex = try! NSRegularExpression(
+        pattern: #"\[\^cn-(\d+)\]"#,
+        options: []
+    )
+
+    public static func addAnnotation(
+        to markdown: String,
+        utf16Range: NSRange,
+        comment: String,
+        author: String,
+        date: Date = Date(),
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) throws -> String {
+        guard let range = Range(utf16Range, in: markdown) else {
+            throw ChangedownAnnotationWriterError.invalidRange
+        }
+
+        return try addAnnotation(
+            to: markdown,
+            range: range,
+            comment: comment,
+            author: author,
+            date: date,
+            calendar: calendar
+        )
+    }
+
+    public static func addAnnotation(
+        to markdown: String,
+        range: Range<String.Index>,
+        comment: String,
+        author: String,
+        date: Date = Date(),
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) throws -> String {
+        let selected = String(markdown[range])
+        let normalizedComment = normalizeComment(comment)
+        let normalizedAuthor = normalizeAuthor(author)
+
+        try validate(markdown: markdown, range: range, selected: selected, comment: normalizedComment)
+
+        let id = nextAnnotationID(in: markdown)
+        var result = markdown
+        result.replaceSubrange(range, with: "{==\(selected)==}[^\(id)]")
+
+        let stamp = dateStamp(for: date, calendar: calendar)
+        let footnote = """
+
+        [^\(id)]: \(normalizedAuthor) | \(stamp) | comment | proposed
+            \(normalizedAuthor) \(stamp): \(normalizedComment)
+        """
+
+        if result.hasSuffix("\n\n") {
+            result += String(footnote.dropFirst(2))
+        } else if result.hasSuffix("\n") {
+            result += footnote.dropFirst()
+        } else {
+            result += footnote
+        }
+
+        return result
+    }
+
+    private static func validate(
+        markdown: String,
+        range: Range<String.Index>,
+        selected: String,
+        comment: String
+    ) throws {
+        guard !selected.isEmpty else {
+            throw ChangedownAnnotationWriterError.emptySelection
+        }
+        guard !selected.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ChangedownAnnotationWriterError.emptySelection
+        }
+        guard !comment.isEmpty else {
+            throw ChangedownAnnotationWriterError.emptyComment
+        }
+        guard !selected.contains("\n") && !selected.contains("\r") else {
+            throw ChangedownAnnotationWriterError.multilineSelection
+        }
+        guard !containsAnnotationMarker(selected) else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside annotation markup are not supported yet.")
+        }
+
+        let lineRange = markdown.lineRange(for: range)
+        let line = String(markdown[lineRange])
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.hasPrefix("[^") else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside footnote definitions are not supported.")
+        }
+        guard !trimmed.hasPrefix("|"), !isTableSeparator(trimmed) else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside tables are not supported yet.")
+        }
+        guard !containsAnnotationMarker(line) else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections on lines with existing annotations are not supported yet.")
+        }
+        guard !isInsideFencedCode(markdown: markdown, range: range) else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside code blocks are not supported.")
+        }
+    }
+
+    private static func nextAnnotationID(in markdown: String) -> String {
+        let nsMarkdown = markdown as NSString
+        let matches = idRegex.matches(
+            in: markdown,
+            range: NSRange(location: 0, length: nsMarkdown.length)
+        )
+        let maxID = matches.compactMap { match -> Int? in
+            Int(nsMarkdown.substring(with: match.range(at: 1)))
+        }.max() ?? 0
+        return "cn-\(maxID + 1)"
+    }
+
+    private static func isInsideFencedCode(markdown: String, range: Range<String.Index>) -> Bool {
+        let selectedOffset = markdown.distance(from: markdown.startIndex, to: range.lowerBound)
+        var offset = 0
+        var insideFence = false
+
+        for rawLine in markdown.components(separatedBy: "\n") {
+            let lineLengthWithSeparator = rawLine.count + 1
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                insideFence.toggle()
+            }
+            if offset <= selectedOffset && selectedOffset < offset + lineLengthWithSeparator {
+                return insideFence
+            }
+            offset += lineLengthWithSeparator
+        }
+
+        return false
+    }
+
+    private static func containsAnnotationMarker(_ text: String) -> Bool {
+        text.contains("{==") ||
+            text.contains("==}") ||
+            text.contains("{>>") ||
+            text.contains("<<}") ||
+            text.contains("[^cn-")
+    }
+
+    private static func isTableSeparator(_ line: String) -> Bool {
+        line.range(
+            of: #"^\|?(?:\s*:?-+:?\s*\|)+\s*:?-+:?\s*\|?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func normalizeComment(_ comment: String) -> String {
+        comment
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private static func normalizeAuthor(_ author: String) -> String {
+        let trimmed = author.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "@me" }
+        return trimmed.hasPrefix("@") ? trimmed : "@\(trimmed)"
+    }
+
+    private static func dateStamp(for date: Date, calendar: Calendar) -> String {
+        var calendar = calendar
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 1970,
+            components.month ?? 1,
+            components.day ?? 1
+        )
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationWriter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationWriter.swift
@@ -28,6 +28,10 @@ public enum ChangedownAnnotationWriter {
         pattern: #"\[\^cn-(\d+)\]"#,
         options: []
     )
+    private static let inlineAnnotationRegex = try! NSRegularExpression(
+        pattern: #"\{==[^\n\r]*?==\}(?:\{>>[^\n\r]*?<<\})?\[\^cn-[A-Za-z0-9.-]+\]"#,
+        options: []
+    )
 
     public static func addAnnotation(
         to markdown: String,
@@ -119,8 +123,8 @@ public enum ChangedownAnnotationWriter {
         guard !trimmed.hasPrefix("|"), !isTableSeparator(trimmed) else {
             throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside tables are not supported yet.")
         }
-        guard !containsAnnotationMarker(line) else {
-            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections on lines with existing annotations are not supported yet.")
+        guard !overlapsExistingAnnotation(markdown: markdown, range: range) else {
+            throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside existing annotations are not supported yet.")
         }
         guard !isInsideFencedCode(markdown: markdown, range: range) else {
             throw ChangedownAnnotationWriterError.unsupportedSelection("Selections inside code blocks are not supported.")
@@ -157,6 +161,17 @@ public enum ChangedownAnnotationWriter {
         }
 
         return false
+    }
+
+    private static func overlapsExistingAnnotation(markdown: String, range: Range<String.Index>) -> Bool {
+        let nsMarkdown = markdown as NSString
+        let selectionRange = NSRange(range, in: markdown)
+        let matches = inlineAnnotationRegex.matches(
+            in: markdown,
+            range: NSRange(location: 0, length: nsMarkdown.length)
+        )
+
+        return matches.contains { NSIntersectionRange($0.range, selectionRange).length > 0 }
     }
 
     private static func containsAnnotationMarker(_ text: String) -> Bool {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -6,13 +6,19 @@ public enum MarkdownRenderer {
     private static let escapedMathDollarToken = "\u{E101}"
     private static let escapedMathPaddingToken = "\u{E102}"
 
-    public static func renderHTML(_ markdown: String, appLinkURLs: Bool = false, includeFrontmatter: Bool = true) -> String {
+    public static func renderHTML(
+        _ markdown: String,
+        appLinkURLs: Bool = false,
+        includeFrontmatter: Bool = true,
+        renderAnnotations: Bool = false
+    ) -> String {
         guard !markdown.isEmpty else { return "" }
 
         let frontmatter = FrontmatterSupport.extract(from: markdown)
 
         let rawBody = frontmatter?.body ?? markdown
-        let (body, codeFilenames) = extractCodeFilenames(rawBody)
+        let annotationProjectedBody = renderAnnotations ? ChangedownAnnotationProjection.project(rawBody).markdown : rawBody
+        let (body, codeFilenames) = extractCodeFilenames(annotationProjectedBody)
         let protectedBody = protectEscapedMathDelimiters(in: body)
         let len = protectedBody.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
@@ -35,6 +35,9 @@ public struct PreviewPalette: Sendable {
     public var caption: String
     public var hrBorder: String
     public var markBg: String
+    public var annotationBg: String
+    public var annotationBorder: String
+    public var annotationHoverBg: String
     public var calloutDefault: String
     public var calloutTip: String
     public var calloutImportant: String
@@ -85,6 +88,9 @@ public struct PreviewPalette: Sendable {
         caption: String,
         hrBorder: String,
         markBg: String,
+        annotationBg: String,
+        annotationBorder: String,
+        annotationHoverBg: String,
         calloutDefault: String,
         calloutTip: String,
         calloutImportant: String,
@@ -134,6 +140,9 @@ public struct PreviewPalette: Sendable {
         self.caption = caption
         self.hrBorder = hrBorder
         self.markBg = markBg
+        self.annotationBg = annotationBg
+        self.annotationBorder = annotationBorder
+        self.annotationHoverBg = annotationHoverBg
         self.calloutDefault = calloutDefault
         self.calloutTip = calloutTip
         self.calloutImportant = calloutImportant
@@ -186,6 +195,9 @@ public struct PreviewPalette: Sendable {
         caption: "#86868B",
         hrBorder: "rgba(0, 0, 0, 0.1)",
         markBg: "rgba(255, 212, 0, 0.3)",
+        annotationBg: "rgba(255, 212, 0, 0.24)",
+        annotationBorder: "rgba(191, 142, 0, 0.45)",
+        annotationHoverBg: "rgba(255, 212, 0, 0.36)",
         calloutDefault: "rgba(0, 122, 255, 0.1)",
         calloutTip: "rgba(52, 199, 89, 0.1)",
         calloutImportant: "rgba(175, 82, 222, 0.1)",
@@ -238,6 +250,9 @@ public struct PreviewPalette: Sendable {
         caption: "#AEAEB2",
         hrBorder: "rgba(255, 255, 255, 0.1)",
         markBg: "rgba(255, 214, 0, 0.25)",
+        annotationBg: "rgba(255, 214, 0, 0.2)",
+        annotationBorder: "rgba(255, 214, 0, 0.45)",
+        annotationHoverBg: "rgba(255, 214, 0, 0.3)",
         calloutDefault: "rgba(10, 132, 255, 0.14)",
         calloutTip: "rgba(48, 209, 88, 0.14)",
         calloutImportant: "rgba(191, 90, 242, 0.14)",
@@ -264,6 +279,8 @@ public struct PreviewPalette: Sendable {
         var p = PreviewPalette.light
         p.tagBg = "rgba(58, 110, 165, 0.06)"
         p.markBg = "rgba(255, 212, 0, 0.4)"
+        p.annotationBg = "rgba(255, 212, 0, 0.18)"
+        p.annotationHoverBg = "rgba(255, 212, 0, 0.18)"
         return p
     }()
 }
@@ -778,6 +795,19 @@ public enum PreviewCSS {
             padding: 0.1em 0.2em;
             border-radius: 3px;
         }
+
+        .cd-annotation {
+            background: var(--c-annotation-bg);
+            border-bottom: 1px solid var(--c-annotation-border);
+            border-radius: 3px;
+            cursor: help;
+            padding: 0.05em 0.15em;
+        }
+
+        .cd-annotation:hover {
+            background: var(--c-annotation-hover-bg);
+        }
+
         /* Superscript/Subscript */
         sup, sub {
             font-size: 0.75em;
@@ -894,8 +924,9 @@ public enum PreviewCSS {
             border-radius: 8px;
         }
 
-        /* Footnote popovers */
-        .footnote-popover {
+        /* Footnote and annotation popovers */
+        .footnote-popover,
+        .annotation-popover {
             position: absolute;
             max-width: 400px;
             padding: 14px 18px;
@@ -907,6 +938,18 @@ public enum PreviewCSS {
             font-size: 0.9em;
             z-index: 100;
             line-height: 1.5;
+        }
+        .annotation-popover {
+            cursor: default;
+        }
+        .annotation-popover-title {
+            font-weight: 650;
+            margin-bottom: 0.35em;
+        }
+        .annotation-popover-meta {
+            color: var(--c-caption);
+            font-size: 0.85em;
+            margin-bottom: 0.6em;
         }
         .footnote-popover p { margin-bottom: 0.5em; }
         .footnote-popover p:last-child { margin-bottom: 0; }
@@ -1057,6 +1100,9 @@ public enum PreviewCSS {
             ("--c-caption", palette.caption),
             ("--c-hr-border", palette.hrBorder),
             ("--c-mark-bg", palette.markBg),
+            ("--c-annotation-bg", palette.annotationBg),
+            ("--c-annotation-border", palette.annotationBorder),
+            ("--c-annotation-hover-bg", palette.annotationHoverBg),
             ("--c-callout-default", palette.calloutDefault),
             ("--c-callout-tip", palette.calloutTip),
             ("--c-callout-important", palette.calloutImportant),

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/AnnotationCommentsState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/AnnotationCommentsState.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+public struct AnnotationCommentItem: Identifiable, Hashable {
+    public let id: String
+    public let highlightedText: String
+    public let comment: String?
+    public let author: String?
+    public let date: String?
+    public let status: String?
+    public let sourceRange: NSRange
+    public let previewAnchor: PreviewSourceAnchor
+
+    public init(
+        id: String,
+        highlightedText: String,
+        comment: String?,
+        author: String?,
+        date: String?,
+        status: String?,
+        sourceRange: NSRange,
+        previewAnchor: PreviewSourceAnchor
+    ) {
+        self.id = id
+        self.highlightedText = highlightedText
+        self.comment = comment
+        self.author = author
+        self.date = date
+        self.status = status
+        self.sourceRange = sourceRange
+        self.previewAnchor = previewAnchor
+    }
+}
+
+public final class AnnotationCommentsState: ObservableObject {
+    @Published public var isVisible: Bool {
+        didSet { UserDefaults.standard.set(isVisible, forKey: Self.visibilityKey) }
+    }
+    @Published public private(set) var comments: [AnnotationCommentItem] = []
+
+    private static let visibilityKey = "annotationCommentsVisible"
+    private static let inlineAnnotationRegex = try! NSRegularExpression(
+        pattern: #"\{==([^\n\r]*?)==\}(?:\{>>\s*([^\n\r]*?)\s*<<\})?\[\^(cn-[A-Za-z0-9.-]+)\]"#,
+        options: []
+    )
+
+    public init() {
+        self.isVisible = UserDefaults.standard.bool(forKey: Self.visibilityKey)
+    }
+
+    public func toggle() {
+        isVisible.toggle()
+    }
+
+    public func parseComments(from markdown: String) {
+        let nsMarkdown = markdown as NSString
+        let fullRange = NSRange(location: 0, length: nsMarkdown.length)
+        let footnotes = ChangedownAnnotationParser.parseFootnotes(in: markdown)
+
+        let parsed = Self.inlineAnnotationRegex.matches(in: markdown, range: fullRange).map { match in
+            let id = Self.substring(in: nsMarkdown, match.range(at: 3))
+            let highlightedText = Self.normalizeDisplayText(Self.substring(in: nsMarkdown, match.range(at: 1)))
+            let inlineComment = match.range(at: 2).location == NSNotFound
+                ? nil
+                : Self.normalizeOptionalText(Self.substring(in: nsMarkdown, match.range(at: 2)))
+            let footnote = footnotes[id]
+            let highlightRange = match.range(at: 1)
+            return AnnotationCommentItem(
+                id: id,
+                highlightedText: highlightedText,
+                comment: footnote?.summary ?? inlineComment,
+                author: footnote?.author,
+                date: footnote?.date,
+                status: footnote?.status,
+                sourceRange: highlightRange,
+                previewAnchor: Self.previewAnchor(for: highlightRange, in: nsMarkdown)
+            )
+        }
+
+        comments = parsed
+    }
+
+    private static func substring(in string: NSString, _ range: NSRange) -> String {
+        guard range.location != NSNotFound else { return "" }
+        return string.substring(with: range)
+    }
+
+    private static func normalizeDisplayText(_ text: String) -> String {
+        let normalized = text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? "Untitled selection" : normalized
+    }
+
+    private static func normalizeOptionalText(_ text: String) -> String? {
+        let normalized = text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func previewAnchor(for range: NSRange, in text: NSString) -> PreviewSourceAnchor {
+        let start = lineAndColumn(for: range.location, in: text)
+        let endOffset = max(range.location, NSMaxRange(range) - 1)
+        let end = lineAndColumn(for: endOffset, in: text)
+        return PreviewSourceAnchor(
+            startLine: start.line,
+            startColumn: start.column,
+            endLine: end.line,
+            endColumn: end.column,
+            progress: 0
+        )
+    }
+
+    private static func lineAndColumn(for offset: Int, in text: NSString) -> (line: Int, column: Int) {
+        let clampedOffset = min(max(0, offset), text.length)
+        var line = 1
+        var lineStart = 0
+
+        while lineStart < clampedOffset {
+            let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            let nextLineStart = NSMaxRange(lineRange)
+            if nextLineStart > clampedOffset {
+                break
+            }
+            line += 1
+            lineStart = nextLineStart
+        }
+
+        return (line, max(1, clampedOffset - lineStart + 1))
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/OutlineState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/OutlineState.swift
@@ -25,6 +25,8 @@ public final class OutlineState: ObservableObject {
     public var scrollToRange: ((NSRange) -> Void)?
     /// Set by PreviewView coordinator, called when user clicks a heading (preview scroll)
     public var scrollToHeading: ((HeadingItem) -> Void)?
+    /// Set by PreviewView coordinator, called when non-heading UI needs preview scroll.
+    public var scrollToPreviewAnchor: ((PreviewSourceAnchor) -> Void)?
 
     private static let atxHeadingRegex = try! NSRegularExpression(
         pattern: "^(#{1,6})\\s+(.+)$",

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
@@ -115,4 +115,88 @@ final class ChangedownAnnotationTests: XCTestCase {
         XCTAssertTrue(result.markdown.contains("&lt;unsafe&gt; &amp; text"))
         XCTAssertTrue(result.markdown.contains("Quote &quot;this&quot; &amp; that"))
     }
+
+    func testWriterAddsCanonicalFootnoteBackedAnnotation() throws {
+        let markdown = "Select a few words in this paragraph."
+        let range = markdown.range(of: "few words")!
+        let date = fixedDate()
+
+        let result = try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "Phrase this more concretely.",
+            author: "avi",
+            date: date
+        )
+
+        XCTAssertTrue(result.contains("Select a {==few words==}[^cn-1] in this paragraph."))
+        XCTAssertTrue(result.contains("[^cn-1]: @avi | 2026-04-27 | comment | proposed"))
+        XCTAssertTrue(result.contains("@avi 2026-04-27: Phrase this more concretely."))
+        XCTAssertFalse(result.contains("{>>"))
+    }
+
+    func testWriterAllocatesNextNumericID() throws {
+        let markdown = """
+        Existing {==text==}[^cn-3].
+
+        [^cn-3]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Existing.
+
+        Add another annotation here.
+        """
+        let range = markdown.range(of: "another annotation")!
+
+        let result = try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "New note.",
+            author: "@avi",
+            date: fixedDate()
+        )
+
+        XCTAssertTrue(result.contains("{==another annotation==}[^cn-4]"))
+        XCTAssertTrue(result.contains("[^cn-4]: @avi | 2026-04-27 | comment | proposed"))
+    }
+
+    func testWriterRejectsEmptySelection() {
+        let markdown = "Text"
+        XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: markdown.startIndex..<markdown.startIndex,
+            comment: "Note",
+            author: "@avi"
+        )) { error in
+            XCTAssertEqual(error as? ChangedownAnnotationWriterError, .emptySelection)
+        }
+    }
+
+    func testWriterRejectsMultilineSelection() {
+        let markdown = "First line\nSecond line"
+        let range = markdown.startIndex..<markdown.endIndex
+        XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "Note",
+            author: "@avi"
+        )) { error in
+            XCTAssertEqual(error as? ChangedownAnnotationWriterError, .multilineSelection)
+        }
+    }
+
+    func testWriterRejectsExistingAnnotationLine() {
+        let markdown = "Existing {==text==}[^cn-1]."
+        let range = markdown.range(of: "Existing")!
+        XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "Note",
+            author: "@avi"
+        ))
+    }
+
+    private func fixedDate() -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar.date(from: DateComponents(year: 2026, month: 4, day: 27))!
+    }
 }

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import ClearlyCore
+
+final class ChangedownAnnotationTests: XCTestCase {
+    func testParserExtractsFootnoteMetadataAndEntries() {
+        let markdown = """
+        Body.
+
+        [^cn-4]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Tie this to faster review cycles.
+            @sam 2026-04-27: Agreed.
+        """
+
+        let footnotes = ChangedownAnnotationParser.parseFootnotes(in: markdown)
+        let footnote = footnotes["cn-4"]
+
+        XCTAssertEqual(footnote?.author, "@avi")
+        XCTAssertEqual(footnote?.date, "2026-04-27")
+        XCTAssertEqual(footnote?.kind, "comment")
+        XCTAssertEqual(footnote?.status, "proposed")
+        XCTAssertEqual(footnote?.entries.count, 2)
+        XCTAssertEqual(footnote?.entries.first?.text, "Tie this to faster review cycles.")
+        XCTAssertEqual(footnote?.entries.last?.author, "@sam")
+    }
+
+    func testProjectionTreatsFootnoteBackedAnnotationAsFirstClassSyntax() {
+        let markdown = """
+        This release introduces a {==lighter preview reading mode==}[^cn-1].
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Phrase this more concretely.
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertTrue(result.markdown.contains(#"<span class="cd-annotation" data-change-id="cn-1""#))
+        XCTAssertTrue(result.markdown.contains("lighter preview reading mode"))
+        XCTAssertTrue(result.markdown.contains(#"data-comment="Phrase this more concretely.""#))
+        XCTAssertFalse(result.markdown.contains("{=="))
+        XCTAssertFalse(result.markdown.contains("[^cn-1]:"))
+        XCTAssertNil(result.annotations["cn-1"]?.inlineComment)
+    }
+
+    func testProjectionReadsInlineCommentAnnotationButPrefersFootnoteSummary() {
+        let markdown = """
+        This release introduces a {==lighter preview reading mode==}{>> Legacy inline note. <<}[^cn-1].
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Canonical footnote note.
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertTrue(result.markdown.contains(#"<span class="cd-annotation" data-change-id="cn-1""#))
+        XCTAssertTrue(result.markdown.contains("lighter preview reading mode"))
+        XCTAssertTrue(result.markdown.contains(#"data-comment="Canonical footnote note.""#))
+        XCTAssertFalse(result.markdown.contains("Legacy inline note"))
+        XCTAssertFalse(result.markdown.contains("{=="))
+        XCTAssertFalse(result.markdown.contains("{>>"))
+        XCTAssertFalse(result.markdown.contains("[^cn-1]:"))
+        XCTAssertEqual(result.annotations["cn-1"]?.inlineComment, "Legacy inline note.")
+    }
+
+    func testProjectionFallsBackToInlineCommentWhenFootnoteHasNoSummary() {
+        let markdown = """
+        Annotated {==text==}{>> Inline fallback. <<}[^cn-1].
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertTrue(result.markdown.contains(#"data-comment="Inline fallback.""#))
+    }
+
+    func testProjectionUsesFootnoteSummaryForHighlightOnlyAnnotation() {
+        let markdown = """
+        Support docs recommend Clearly for {==reviewing markdown before publishing==}[^cn-3].
+
+        [^cn-3]: @avi | 2026-04-27 | highlight | proposed
+            @avi 2026-04-27: This wording is good.
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertTrue(result.markdown.contains(#"data-change-id="cn-3""#))
+        XCTAssertTrue(result.markdown.contains(#"data-comment="This wording is good.""#))
+        XCTAssertFalse(result.markdown.contains("[^cn-3]:"))
+        XCTAssertEqual(result.annotations["cn-3"]?.footnote?.kind, "highlight")
+    }
+
+    func testProjectionKeepsOrdinaryFootnotes() {
+        let markdown = """
+        Annotated {==text==}{>> note <<}[^cn-1] and ordinary footnote.[^1]
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: note
+
+        [^1]: Ordinary markdown footnote.
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertFalse(result.markdown.contains("[^cn-1]:"))
+        XCTAssertTrue(result.markdown.contains("[^1]: Ordinary markdown footnote."))
+    }
+
+    func testProjectionEscapesHTMLInTextAndAttributes() {
+        let markdown = """
+        Annotated {==<unsafe> & text==}{>> Quote "this" & that <<}[^cn-1].
+        """
+
+        let result = ChangedownAnnotationProjection.project(markdown)
+
+        XCTAssertTrue(result.markdown.contains("&lt;unsafe&gt; &amp; text"))
+        XCTAssertTrue(result.markdown.contains("Quote &quot;this&quot; &amp; that"))
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
@@ -158,6 +158,48 @@ final class ChangedownAnnotationTests: XCTestCase {
         XCTAssertTrue(result.contains("[^cn-4]: @avi | 2026-04-27 | comment | proposed"))
     }
 
+    func testWriterAllowsAnnotationBeforeExistingAnnotationOnSameLine() throws {
+        let markdown = """
+        Annotate first phrase and {==second phrase==}[^cn-1] on the same line.
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Existing.
+        """
+        let range = markdown.range(of: "first phrase")!
+
+        let result = try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "New note.",
+            author: "@avi",
+            date: fixedDate()
+        )
+
+        XCTAssertTrue(result.contains("Annotate {==first phrase==}[^cn-2] and {==second phrase==}[^cn-1] on the same line."))
+        XCTAssertTrue(result.contains("[^cn-2]: @avi | 2026-04-27 | comment | proposed"))
+    }
+
+    func testWriterAllowsAnnotationAfterExistingAnnotationOnSameLine() throws {
+        let markdown = """
+        Annotate {==first phrase==}[^cn-1] and second phrase on the same line.
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Existing.
+        """
+        let range = markdown.range(of: "second phrase")!
+
+        let result = try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "New note.",
+            author: "@avi",
+            date: fixedDate()
+        )
+
+        XCTAssertTrue(result.contains("Annotate {==first phrase==}[^cn-1] and {==second phrase==}[^cn-2] on the same line."))
+        XCTAssertTrue(result.contains("[^cn-2]: @avi | 2026-04-27 | comment | proposed"))
+    }
+
     func testWriterRejectsEmptySelection() {
         let markdown = "Text"
         XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
@@ -183,15 +225,36 @@ final class ChangedownAnnotationTests: XCTestCase {
         }
     }
 
-    func testWriterRejectsExistingAnnotationLine() {
+    func testWriterRejectsSelectionInsideExistingAnnotation() {
         let markdown = "Existing {==text==}[^cn-1]."
-        let range = markdown.range(of: "Existing")!
+        let range = markdown.range(of: "text")!
         XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
             to: markdown,
             range: range,
             comment: "Note",
             author: "@avi"
-        ))
+        )) { error in
+            XCTAssertEqual(
+                error as? ChangedownAnnotationWriterError,
+                .unsupportedSelection("Selections inside existing annotations are not supported yet.")
+            )
+        }
+    }
+
+    func testWriterRejectsSelectionCrossingExistingAnnotationBoundary() {
+        let markdown = "Existing {==text==}[^cn-1] remains."
+        let range = markdown.range(of: "Existing {==text==}")!
+        XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(
+            to: markdown,
+            range: range,
+            comment: "Note",
+            author: "@avi"
+        )) { error in
+            XCTAssertEqual(
+                error as? ChangedownAnnotationWriterError,
+                .unsupportedSelection("Selections inside annotation markup are not supported yet.")
+            )
+        }
     }
 
     private func fixedDate() -> Date {

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift
@@ -200,6 +200,38 @@ final class ChangedownAnnotationTests: XCTestCase {
         XCTAssertTrue(result.contains("[^cn-2]: @avi | 2026-04-27 | comment | proposed"))
     }
 
+    func testCommentsStateParsesAnnotationsInDocumentOrder() {
+        let markdown = """
+        First {==selection==}[^cn-2].
+
+        Second {==phrase==}[^cn-1].
+
+        [^cn-1]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: Second note.
+
+        [^cn-2]: @avi | 2026-04-27 | comment | proposed
+            @avi 2026-04-27: First note.
+        """
+        let state = AnnotationCommentsState()
+
+        state.parseComments(from: markdown)
+
+        XCTAssertEqual(state.comments.map(\.id), ["cn-2", "cn-1"])
+        XCTAssertEqual(state.comments.map(\.highlightedText), ["selection", "phrase"])
+        XCTAssertEqual(state.comments.map(\.comment), ["First note.", "Second note."])
+    }
+
+    func testCommentsStateFallsBackToLegacyInlineComment() {
+        let markdown = "This has {==text==}{>> Inline note. <<}[^cn-1]."
+        let state = AnnotationCommentsState()
+
+        state.parseComments(from: markdown)
+
+        XCTAssertEqual(state.comments.count, 1)
+        XCTAssertEqual(state.comments.first?.id, "cn-1")
+        XCTAssertEqual(state.comments.first?.comment, "Inline note.")
+    }
+
     func testWriterRejectsEmptySelection() {
         let markdown = "Text"
         XCTAssertThrowsError(try ChangedownAnnotationWriter.addAnnotation(

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewCSSTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewCSSTests.swift
@@ -16,6 +16,7 @@ final class PreviewCSSTests: XCTestCase {
             "--c-blockquote-bg", "--c-blockquote-fg",
             "--c-border-subtle", "--c-border-strong", "--c-th-hover-bg", "--c-row-hover-bg",
             "--c-caption", "--c-hr-border", "--c-mark-bg",
+            "--c-annotation-bg", "--c-annotation-border", "--c-annotation-hover-bg",
             "--c-callout-default", "--c-callout-tip", "--c-callout-important",
             "--c-callout-warning", "--c-callout-caution", "--c-callout-abstract",
             "--c-callout-example", "--c-callout-quote", "--c-callout-question",

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -32021,11 +32021,20 @@
   }
   function requestAddAnnotation(view) {
     const selection = view.state.selection.main;
+    const fromRect = view.coordsAtPos(selection.from);
+    const toRect = view.coordsAtPos(selection.to);
+    const selectionRect = fromRect && toRect ? {
+      x: Math.min(fromRect.left, toRect.left),
+      y: Math.min(fromRect.top, toRect.top),
+      width: Math.max(1, Math.abs(toRect.right - fromRect.left)),
+      height: Math.max(fromRect.bottom, toRect.bottom) - Math.min(fromRect.top, toRect.top)
+    } : null;
     postMessage({
       type: "addAnnotationRequested",
       markdown: view.state.doc.toString(),
       from: selection.from,
-      to: selection.to
+      to: selection.to,
+      selectionRect
     });
   }
   function applyFormattingCommand(command2) {

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -32019,6 +32019,15 @@
     });
     view.focus();
   }
+  function requestAddAnnotation(view) {
+    const selection = view.state.selection.main;
+    postMessage({
+      type: "addAnnotationRequested",
+      markdown: view.state.doc.toString(),
+      from: selection.from,
+      to: selection.to
+    });
+  }
   function applyFormattingCommand(command2) {
     if (!editor) {
       return;
@@ -32122,13 +32131,7 @@ $$`);
         insertSnippet(editor, '\n\n<div class="page-break"></div>\n\n');
         break;
       case "addAnnotation": {
-        const selection = editor.state.selection.main;
-        postMessage({
-          type: "addAnnotationRequested",
-          markdown: editor.state.doc.toString(),
-          from: selection.from,
-          to: selection.to
-        });
+        requestAddAnnotation(editor);
         break;
       }
       case "findNext":

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -32121,6 +32121,16 @@ $$`);
       case "pageBreak":
         insertSnippet(editor, '\n\n<div class="page-break"></div>\n\n');
         break;
+      case "addAnnotation": {
+        const selection = editor.state.selection.main;
+        postMessage({
+          type: "addAnnotationRequested",
+          markdown: editor.state.doc.toString(),
+          from: selection.from,
+          to: selection.to
+        });
+        break;
+      }
       case "findNext":
         findNext(editor);
         updateFindStatus(editor.state);
@@ -32170,6 +32180,13 @@ $$`);
       decorateWrapped(new RegExp("(?<!!)\\[([^\\]]+)\\]\\(([^)]+)\\)", "g"), "cm-live-link", (match2) => ({
         "data-live-link-kind": "markdown",
         "data-live-href": match2[2] ?? ""
+      }));
+      decorateWrapped(/\{==(.+?)==\}\{>>\s*(.+?)\s*<<\}\[\^(cn-[A-Za-z0-9.-]+)\]/g, "cm-live-annotation", (match2) => ({
+        "data-live-annotation-id": match2[3] ?? "",
+        "data-live-annotation-comment": match2[2] ?? ""
+      }));
+      decorateWrapped(/\{==(.+?)==\}\[\^(cn-[A-Za-z0-9.-]+)\]/g, "cm-live-annotation", (match2) => ({
+        "data-live-annotation-id": match2[2] ?? ""
       }));
       decorateWrapped(/\[\[([^\]#]+(?:#[^\]]+)?)\]\]/g, "cm-live-wiki-link", (match2) => {
         const raw = match2[1] ?? "";
@@ -32553,6 +32570,12 @@ $$`);
         borderRadius: "3px",
         padding: "1px 5px",
         fontSize: "0.9em"
+      },
+      ".cm-live-annotation": {
+        backgroundColor: isDark ? "rgba(255, 214, 0, 0.2)" : "rgba(255, 212, 0, 0.24)",
+        borderBottom: `1px solid ${isDark ? "rgba(255, 214, 0, 0.45)" : "rgba(191, 142, 0, 0.45)"}`,
+        borderRadius: "3px",
+        padding: "0.05em 0.15em"
       },
       ".cm-live-prefix": {
         display: "inline-flex",


### PR DESCRIPTION
# Annotations and Comments

https://github.com/user-attachments/assets/d4fea794-10d2-4aa3-b8c1-ac672d86a90b

Clearly now supports [ChangeDown](https://changedown.com/)-style annotations as first-class comments on selected markdown text. The editor writes the annotation into markdown, preview renders it as a highlighted span, and the macOS shell exposes a comments side panel for reviewing all comments in the current document.

## ChangeDown Pattern

The preferred syntax is:

```md
{==selected text==}[^cn-1]

[^cn-1]: @username | 2026-04-27 | comment | proposed
    @username 2026-04-27: Comment text.
```

Supported legacy syntax remains readable:

```md
{==selected text==}{>> Inline comment text. <<}[^cn-1]
```

Rendering and side-panel display prefer the footnote summary when it exists. Legacy inline comment text is used as a fallback.

New annotations use the macOS account username from `NSUserName()`. There is no editable Annotation Username setting.

## Feature Radius

Users can add comments from:

- Format menu: `Format > Add Annotation...`
- Formatting popover: `Aa` popover, `Add Annotation`
- Toolbar: `plus.bubble` Add Annotation button
- Classic editor context menu
- Preview context menu
- Live Preview context menu

Users can view comments from:

- Rendered highlights in Preview and Live Preview
- Native trailing Comments panel, toggled by the `text.bubble` toolbar button beside Outline
- View menu: `View > Toggle Comments`

The Comments panel lists annotations in document order. Each row shows selected text, comment summary, and metadata when available. Clicking a row jumps to the annotation using the same editor/preview scroll hooks as Outline.

## Code Paths

Core annotation model and parsing:

- `Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotation.swift`
- `Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationParser.swift`
- `Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationProjection.swift`
- `Packages/ClearlyCore/Sources/ClearlyCore/Annotations/ChangedownAnnotationWriter.swift`
- `Packages/ClearlyCore/Sources/ClearlyCore/State/AnnotationCommentsState.swift`

macOS creation and UI entrypoints:

- `Clearly/AnnotationCommand.swift`
- `Clearly/ClearlyTextView.swift`
- `Clearly/PreviewView.swift`
- `Clearly/LiveEditorView.swift`
- `Clearly/Native/MacFormatPopover.swift`
- `Clearly/Native/MacDetailColumn.swift`

Comments panel and shell wiring:

- `Clearly/AnnotationCommentsView.swift`
- `Clearly/Native/MacRootView.swift`
- `Clearly/Native/NativeShellSupport.swift`
- `Clearly/ClearlyApp.swift`

Settings cleanup:

- `Clearly/SettingsView.swift`
- `Clearly/UserDefaultsMigrator.swift`

Tests:

- `Packages/ClearlyCore/Tests/ClearlyCoreTests/ChangedownAnnotationTests.swift`

## Current Limits

- Creation supports single-line selections.
- Creation rejects selections inside tables, fenced code blocks, footnote definitions, or existing annotation markup.
- Multiple non-overlapping annotations can exist on the same line.
- Preview selection mapping requires selected text to resolve unambiguously to markdown source.
