### PR TITLE
[mac] Background Integrate pass for hand-dropped wiki notes

### DIFF
--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -157,14 +157,15 @@ struct MacDetailToolbar: ToolbarContent {
                 ToolbarSpacer(.fixed, placement: .primaryAction)
             }
             ToolbarItemGroup(placement: .primaryAction) {
-                // Auto-Review surfaced affordance. Only renders when the agent
+                // Background wiki operation affordance. Only renders when the agent
                 // has parked a proposal on `pendingOperation`; click goes
                 // straight to the diff sheet (skipping the sidebar). Lives in
                 // the wiki cluster so it sits next to Capture/Chat — the
                 // LogSidebar header badge alone is invisible to anyone who
                 // keeps the sidebar closed.
-                if wikiController.hasPendingReview {
+                if wikiController.hasPendingOperation {
                     let count = wikiController.pendingOperation?.changes.count ?? 0
+                    let label = wikiController.pendingOperationLabel
                     Button {
                         wikiController.presentPending()
                     } label: {
@@ -180,7 +181,7 @@ struct MacDetailToolbar: ToolbarContent {
                                     .offset(x: 8, y: -6)
                             }
                     }
-                    .help("Review ready · \(count) change\(count == 1 ? "" : "s")")
+                    .help("\(label) ready · \(count) change\(count == 1 ? "" : "s")")
                 }
 
                 Button {
@@ -650,6 +651,7 @@ struct MacDetailColumn: View {
     private func warmAndReviewActiveVaultIfNeeded() {
         WikiAgentCoordinator.warmForActiveVaultIfPossible(workspace: workspace)
         WikiAgentCoordinator.runReviewIfStale(workspace: workspace, controller: wikiController)
+        WikiAgentCoordinator.runIntegrationIfNeeded(workspace: workspace, controller: wikiController)
     }
 
     private func setupFileWatcher() {

--- a/Clearly/Wiki/WikiAgentCoordinator.swift
+++ b/Clearly/Wiki/WikiAgentCoordinator.swift
@@ -184,7 +184,7 @@ enum WikiAgentCoordinator {
         }
 
         // Already running or pending? Don't double-fire.
-        guard !controller.hasPendingReview,
+        guard !controller.hasPendingOperation,
               !controller.isPresenting,
               !controller.isRunningRecipe,
               !controller.isAutoReviewing else {
@@ -223,6 +223,141 @@ enum WikiAgentCoordinator {
                 stageMode: .holdForReview
             ) { "" }
         }
+    }
+
+    /// Background pass that integrates user-dropped notes — adds them to
+    /// `index.md` and proposes cross-references. Same lifecycle as auto-Review:
+    /// throttled, parks on `pendingOperation`, never popping a sheet unprompted.
+    /// Throttle is 5 min so editing a single note doesn't trigger an agent run
+    /// every keystroke; the batch cap keeps token cost and diff size bounded
+    /// for bulk imports.
+    static func runIntegrationIfNeeded(workspace: WorkspaceManager, controller: WikiOperationController) {
+        guard workspace.activeVaultIsWiki,
+              let vaultURL = workspace.activeLocation?.url else {
+            return
+        }
+
+        let candidates = integrationCandidates(under: vaultURL)
+        let candidateSignature = integrationCandidateSignature(candidates)
+
+        if let state = WikiVaultState.read(at: vaultURL),
+           let last = state.lastIntegrationAt {
+            let elapsed = Date().timeIntervalSince(last)
+            if elapsed < integrationThrottleSeconds,
+               state.lastIntegrationCandidateSignature == candidateSignature {
+                return
+            }
+        }
+
+        guard !controller.hasPendingOperation,
+              !controller.isPresenting,
+              !controller.isRunningRecipe,
+              !controller.isAutoReviewing else {
+            return
+        }
+
+        guard !candidates.isEmpty else {
+            // Mark the pass as run so we don't re-scan on every tree-revision
+            // change while the wiki is fully indexed. A changed candidate
+            // signature bypasses the throttle, so new drops still run
+            // immediately.
+            WikiVaultState.recordIntegrationRun(at: vaultURL, candidateSignature: candidateSignature)
+            return
+        }
+
+        guard let runner = resolveToolEnabledRunner(vaultURL: vaultURL) else {
+            DiagnosticLog.log("[Integrate] skipped: no agent CLI installed")
+            return
+        }
+        AgentWarmer.warmIfNeeded(runner: runner)
+        let session = Session(vaultURL: vaultURL, runner: runner)
+
+        let truncated = candidates.count > integrationCap
+        let batch = truncated ? Array(candidates.prefix(integrationCap)) : candidates
+        let inputBody = renderIntegrationInput(paths: batch, truncatedRemaining: truncated ? candidates.count - integrationCap : 0)
+
+        Task { @MainActor in
+            guard !controller.isAutoReviewing else {
+                DiagnosticLog.log("[Integrate] skipped: another auto-pass in flight")
+                return
+            }
+            DiagnosticLog.log("[Integrate] start: \(batch.count) note(s) (\(candidates.count) total candidate(s))")
+            await runRecipe(
+                kind: .integrate,
+                session: session,
+                controller: controller,
+                startStatus: "Integrating dropped notes…",
+                titleFor: { proposal in
+                    let count = batch.count
+                    return "Integrate: \(count) note\(count == 1 ? "" : "s")"
+                },
+                stageMode: .holdForReview
+            ) { inputBody }
+            WikiVaultState.recordIntegrationRun(at: vaultURL, candidateSignature: candidateSignature)
+        }
+    }
+
+    /// Cap on notes integrated per pass. Above this, the recipe input gets
+    /// truncated and a "drop the rest after" hint is added — the next throttle
+    /// window picks them up. Conservative starting point: each integrated note
+    /// costs the agent one Read on the note plus up to three Reads on cross-ref
+    /// targets, so a 25-note batch is already ~100 file reads + the recipe.
+    /// Tune up only after observing real runs.
+    static let integrationCap = 25
+
+    /// Minimum gap between integration passes. Prevents tree-revision events
+    /// (which fire on every save) from re-triggering an agent run while a
+    /// previous pass is still cooling down.
+    static let integrationThrottleSeconds: TimeInterval = 5 * 60
+
+    /// Compute the set of vault-relative `.md` paths that are NOT yet
+    /// referenced from `index.md` and aren't wiki infrastructure. Sorted
+    /// deterministically so test fixtures are stable.
+    static func integrationCandidates(under vaultURL: URL) -> [String] {
+        let indexURL = vaultURL.appendingPathComponent("index.md")
+        let indexContent = (try? String(contentsOf: indexURL, encoding: .utf8)) ?? ""
+        return WikiIntegrationCandidates.select(
+            allPaths: enumerateMarkdown(under: vaultURL),
+            indexContent: indexContent
+        )
+    }
+
+    private static func enumerateMarkdown(under vaultURL: URL) -> [String] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: vaultURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        let root = vaultURL.resolvingSymlinksInPath().path
+        var results: [String] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension.lowercased() == "md" else { continue }
+            let full = url.resolvingSymlinksInPath().path
+            guard full.hasPrefix(root) else { continue }
+            var relative = String(full.dropFirst(root.count))
+            if relative.hasPrefix("/") { relative = String(relative.dropFirst()) }
+            results.append(relative)
+        }
+        return results
+    }
+
+    private static func renderIntegrationInput(paths: [String], truncatedRemaining: Int) -> String {
+        var lines: [String] = []
+        lines.append("These notes were dropped into the vault and aren't yet referenced from `index.md`. Integrate them.")
+        lines.append("")
+        for path in paths {
+            lines.append("- \(path)")
+        }
+        if truncatedRemaining > 0 {
+            lines.append("")
+            lines.append("\(truncatedRemaining) more note\(truncatedRemaining == 1 ? "" : "s") will be integrated on the next pass — focus on the list above.")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func integrationCandidateSignature(_ paths: [String]) -> String {
+        paths.joined(separator: "\n")
     }
 
     /// Fire a silent cache warmup for the chat/query path as soon as a wiki
@@ -337,6 +472,7 @@ enum WikiAgentCoordinator {
                     case .capture: return "Nothing staged"
                     case .chat: return "Answer"
                     case .review: return "No issues found"
+                    case .integrate: return "Nothing to integrate"
                     case .other: return "No action"
                     }
                 }()

--- a/Clearly/Wiki/WikiDiffSheet.swift
+++ b/Clearly/Wiki/WikiDiffSheet.swift
@@ -122,6 +122,7 @@ private extension OperationKind {
         case .capture: return "Capture"
         case .chat: return "Chat"
         case .review: return "Review"
+        case .integrate: return "Integrate"
         case .other: return "Operation"
         }
     }

--- a/Clearly/Wiki/WikiLogSidebar.swift
+++ b/Clearly/Wiki/WikiLogSidebar.swift
@@ -18,7 +18,7 @@ struct WikiLogSidebar: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             separator
-            if controller.hasPendingReview {
+            if controller.hasPendingOperation {
                 pendingBadge
                 separator
             }
@@ -81,6 +81,7 @@ struct WikiLogSidebar: View {
 
     private var pendingBadge: some View {
         let count = controller.pendingOperation?.changes.count ?? 0
+        let label = controller.pendingOperationLabel
         return Button {
             controller.presentPending()
         } label: {
@@ -88,7 +89,7 @@ struct WikiLogSidebar: View {
                 Circle()
                     .fill(.tint)
                     .frame(width: 6, height: 6)
-                Text("Review ready · \(count) change\(count == 1 ? "" : "s")")
+                Text("\(label) ready · \(count) change\(count == 1 ? "" : "s")")
                     .font(.callout)
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -98,7 +99,7 @@ struct WikiLogSidebar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("Open the Review diff sheet")
+        .help("Open the \(label) diff sheet")
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
     }
@@ -226,6 +227,7 @@ private struct WikiLogRow: View {
         case "capture", "ingest": return "tray.and.arrow.down"
         case "chat", "query": return "bubble.left"
         case "review", "lint": return "checkmark.shield"
+        case "integrate": return "link"
         default: return "square.and.pencil"
         }
     }
@@ -235,6 +237,7 @@ private struct WikiLogRow: View {
         case "capture", "ingest": return .blue
         case "chat", "query": return .purple
         case "review", "lint": return .orange
+        case "integrate": return .teal
         default: return .secondary
         }
     }

--- a/Clearly/Wiki/WikiOperationController.swift
+++ b/Clearly/Wiki/WikiOperationController.swift
@@ -20,12 +20,21 @@ final class WikiOperationController {
 
     /// Auto-Review parks its proposal here instead of staging immediately, so
     /// the diff sheet doesn't pop in the user's face on vault open. The
-    /// LogSidebar header surfaces a "Review ready" badge while a pending op
+    /// LogSidebar header surfaces a ready badge while a pending op
     /// exists; clicking the badge calls `presentPending()` to move it onto
     /// the staged slot and open the sheet.
     var pendingOperation: WikiOperation?
     var pendingVaultRoot: URL?
-    var hasPendingReview: Bool { pendingOperation != nil }
+    var hasPendingOperation: Bool { pendingOperation != nil }
+    var pendingOperationLabel: String {
+        switch pendingOperation?.kind {
+        case .capture: return "Capture"
+        case .chat: return "Chat"
+        case .review: return "Review"
+        case .integrate: return "Integrate"
+        case .other, .none: return "Operation"
+        }
+    }
 
     /// Set while an *interactive* recipe (Capture) is running — drives the
     /// progress overlay so a long cache warmup doesn't look like silent

--- a/Clearly/Wiki/WikiVaultState.swift
+++ b/Clearly/Wiki/WikiVaultState.swift
@@ -10,14 +10,23 @@ import ClearlyCore
 /// via `DiagnosticLog` and swallow.
 struct WikiVaultState: Codable {
     var lastReviewAt: Date?
+    var lastIntegrationAt: Date?
+    var lastIntegrationCandidateSignature: String?
     var schemaVersion: Int
 
     static let currentSchemaVersion = 1
     static let directoryName = ".clearly"
     static let fileName = "state.json"
 
-    init(lastReviewAt: Date? = nil, schemaVersion: Int = currentSchemaVersion) {
+    init(
+        lastReviewAt: Date? = nil,
+        lastIntegrationAt: Date? = nil,
+        lastIntegrationCandidateSignature: String? = nil,
+        schemaVersion: Int = currentSchemaVersion
+    ) {
         self.lastReviewAt = lastReviewAt
+        self.lastIntegrationAt = lastIntegrationAt
+        self.lastIntegrationCandidateSignature = lastIntegrationCandidateSignature
         self.schemaVersion = schemaVersion
     }
 
@@ -36,6 +45,18 @@ struct WikiVaultState: Codable {
     static func recordReviewRun(at vaultURL: URL, time: Date = Date()) {
         var state = read(at: vaultURL) ?? WikiVaultState()
         state.lastReviewAt = time
+        state.schemaVersion = currentSchemaVersion
+        write(state, to: vaultURL)
+    }
+
+    static func recordIntegrationRun(
+        at vaultURL: URL,
+        time: Date = Date(),
+        candidateSignature: String? = nil
+    ) {
+        var state = read(at: vaultURL) ?? WikiVaultState()
+        state.lastIntegrationAt = time
+        state.lastIntegrationCandidateSignature = candidateSignature
         state.schemaVersion = currentSchemaVersion
         write(state, to: vaultURL)
     }

--- a/Packages/ClearlyCore/Package.resolved
+++ b/Packages/ClearlyCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "10835373ab84647a3a4114425fd70a6b5ddf7a7f69a1ad1f0d5c08bdcbc2ecc3",
+  "originHash" : "870526a6d449370f117dd62a814613a50caed6f264de0926463355b263500234",
   "pins" : [
     {
       "identity" : "cmark-gfm",
@@ -11,12 +11,102 @@
       }
     },
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     }
   ],

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiIntegrationCandidates.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiIntegrationCandidates.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Picks user-dropped notes that haven't been linked from `index.md` yet so
+/// the Integrate pass can hand them to the agent for indexing + cross-
+/// referencing. Pure data — no I/O, no main-actor dependencies — so the
+/// selection rules are unit-testable without filesystem fixtures.
+public enum WikiIntegrationCandidates {
+
+    /// Vault-relative `.md` paths that should be proposed for integration.
+    /// Filters out wiki infrastructure (`raw/`, `_audit/`, `index.md`, etc.)
+    /// and anything already referenced from `index.md` by either its full
+    /// vault-relative stem or its basename stem. Returns results sorted so
+    /// callers and tests see deterministic order.
+    public static func select(allPaths: [String], indexContent: String) -> [String] {
+        let indexed = indexedReferences(in: indexContent)
+        let basenameCounts = allPaths.reduce(into: [String: Int]()) { counts, path in
+            guard !WikiSystemFiles.isExcluded(vaultRelativePath: path) else { return }
+            let withoutExt = path.hasSuffix(".md") ? String(path.dropLast(3)) : path
+            let stem = (withoutExt as NSString).lastPathComponent.lowercased()
+            counts[stem, default: 0] += 1
+        }
+        let unindexed = allPaths.filter { path in
+            if WikiSystemFiles.isExcluded(vaultRelativePath: path) { return false }
+            let withoutExt = path.hasSuffix(".md") ? String(path.dropLast(3)) : path
+            let stem = (withoutExt as NSString).lastPathComponent
+            let stemKey = stem.lowercased()
+            let basenameIsUnique = basenameCounts[stemKey, default: 0] == 1
+            return !indexed.contains(withoutExt.lowercased())
+                && !(basenameIsUnique && indexed.contains(stemKey))
+        }
+        return unindexed.sorted()
+    }
+
+    /// Set of every `[[link]]` reference body found in `index.md`, normalised
+    /// to lowercase with alias and section-anchor suffixes stripped — matching
+    /// Obsidian's case-insensitive wiki-link semantics. Exposed for tests; the
+    /// `select(allPaths:indexContent:)` entry point is the production caller.
+    public static func indexedReferences(in indexContent: String) -> Set<String> {
+        guard !indexContent.isEmpty else { return [] }
+        let pattern = try! NSRegularExpression(pattern: #"\[\[([^\]]+)\]\]"#)
+        let ns = indexContent as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        var refs: Set<String> = []
+        for match in pattern.matches(in: indexContent, range: range) {
+            let body = ns.substring(with: match.range(at: 1))
+            var target = body
+            if let pipe = target.firstIndex(of: "|") { target = String(target[..<pipe]) }
+            if let hash = target.firstIndex(of: "#") { target = String(target[..<hash]) }
+            target = target.trimmingCharacters(in: .whitespaces)
+            if target.isEmpty { continue }
+            refs.insert(target.lowercased())
+        }
+        return refs
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiOperation.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiOperation.swift
@@ -38,6 +38,7 @@ public enum OperationKind: String, Codable, Sendable, CaseIterable {
     case capture
     case chat
     case review
+    case integrate
     case other
 }
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiSystemFiles.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Wiki/WikiSystemFiles.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Vault-relative paths the wiki treats as infrastructure rather than user
+/// content. Centralized so the integrate pass, the inventory listing, and any
+/// future scanner agree on the same skip rules. Add new entries here, not in
+/// callsites.
+public enum WikiSystemFiles {
+
+    /// Top-level filenames that aren't user notes — the wiki's own scaffolding.
+    /// Anchored to vault root: a `Notes/index.md` is user content and won't
+    /// match.
+    public static let reservedRootFiles: Set<String> = [
+        "index.md",
+        "log.md",
+        "AGENTS.md",
+        "getting-started.md",
+    ]
+
+    /// Top-level folders the agent is asked not to crawl. `raw/` is the
+    /// immutable source-material area; `_audit/` is where Review parks its
+    /// own artefacts. Path matching is segment-anchored, so `raw_data.md`
+    /// at the root is NOT excluded.
+    public static let reservedRootFolders: Set<String> = [
+        "raw",
+        "_audit",
+    ]
+
+    /// `true` if the vault-relative path is wiki infrastructure that
+    /// integration / inventory passes should skip. Caller must pass forward-
+    /// slash, vault-relative paths with no leading `/`. Empty paths return
+    /// `true` (degenerate input — skip).
+    public static func isExcluded(vaultRelativePath: String) -> Bool {
+        if vaultRelativePath.isEmpty { return true }
+        let segments = vaultRelativePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard let first = segments.first, !first.isEmpty else { return true }
+
+        // Hidden segment anywhere in the path → skip. Catches `.clearly/state.json`,
+        // dotfiles at root, and dot-prefixed subfolders.
+        if segments.contains(where: { $0.hasPrefix(".") }) { return true }
+
+        if segments.count == 1, reservedRootFiles.contains(first) { return true }
+        if reservedRootFolders.contains(first) { return true }
+        return false
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiIntegrationCandidatesTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiIntegrationCandidatesTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import ClearlyCore
+
+final class WikiIntegrationCandidatesTests: XCTestCase {
+
+    // MARK: - select(allPaths:indexContent:)
+
+    func testReturnsNotesNotReferencedInIndex() {
+        let paths = ["concepts/foo.md", "people/jane.md"]
+        let index = """
+        # Index
+
+        ## Concepts
+        - [[foo]]
+        """
+        let result = WikiIntegrationCandidates.select(allPaths: paths, indexContent: index)
+        XCTAssertEqual(result, ["people/jane.md"])
+    }
+
+    func testFiltersOutSystemFiles() {
+        let paths = [
+            "index.md",
+            "log.md",
+            "AGENTS.md",
+            "getting-started.md",
+            "raw/article.md",
+            "_audit/2026-04.md",
+            ".clearly/state.json",
+            "concepts/foo.md",
+        ]
+        let result = WikiIntegrationCandidates.select(allPaths: paths, indexContent: "")
+        XCTAssertEqual(result, ["concepts/foo.md"])
+    }
+
+    func testMatchesByVaultRelativeStem() {
+        let paths = ["concepts/foo.md", "people/foo.md"]
+        let index = "[[concepts/foo]]"
+        // Only concepts/foo is indexed; people/foo is a different note with
+        // the same basename. Path-anchored match keeps people/foo as a
+        // candidate.
+        let result = WikiIntegrationCandidates.select(allPaths: paths, indexContent: index)
+        XCTAssertEqual(result, ["people/foo.md"])
+    }
+
+    func testMatchesByBasenameStem() {
+        let paths = ["concepts/foo.md"]
+        // User wrote `[[foo]]` (just the basename) — should still count as
+        // indexed because that's how Obsidian-style links typically work.
+        let index = "[[foo]]"
+        XCTAssertEqual(WikiIntegrationCandidates.select(allPaths: paths, indexContent: index), [])
+    }
+
+    func testDoesNotMatchDuplicateBasenamesByBareStem() {
+        let paths = ["concepts/foo.md", "people/foo.md"]
+        let index = "[[foo]]"
+        XCTAssertEqual(WikiIntegrationCandidates.select(allPaths: paths, indexContent: index), [
+            "concepts/foo.md",
+            "people/foo.md",
+        ])
+    }
+
+    func testMatchingIsCaseInsensitive() {
+        let paths = ["concepts/Foo.md"]
+        let index = "[[foo]]"
+        XCTAssertEqual(WikiIntegrationCandidates.select(allPaths: paths, indexContent: index), [])
+    }
+
+    func testStripsAliasAndAnchorWhenMatching() {
+        let paths = ["concepts/foo.md", "people/jane.md"]
+        let index = """
+        - [[foo|Foo Page]]
+        - [[jane#Background]]
+        """
+        let result = WikiIntegrationCandidates.select(allPaths: paths, indexContent: index)
+        XCTAssertEqual(result, [])
+    }
+
+    func testReturnsResultsSorted() {
+        let paths = ["zebra.md", "alpha.md", "mango.md"]
+        let result = WikiIntegrationCandidates.select(allPaths: paths, indexContent: "")
+        XCTAssertEqual(result, ["alpha.md", "mango.md", "zebra.md"])
+    }
+
+    func testEmptyVaultReturnsEmpty() {
+        XCTAssertEqual(WikiIntegrationCandidates.select(allPaths: [], indexContent: ""), [])
+    }
+
+    func testFullyIndexedVaultReturnsEmpty() {
+        let paths = ["concepts/foo.md", "people/jane.md"]
+        let index = "[[foo]] [[jane]]"
+        XCTAssertEqual(WikiIntegrationCandidates.select(allPaths: paths, indexContent: index), [])
+    }
+
+    // MARK: - indexedReferences(in:)
+
+    func testExtractsLinksWithoutAliasOrAnchor() {
+        let index = """
+        # Index
+        - [[plain]]
+        - [[with-alias|Display Text]]
+        - [[with-anchor#Section]]
+        - [[both|Display]]#NotPart
+        """
+        let refs = WikiIntegrationCandidates.indexedReferences(in: index)
+        XCTAssertTrue(refs.contains("plain"))
+        XCTAssertTrue(refs.contains("with-alias"))
+        XCTAssertTrue(refs.contains("with-anchor"))
+        XCTAssertTrue(refs.contains("both"))
+    }
+
+    func testIgnoresEmptyLinkBodies() {
+        let index = "[[]] [[real]]"
+        let refs = WikiIntegrationCandidates.indexedReferences(in: index)
+        XCTAssertEqual(refs, ["real"])
+    }
+
+    func testEmptyIndexReturnsEmptySet() {
+        XCTAssertEqual(WikiIntegrationCandidates.indexedReferences(in: ""), [])
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiSystemFilesTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiSystemFilesTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import ClearlyCore
+
+final class WikiSystemFilesTests: XCTestCase {
+
+    func testReservedRootFilesAreExcluded() {
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "index.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "log.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "AGENTS.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "getting-started.md"))
+    }
+
+    func testReservedFolderContentsAreExcluded() {
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "raw/article.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "raw/sub/deeper.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "_audit/2026-04.md"))
+    }
+
+    func testHiddenSegmentsAreExcluded() {
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: ".clearly/state.json"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: ".hidden.md"))
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: "concepts/.draft.md"))
+    }
+
+    func testReservedFilenamesAreOnlyExcludedAtRoot() {
+        // A note someone calls `index.md` in a subfolder is user content,
+        // not the wiki's table of contents.
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "Notes/index.md"))
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "people/log.md"))
+    }
+
+    func testReservedFolderNamesAreSegmentAnchored() {
+        // Substring matches must NOT trip the predicate — `raw_data.md` at root
+        // is user content.
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "raw_data.md"))
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "audit-notes.md"))
+    }
+
+    func testRegularNotesAreNotExcluded() {
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "concepts/foo.md"))
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "people/jane.md"))
+        XCTAssertFalse(WikiSystemFiles.isExcluded(vaultRelativePath: "thoughts.md"))
+    }
+
+    func testEmptyPathIsExcluded() {
+        XCTAssertTrue(WikiSystemFiles.isExcluded(vaultRelativePath: ""))
+    }
+}

--- a/Shared/Resources/recipes/integrate.md
+++ b/Shared/Resources/recipes/integrate.md
@@ -1,0 +1,58 @@
+---
+name: Integrate
+description: Index and cross-reference notes the user dropped into the vault by hand.
+kind: integrate
+tool_allowlist:
+  - Read
+  - Grep
+  - Glob
+expected_output: wiki_operation
+---
+
+You are integrating user-dropped notes into a personal LLM wiki. The user wrote (or imported) these notes themselves — your job is to make them first-class wiki content alongside notes the agent created via Capture: indexed in `index.md`, cross-referenced from topically related pages, treated identically. **Do not move them, do not edit their bodies, do not add frontmatter.** Just index + cross-reference.
+
+# Notes to integrate
+
+{{input}}
+
+# Vault snapshot
+
+{{vault_state}}
+
+# Your task
+
+1. **Read `AGENTS.md`** — know this vault's `index.md` conventions before proposing changes.
+2. **Read `index.md`** — you'll need its exact current contents byte-for-byte to propose a `modify`.
+3. For each note path in the input list:
+   - **Read the note.** Skim it just enough to know what it's about.
+   - **Decide the right `index.md` section** — reuse existing sections wherever possible. Create a new section only if no existing one is even close. Match the formatting of existing entries.
+   - **Add a `[[stem]]` entry** under that section in `index.md`. Use the note's filename without `.md` as the link text by default, or a friendlier display via `[[stem|Display Name]]` if the title in the file is meaningfully different.
+   - **Cross-reference sparingly.** For each note, find at most **3 topically related existing pages** via `Grep`/`Glob`. Propose a small `modify` adding a `[[stem]]` link to each — only where the link is genuinely useful to a reader of that page. Skip if no obvious relation. Do not invent context, do not rewrite paragraphs, do not "improve" notes the user didn't ask you to touch. **No drive-by edits.**
+4. Bundle every change into one `WikiOperation`. Keep `index.md` as a single `modify` with all additions accumulated, even when integrating many notes at once.
+
+# Files you must NOT modify
+
+- Anything under `raw/` — this folder is the user's immutable archive of source material. Don't pick `raw/` files as cross-reference targets, and never `modify` or `delete` a path beginning with `raw/`.
+- Anything under `_audit/` — Review parks its artefacts there.
+- The notes you're integrating themselves — only `index.md` and other already-curated wiki pages get touched. Do not add frontmatter, retitle, or alter the body of an integrated note.
+
+# Modify preconditions
+
+For every `{"type": "modify", ...}` change, you MUST have Read the target file in this session. The `before:` field must be the file's exact current contents — do not paraphrase or reconstruct from memory. If you didn't Read it, don't modify it.
+
+# Output contract
+
+When done, return ONLY a JSON object (no prose before or after):
+
+```json
+{
+  "title": "integrate: <N notes>",
+  "rationale": "one or two sentences summarising what got indexed and where",
+  "changes": [
+    {"type": "modify", "path": "index.md", "before": "...", "after": "..."},
+    {"type": "modify", "path": "concepts/foo.md", "before": "...", "after": "..."}
+  ]
+}
+```
+
+An empty `changes` array means nothing needed integrating after all (rare — caller already filtered). Paths are vault-relative, forward slashes.

--- a/Shared/Resources/wiki-template/AGENTS.md
+++ b/Shared/Resources/wiki-template/AGENTS.md
@@ -20,8 +20,8 @@ by an LLM on your behalf.
 
 ## Operations
 
-Two manual actions are available from Clearly's **Wiki** menu. Review runs
-quietly in the background when the vault opens.
+Two manual actions are available from Clearly's **Wiki** menu. Review and
+Integrate run quietly in the background when the vault opens.
 
 - **Capture** (⌃⌘I). Paste a URL or text. The agent reads it, writes a
   summary page, updates `index.md`, cross-references related notes, and
@@ -35,6 +35,13 @@ quietly in the background when the vault opens.
   orphan pages, missing cross-references, and concepts mentioned without their
   own page. Clearly runs this automatically about once a day; proposed changes
   appear as a "Review ready" badge.
+
+- **Integrate**. When you drop a `.md` file into the vault by hand, Clearly
+  proposes adding it to `index.md` under the right section and inserting
+  `[[wiki-link]]` cross-references in topically related notes. Hand-dropped
+  notes are treated identically to agent-created ones — same diff sheet, same
+  review flow. Notes are never moved; wherever you put them is where they
+  stay.
 
 ## Conventions
 

--- a/Shared/Resources/wiki-template/getting-started.md
+++ b/Shared/Resources/wiki-template/getting-started.md
@@ -24,9 +24,14 @@ to each other with `[[wiki-links]]` — click one to jump.
 Capture is for when you want the agent to synthesize a note from a
 source. If you already know what you want to write, just drop a `.md`
 file into this folder — drag from Finder, drop onto a folder in the
-sidebar, or press ⌘N and save here. Clearly indexes everything, and
-Chat finds hand-written notes the same way it finds agent-written ones.
-The next Review pass will spot them and suggest cross-references.
+sidebar, or press ⌘N and save here. Wherever you put it is where it
+stays — Clearly never moves your notes around.
+
+Shortly after you drop a note, an Integrate pass runs in the background:
+it adds the note to `index.md` under the right section and proposes
+`[[wiki-link]]` cross-references in topically related pages. You review
+the diff before anything lands. Hand-dropped notes are treated
+identically to agent-created ones.
 
 For raw source material (articles, PDFs, transcripts) you want the agent
 to read later, drop the file into `raw/`. The agent reads from there but


### PR DESCRIPTION
## Summary

Treat user-dropped `.md` files identically to agent-created ones: when a note appears in the vault that isn't yet referenced from `index.md`, an Integrate pass adds it under the right section and proposes `[[wiki-link]]` cross-references in topically related pages. Same diff-sheet review flow as Capture and Review; nothing lands without approval, and notes are never moved.

Triggers on tree-revision change, throttled to 5 min, capped at 25 notes per pass, with a candidate-signature check to avoid re-running on unchanged inputs. Skip list (`raw/`, `_audit/`, `index.md`, `log.md`, `AGENTS.md`, dotfiles) lives in a centralized `WikiSystemFiles` predicate covered by unit tests.

## Test plan

- [ ] Drop one `.md` into a wiki vault root → "Integrate ready · N changes" badge appears within ~1s
- [ ] Click → diff sheet shows `modify(index.md)` adding `[[stem]]` plus ≤3 cross-ref modifies. Accept. File stays at the dropped location.
- [ ] Drop 30 fresh files → only 25 propose; recipe input mentions "5 more on the next pass"
- [ ] Drop into `raw/foo.md` or `.clearly/foo.md` → no badge
- [ ] Drop a file already linked from `index.md` → no badge
- [ ] All 138 ClearlyCore tests pass (19 new in `WikiSystemFilesTests` + `WikiIntegrationCandidatesTests`)