### PR TITLE
[shared] Cap file size on open + harden memory paths

### DIFF
--- a/Clearly/FileWatcher.swift
+++ b/Clearly/FileWatcher.swift
@@ -88,6 +88,10 @@ final class FileWatcher: ObservableObject {
 
     private func readAndNotify() {
         guard let url = monitoredURL else { return }
+        guard Limits.isOpenableSize(url) else {
+            DiagnosticLog.log("FileWatcher: skipping oversized reload \(url.lastPathComponent)")
+            return
+        }
         guard let data = try? Data(contentsOf: url),
               let newText = String(data: data, encoding: .utf8) else { return }
 

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -45,7 +45,7 @@ struct PreviewView: NSViewRepresentable {
     }
 
     private var contentKey: String {
-        "\(markdown)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")__\(hideFrontmatterInPreview)"
+        "\(markdown.count)|\(markdown.hashValue)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")__\(hideFrontmatterInPreview)"
     }
 
     private var wikiFilesKey: String {

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -417,6 +417,12 @@ final class WorkspaceManager {
         // Save current file-backed document before switching
         guard saveFileBacked() else { return false }
 
+        guard Limits.isOpenableSize(url) else {
+            DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
+            presentFileTooLargeAlert(for: url)
+            return false
+        }
+
         // Load new file
         guard let data = try? Data(contentsOf: url),
               let text = String(data: data, encoding: .utf8) else {
@@ -485,6 +491,12 @@ final class WorkspaceManager {
         }
 
         guard saveFileBacked() else { return false }
+
+        guard Limits.isOpenableSize(url) else {
+            DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
+            presentFileTooLargeAlert(for: url)
+            return false
+        }
 
         guard let data = try? Data(contentsOf: url),
               let text = String(data: data, encoding: .utf8) else {
@@ -597,6 +609,10 @@ final class WorkspaceManager {
                 content = openDocuments[openDocumentIndex].text
             }
         } else {
+            guard Limits.isOpenableSize(fileURL) else {
+                DiagnosticLog.log("Skipping oversized backlink source: \(fileURL.lastPathComponent)")
+                return false
+            }
             guard let data = try? Data(contentsOf: fileURL),
                   let diskContent = String(data: data, encoding: .utf8) else {
                 DiagnosticLog.log("Failed to read backlink source: \(fileURL.lastPathComponent)")
@@ -2049,8 +2065,12 @@ final class WorkspaceManager {
                 accessedURLs.insert(normalizedURL)
             }
 
-            guard FileManager.default.fileExists(atPath: normalizedURL.path),
-                  let data = try? Data(contentsOf: normalizedURL),
+            guard FileManager.default.fileExists(atPath: normalizedURL.path) else { return nil }
+            guard Limits.isOpenableSize(normalizedURL) else {
+                DiagnosticLog.log("Skipping oversized restore: \(normalizedURL.lastPathComponent)")
+                return nil
+            }
+            guard let data = try? Data(contentsOf: normalizedURL),
                   let text = String(data: data, encoding: .utf8) else {
                 return nil
             }
@@ -2102,6 +2122,16 @@ final class WorkspaceManager {
         Task { @MainActor in
             WindowRouter.shared.showMainWindow()
         }
+    }
+
+    private func presentFileTooLargeAlert(for url: URL) {
+        let limitMB = Limits.maxOpenableFileSize / 1_000_000
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "“\(url.lastPathComponent)” is too large to open."
+        alert.informativeText = "Clearly limits markdown files to \(limitMB) MB. Files larger than this are typically logs or pasted dumps and can crash the editor. Open a smaller file or split this one."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     private func showSidebar() {

--- a/Clearly/iOS/IOSDocumentSession.swift
+++ b/Clearly/iOS/IOSDocumentSession.swift
@@ -59,6 +59,12 @@ public final class IOSDocumentSession {
             if file.isPlaceholder {
                 try await vault.ensureDownloaded(file.url)
             }
+            guard Limits.isOpenableSize(file.url) else {
+                let limitMB = Limits.maxOpenableFileSize / 1_000_000
+                errorMessage = "“\(file.url.lastPathComponent)” is larger than \(limitMB) MB. Clearly can't open files this large safely."
+                isLoading = false
+                return
+            }
             let loaded = try await vault.readRawText(at: file.url)
             lastSavedText = loaded
             text = loaded

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum Limits {
+    public static let maxOpenableFileSize: Int64 = 50_000_000
+
+    public static let maxLocalImageSize: Int64 = 20_000_000
+
+    public static let maxHighlightAllLength: Int = 5_000_000
+
+    public static func isOpenableSize(_ url: URL) -> Bool {
+        isFileSize(url, atMost: maxOpenableFileSize)
+    }
+
+    public static func isFileSize(_ url: URL, atMost limit: Int64) -> Bool {
+        let resolvedURL = url.resolvingSymlinksInPath()
+        guard let values = try? resolvedURL.resourceValues(forKeys: [.fileSizeKey]),
+              let size = values.fileSize else {
+            return true
+        }
+        return Int64(size) <= limit
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/LocalImageSupport.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/LocalImageSupport.swift
@@ -80,8 +80,25 @@ public final class LocalImageSchemeHandler: NSObject, WKURLSchemeHandler {
         }
 
         let path = url.path.removingPercentEncoding ?? url.path
-        guard !path.isEmpty,
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+        guard !path.isEmpty else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+
+        let fileURL = URL(fileURLWithPath: path)
+        if !Limits.isFileSize(fileURL, atMost: Limits.maxLocalImageSize) {
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 413,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/plain"]
+            )!
+            urlSchemeTask.didReceive(response)
+            urlSchemeTask.didFinish()
+            return
+        }
+
+        guard let data = try? Data(contentsOf: fileURL) else {
             urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
             return
         }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -69,13 +69,13 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         add("^(#{1,6}\\s+)(.+)$", .heading, options: .anchorsMatchLines)
 
         // Bold italic: ***text*** or ___text___
-        add("(\\*\\*\\*|___)(.+?)(\\1)", .boldItalic)
+        add("(\\*\\*\\*|___)([^\n]+?)(\\1)", .boldItalic)
 
         // Bold: **text** or __text__ (not part of ***triple***)
-        add("(?<![*_])(\\*\\*(?!\\*)|__(?!_))(.+?)(\\1)(?![*_])", .bold)
+        add("(?<![*_])(\\*\\*(?!\\*)|__(?!_))([^\n]+?)(\\1)(?![*_])", .bold)
 
         // Italic: *text* or _text_ (not inside words for _)
-        add("(?<![\\w*])(\\*(?!\\*)|_(?!_))(?!\\s)(.+?)(?<!\\s)\\1(?![\\w*])", .italic)
+        add("(?<![\\w*])(\\*(?!\\*)|_(?!_))(?!\\s)([^\n]+?)(?<!\\s)\\1(?![\\w*])", .italic)
 
         // Strikethrough: ~~text~~
         add("(~~)([^\n]+?)(~~)", .strikethrough)
@@ -170,6 +170,10 @@ public final class MarkdownSyntaxHighlighter: NSObject {
 
     public func highlightAll(_ textStorage: PlatformTextStorage, caller: String = "") {
         guard !isHighlighting else { return }
+        guard textStorage.length <= Limits.maxHighlightAllLength else {
+            DiagnosticLog.log("MarkdownSyntaxHighlighter: skipping highlightAll over \(textStorage.length) chars")
+            return
+        }
         isHighlighting = true
         defer { isHighlighting = false }
         let startTime = CACurrentMediaTime()
@@ -483,6 +487,15 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         }
         let postEditRange = NSRange(location: safeLocation, length: safeLength)
         let paragraphRange = nsText.paragraphRange(for: postEditRange)
+
+        // A "paragraph" here is a `\n`-bounded run. A file with no newlines (binary blob,
+        // pasted log dump) is one paragraph the size of the whole file — running the regex
+        // pipeline over multi-MB input is the catastrophic case. Bail; the file-size cap on
+        // open already keeps these out of the editor in normal use.
+        guard paragraphRange.length <= Limits.maxHighlightAllLength else {
+            DiagnosticLog.log("MarkdownSyntaxHighlighter: skipping highlightAround over \(paragraphRange.length)-char paragraph")
+            return
+        }
 
         // If the edited paragraph contains a block delimiter, the change could affect
         // everything below (opening/closing a code block or math block). Signal the caller

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/BacklinksState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/BacklinksState.swift
@@ -113,6 +113,7 @@ public final class BacklinksState: ObservableObject {
 
     private func readContextLine(from fileURL: URL, at lineNumber: Int?) -> String {
         guard let lineNumber, lineNumber > 0,
+              Limits.isOpenableSize(fileURL),
               let data = try? Data(contentsOf: fileURL),
               let content = String(data: data, encoding: .utf8) else {
             return ""

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -214,16 +214,20 @@ public final class VaultIndex: @unchecked Sendable {
 
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
                 if let id: Int64 = existingRow?["id"] {
-                    try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [id])
-                    try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [id])
-                    try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [id])
-                    try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [id])
-                    try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [id])
+                    try self.removeIndexedFile(db: db, id: id)
                     try self.resolveWikiLinkTargets(db: db)
                 }
                 return nil
             }
 
+            guard Limits.isOpenableSize(fileURL) else {
+                DiagnosticLog.log("VaultIndex: skipping oversized file \(fileURL.lastPathComponent)")
+                if let id: Int64 = existingRow?["id"] {
+                    try self.removeIndexedFile(db: db, id: id)
+                    try self.resolveWikiLinkTargets(db: db)
+                }
+                return nil
+            }
             guard let data = try? Data(contentsOf: fileURL),
                   let content = String(data: data, encoding: .utf8) else {
                 return nil
@@ -310,6 +314,14 @@ public final class VaultIndex: @unchecked Sendable {
 
                 for fileURL in markdownFiles {
                     let relativePath = Self.relativePath(of: fileURL, from: rootURL)
+
+                    guard Limits.isOpenableSize(fileURL) else {
+                        DiagnosticLog.log("VaultIndex: skipping oversized file \(fileURL.lastPathComponent)")
+                        if let existing = existingByPath[relativePath] {
+                            try self.removeIndexedFile(db: db, id: existing.id)
+                        }
+                        continue
+                    }
                     processedPaths.insert(relativePath)
 
                     guard let data = try? Data(contentsOf: fileURL),
@@ -366,8 +378,7 @@ public final class VaultIndex: @unchecked Sendable {
                 let removedPaths = existingPaths.subtracting(processedPaths)
                 for path in removedPaths {
                     if let existing = existingByPath[path] {
-                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
-                        try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [existing.id])
+                        try self.removeIndexedFile(db: db, id: existing.id)
                     }
                 }
 
@@ -409,11 +420,21 @@ public final class VaultIndex: @unchecked Sendable {
             if Task.isCancelled { return }
 
             let relativePath = Self.relativePath(of: fileURL, from: rootURL)
-            processedPaths.insert(relativePath)
 
             var usable = true
             if let hook = downloadPlaceholder {
                 usable = await hook(fileURL)
+            }
+
+            var retainIndexedPath = true
+            if usable, !Limits.isOpenableSize(fileURL) {
+                DiagnosticLog.log("VaultIndex: skipping oversized file \(fileURL.lastPathComponent)")
+                usable = false
+                retainIndexedPath = false
+            }
+
+            if retainIndexedPath {
+                processedPaths.insert(relativePath)
             }
 
             if usable,
@@ -488,11 +509,7 @@ public final class VaultIndex: @unchecked Sendable {
                 let removedPaths = existingPaths.subtracting(processed)
                 for path in removedPaths {
                     if let existing = existingByPath[path] {
-                        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [existing.id])
-                        try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [existing.id])
-                        try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [existing.id])
-                        try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [existing.id])
-                        try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [existing.id])
+                        try self.removeIndexedFile(db: db, id: existing.id)
                     }
                 }
 
@@ -536,6 +553,17 @@ public final class VaultIndex: @unchecked Sendable {
                 VALUES (?, ?, ?, ?)
                 """, arguments: [fileId, heading.text, heading.level, heading.lineNumber])
         }
+    }
+
+    private func removeIndexedFile(db: Database, id: Int64) throws {
+        try db.execute(sql: "DELETE FROM files_fts WHERE rowid = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM chunks_fts WHERE file_id = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM embeddings WHERE file_id = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM links WHERE source_file_id = ?", arguments: [id])
+        try db.execute(sql: "UPDATE links SET target_file_id = NULL WHERE target_file_id = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM tags WHERE file_id = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM headings WHERE file_id = ?", arguments: [id])
+        try db.execute(sql: "DELETE FROM files WHERE id = ?", arguments: [id])
     }
 
     // MARK: Read — Files
@@ -1264,6 +1292,10 @@ public final class VaultIndex: @unchecked Sendable {
                 for target in stale {
                     if Task.isCancelled { return }
                     let fileURL = self.rootURL.appendingPathComponent(target.path)
+                    guard Limits.isOpenableSize(fileURL) else {
+                        DiagnosticLog.log("VaultIndex embed: skipping oversized file \(fileURL.lastPathComponent)")
+                        continue
+                    }
                     guard let data = try? Data(contentsOf: fileURL),
                           let content = String(data: data, encoding: .utf8) else { continue }
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -207,6 +207,9 @@ public final class VaultSession {
 
     public func readRawText(at url: URL) async throws -> String {
         try await Task.detached(priority: .userInitiated) { () throws -> String in
+            guard Limits.isOpenableSize(url) else {
+                throw CocoaError(.fileReadTooLarge)
+            }
             let data = try CoordinatedFileIO.read(at: url)
             return String(decoding: data, as: UTF8.self)
         }.value

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/LimitsTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/LimitsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import ClearlyCore
+
+final class LimitsTests: XCTestCase {
+
+    func testIsOpenableSizeMeasuresSymlinkTarget() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("limits-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let targetURL = rootURL.appendingPathComponent("target.md")
+        FileManager.default.createFile(atPath: targetURL.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: targetURL)
+        try handle.truncate(atOffset: UInt64(Limits.maxOpenableFileSize + 1))
+        try handle.close()
+
+        let linkURL = rootURL.appendingPathComponent("link.md")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        XCTAssertFalse(Limits.isOpenableSize(linkURL))
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/VaultIndexLimitsTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/VaultIndexLimitsTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import ClearlyCore
+
+final class VaultIndexLimitsTests: XCTestCase {
+
+    private var tempVault: URL!
+
+    override func setUpWithError() throws {
+        tempVault = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vault-index-limits-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempVault, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempVault)
+    }
+
+    func testUpdateFileRemovesPreviouslyIndexedFileWhenItGrowsPastLimit() throws {
+        let index = try VaultIndex(locationURL: tempVault)
+        let noteURL = try writeNote("big.md", body: "# Big\n\nneedle #tag")
+        index.indexAllFiles()
+        let indexed = try XCTUnwrap(index.file(forRelativePath: "big.md"))
+        try index.upsertChunkEmbeddings(
+            fileID: indexed.id,
+            contentHash: indexed.contentHash,
+            chunks: [VaultIndex.ChunkEmbeddingInput(
+                chunkIndex: 0,
+                textOffset: 0,
+                textLength: 6,
+                headingPath: [],
+                body: "needle",
+                vector: [1]
+            )],
+            modelVersion: 1
+        )
+
+        try makeOversized(noteURL)
+        let updated = try index.updateFile(at: "big.md")
+
+        XCTAssertNil(updated)
+        XCTAssertNil(index.file(forRelativePath: "big.md"))
+        XCTAssertEqual(index.searchFiles(query: "needle").count, 0)
+        XCTAssertEqual(index.searchByKeywords(["needle"], modelVersion: 1).count, 0)
+        XCTAssertEqual(index.allTags().count, 0)
+    }
+
+    func testIndexAllFilesRemovesPreviouslyIndexedFileWhenItGrowsPastLimit() throws {
+        let index = try VaultIndex(locationURL: tempVault)
+        let noteURL = try writeNote("big.md", body: "# Big\n\nneedle")
+        index.indexAllFiles()
+        XCTAssertNotNil(index.file(forRelativePath: "big.md"))
+
+        try makeOversized(noteURL)
+        index.indexAllFiles()
+
+        XCTAssertNil(index.file(forRelativePath: "big.md"))
+        XCTAssertEqual(index.searchFiles(query: "needle").count, 0)
+    }
+
+    private func writeNote(_ name: String, body: String) throws -> URL {
+        let url = tempVault.appendingPathComponent(name)
+        try body.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func makeOversized(_ url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: UInt64(Limits.maxOpenableFileSize + 1))
+        try handle.close()
+    }
+}


### PR DESCRIPTION
## Summary

A 1-star reviewer on v2.2.0 reported the app consumed 32+ GB of RAM. Root cause: no file-size cap anywhere — opening a fat file gets multiplied 5–10× through copies, regex passes, and HTML expansion. Every risk path was still live in v2.8.0 HEAD.

This PR adds a 50 MB hard cap on file open (alert on Mac, `errorMessage` on iOS), silently skips oversized files in vault indexing / file-watcher reload / backlink reads, hashes `PreviewView.contentKey` instead of interpolating the full markdown body each render, anchors three syntax-highlighter regex patterns to `[^\n]+?` (matching the rest of the file) and bails out of `highlightAll`/`highlightAround` over 5 MB, and 413's local images > 20 MB before they reach WebKit.

## Test plan

- [x] `xcodebuild` Mac, iOS, ClearlyCLI, ClearlyQuickLook all build clean (no new warnings)
- [x] 160 ClearlyCore tests pass, including new `LimitsTests` and `VaultIndexLimitsTests`
- [ ] Open a 60 MB markdown file via File → Open → expect "is too large" alert; app stays responsive
- [ ] Drop the same file into a vault folder; reindex → silently skipped, other files still index
- [ ] Open `Shared/Resources/demo.md` to confirm normal bold/italic/links still highlight correctly