### PR TITLE
[shared] Stop turning every pasted URL into a failed image download

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -150,6 +150,16 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
     private func handleIncomingPasteboard(
         _ pasteboard: NSPasteboard
     ) -> Bool {
+        if selectedRange().length > 0,
+           let raw = pasteboard.string(forType: .string)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty, !raw.contains("\n"), !raw.contains(" "),
+           let url = URL(string: raw),
+           let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            let selected = (string as NSString).substring(with: selectedRange())
+            insertText("[\(selected)](\(raw))", replacementRange: selectedRange())
+            return true
+        }
+
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
             .urlReadingFileURLsOnly: true
         ]) as? [URL], !urls.isEmpty {

--- a/Clearly/iOS/ClearlyUITextView.swift
+++ b/Clearly/iOS/ClearlyUITextView.swift
@@ -65,6 +65,19 @@ final class ClearlyUITextView: UITextView {
     override func paste(_ sender: Any?) {
         let pb = UIPasteboard.general
 
+        // 0. Text selected + URL on pasteboard → wrap selection as a
+        // markdown link instead of pasting/downloading.
+        if selectedRange.length > 0,
+           let raw = pb.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty, !raw.contains("\n"), !raw.contains(" "),
+           let url = URL(string: raw),
+           let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            let current = (text ?? "") as NSString
+            let selected = current.substring(with: selectedRange)
+            insertMarkdown("[\(selected)](\(raw))")
+            return
+        }
+
         // 1. Raw image on pasteboard — normalize HEIC/JPEG/etc. to PNG.
         if pb.hasImages, let image = pb.image, let png = image.pngData() {
             insertPastedPNG(png)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Editor/ImagePasteService.swift
@@ -18,13 +18,13 @@ public enum ImagePasteService {
     ]
 
     /// URL is worth attempting to download as an image when it's HTTP(S) and
-    /// either its path ends in a known image extension OR it has no
-    /// extension (common for CDN / signed URLs — MIME check decides later).
+    /// its path ends in a known image extension. Extension-less URLs aren't
+    /// treated as images — most modern links (articles, share URLs, CDN
+    /// endpoints without an explicit extension) would otherwise trigger a
+    /// download that fails and leaves a broken `![](failed-download)`.
     public static func isLikelyImageURL(_ url: URL) -> Bool {
         guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return false }
-        let ext = url.pathExtension.lowercased()
-        if ext.isEmpty { return true }
-        return imageFileExtensions.contains(ext)
+        return imageFileExtensions.contains(url.pathExtension.lowercased())
     }
 
     /// Derive a URL-safe slug from the document's filename stem. Lowercased,


### PR DESCRIPTION
## Summary

- `ImagePasteService.isLikelyImageURL` was returning `true` for any extension-less HTTP(S) URL, so pasting a normal link (an article, a dashboard, an X.com post) always tripped the auto-image-download path and replaced itself with `![](failed-download)` after a couple of seconds. Tightened the predicate to require a known image extension; non-image URLs now paste as plain text on both Mac and iOS.
- Added a selection-aware branch at the top of `paste(_:)` on Mac and iOS: when text is selected and the clipboard is an `http`/`https` URL, replace the selection with `[selected](url)` instead of pasting raw or kicking off a download.

Fixes #278

## Test plan

- [ ] Mac: paste `https://example.com/some/article` with no selection — appears as plain text, no placeholder, no `![](failed-download)`.
- [ ] Mac: paste a real image URL ending in `.png`/`.jpg` with no selection — still downloads and inserts `![](slug-N.png)`.
- [ ] Mac: select some text, paste any http(s) URL — wraps to `[selected](url)`.
- [ ] Mac: select text, paste plain non-URL text — replaces selection with the text (no wrap).
- [ ] iOS: repeat the no-selection plain-text-paste and selection-wrap cases on the simulator.