### PR TITLE
[ios] Long-press file menu: move, duplicate, share, inline rename

### DIFF
--- a/Clearly/iOS/FolderListView_iOS.swift
+++ b/Clearly/iOS/FolderListView_iOS.swift
@@ -23,9 +23,8 @@ struct FolderListView_iOS: View {
     @State private var pendingFolderParent: URL?
     @State private var operationError: String?
 
-    @State private var renameTarget: VaultFile?
-    @State private var renameDraft: String = ""
     @State private var deleteTarget: VaultFile?
+    @State private var moveTarget: VaultFile?
 
     var body: some View {
         @Bindable var session = session
@@ -78,14 +77,11 @@ struct FolderListView_iOS: View {
         } message: {
             Text("Name this folder. It will be created in \(newFolderLocationDescription).")
         }
-        .alert("Rename note", isPresented: renameAlertBinding) {
-            TextField("Name", text: $renameDraft)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-            Button("Cancel", role: .cancel) { renameTarget = nil }
-            Button("Save") { commitRename() }
-        } message: {
-            Text("Enter a new name (extension preserved).")
+        .sheet(item: $moveTarget) { file in
+            FolderPickerSheet_iOS(movingFile: file) { destination in
+                performMove(file, to: destination)
+            }
+            .environment(session)
         }
         .confirmationDialog(
             deleteTarget.map { "Delete \u{201C}\($0.name)\u{201D}?" } ?? "",
@@ -139,8 +135,10 @@ struct FolderListView_iOS: View {
                                 navPath.append(file)
                                 session.markRecent(file)
                             },
-                            onRenameFile: { file in beginRename(file) },
+                            onRenameFile: { file, newName in performRename(file, to: newName) },
                             onDeleteFile: { file in deleteTarget = file },
+                            onMoveFile: { file in moveTarget = file },
+                            onDuplicateFile: { file in performDuplicate(file) },
                             onCreateFile: { folder in createFile(in: folder) },
                             onCreateFolder: { folder in beginCreateFolder(in: folder) }
                         )
@@ -292,14 +290,7 @@ struct FolderListView_iOS: View {
         return session.currentVault?.displayName ?? "the vault"
     }
 
-    // MARK: - Rename / delete
-
-    private var renameAlertBinding: Binding<Bool> {
-        Binding(
-            get: { renameTarget != nil },
-            set: { if !$0 { renameTarget = nil } }
-        )
-    }
+    // MARK: - Rename / move / duplicate / delete
 
     private var deleteConfirmBinding: Binding<Bool> {
         Binding(
@@ -308,18 +299,34 @@ struct FolderListView_iOS: View {
         )
     }
 
-    private func beginRename(_ file: VaultFile) {
-        renameDraft = (file.name as NSString).deletingPathExtension
-        renameTarget = file
-    }
-
-    private func commitRename() {
-        guard let target = renameTarget else { return }
-        let draft = renameDraft
-        renameTarget = nil
+    private func performRename(_ file: VaultFile, to newName: String) {
         Task {
             do {
-                try await session.renameFile(target, to: draft)
+                try await session.renameFile(file, to: newName)
+            } catch VaultSessionError.readFailed(let msg) {
+                operationError = msg
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performMove(_ file: VaultFile, to destination: URL) {
+        Task {
+            do {
+                try await session.moveFile(file, to: destination)
+            } catch VaultSessionError.readFailed(let msg) {
+                operationError = msg
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performDuplicate(_ file: VaultFile) {
+        Task {
+            do {
+                _ = try await session.duplicateFile(file)
             } catch VaultSessionError.readFailed(let msg) {
                 operationError = msg
             } catch {

--- a/Clearly/iOS/FolderPickerSheet_iOS.swift
+++ b/Clearly/iOS/FolderPickerSheet_iOS.swift
@@ -1,0 +1,124 @@
+#if os(iOS)
+import SwiftUI
+import ClearlyCore
+
+/// Vault-only folder tree picker presented as a sheet for the "Move…" action
+/// in the file context menu. Mirrors the main sidebar's `OutlineGroup` pattern
+/// with a folder-only filter, plus the vault root as a top-level destination.
+struct FolderPickerSheet_iOS: View {
+    let movingFile: VaultFile
+    let onSelect: (URL) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(VaultSession.self) private var session
+    @State private var folderTree: [FileNode] = []
+    @State private var selection: URL?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let rootURL = session.currentVault?.url {
+                    rootRow(url: rootURL)
+                }
+                OutlineGroup(folderTree, children: \.displayChildren) { node in
+                    folderRow(node)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Move \u{201C}\(displayTitle)\u{201D}")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Move") {
+                        if let dest = selection {
+                            onSelect(dest)
+                            dismiss()
+                        }
+                    }
+                    .disabled(!isMoveEnabled)
+                }
+            }
+            .onAppear { rebuild() }
+            .onChange(of: session.files) { _, _ in rebuild() }
+        }
+    }
+
+    private var displayTitle: String {
+        (movingFile.name as NSString).deletingPathExtension
+    }
+
+    private var currentParent: URL? {
+        movingFile.url.deletingLastPathComponent().standardizedFileURL
+    }
+
+    private var isMoveEnabled: Bool {
+        guard let dest = selection?.standardizedFileURL else { return false }
+        return dest != currentParent
+    }
+
+    private func rootRow(url: URL) -> some View {
+        let label = session.currentVault?.displayName ?? "Vault"
+        return pickerRow(
+            url: url,
+            label: Label(label, systemImage: "tray.full")
+        )
+    }
+
+    private func folderRow(_ node: FileNode) -> some View {
+        pickerRow(
+            url: node.url,
+            label: Label(node.name, systemImage: "folder")
+        )
+    }
+
+    private func pickerRow<L: View>(url: URL, label: L) -> some View {
+        let standardized = url.standardizedFileURL
+        let isSelected = selection?.standardizedFileURL == standardized
+        let isCurrentParent = currentParent == standardized
+        return HStack {
+            label
+                .foregroundStyle(isCurrentParent ? .secondary : .primary)
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(.tint)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // Tapping the file's current folder is a no-op — picking it would
+            // leave the Move button disabled and dangle a checkmark next to a
+            // dead button.
+            guard !isCurrentParent else { return }
+            selection = url
+        }
+    }
+
+    private func rebuild() {
+        guard let rootURL = session.currentVault?.url else {
+            folderTree = []
+            return
+        }
+        let files = session.files
+        Task.detached(priority: .userInitiated) {
+            let raw = FileNode.buildTree(at: rootURL, including: files)
+            let folders = raw.compactMap { Self.keepFolders($0) }
+            await MainActor.run { folderTree = folders }
+        }
+    }
+
+    private static func keepFolders(_ node: FileNode) -> FileNode? {
+        guard node.isDirectory else { return nil }
+        let filteredChildren = (node.children ?? []).compactMap { keepFolders($0) }
+        return FileNode(
+            name: node.name,
+            url: node.url,
+            isHidden: node.isHidden,
+            children: filteredChildren
+        )
+    }
+}
+#endif

--- a/Clearly/iOS/IPadRootView.swift
+++ b/Clearly/iOS/IPadRootView.swift
@@ -22,9 +22,8 @@ struct IPadRootView: View {
 
     @State private var folderTree: [FileNode] = []
 
-    @State private var renameTarget: VaultFile?
-    @State private var renameDraft: String = ""
     @State private var deleteTarget: VaultFile?
+    @State private var moveTarget: VaultFile?
     @State private var operationError: String?
 
     @State private var isCreatingFolder: Bool = false
@@ -71,14 +70,11 @@ struct IPadRootView: View {
             QuickSwitcherShortcuts()
             IPadKeyboardShortcuts(onNewNote: createNewNote)
         }
-        .alert("Rename note", isPresented: renameAlertBinding) {
-            TextField("Name", text: $renameDraft)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-            Button("Cancel", role: .cancel) { renameTarget = nil }
-            Button("Save") { commitRename() }
-        } message: {
-            Text("Enter a new name (extension preserved).")
+        .sheet(item: $moveTarget) { file in
+            FolderPickerSheet_iOS(movingFile: file) { destination in
+                performMove(file, to: destination)
+            }
+            .environment(session)
         }
         .confirmationDialog(
             deleteTarget.map { "Delete \u{201C}\($0.name)\u{201D}?" } ?? "",
@@ -160,8 +156,10 @@ struct IPadRootView: View {
                 SidebarOutline_iOS(
                     nodes: folderTree,
                     onSelectFile: { file in openFile(file) },
-                    onRenameFile: { file in beginRename(file) },
+                    onRenameFile: { file, newName in performRename(file, to: newName) },
                     onDeleteFile: { file in deleteTarget = file },
+                    onMoveFile: { file in moveTarget = file },
+                    onDuplicateFile: { file in performDuplicate(file) },
                     onCreateFile: { folder in createFile(in: folder) },
                     onCreateFolder: { folder in beginCreateFolder(in: folder) }
                 )
@@ -242,16 +240,7 @@ struct IPadRootView: View {
         }
     }
 
-    // MARK: - Rename / delete
-
-    private var renameAlertBinding: Binding<Bool> {
-        Binding(
-            get: { renameTarget != nil },
-            set: { newValue in
-                if !newValue { renameTarget = nil }
-            }
-        )
-    }
+    // MARK: - Rename / move / duplicate / delete
 
     private var deleteConfirmBinding: Binding<Bool> {
         Binding(
@@ -262,18 +251,34 @@ struct IPadRootView: View {
         )
     }
 
-    private func beginRename(_ file: VaultFile) {
-        renameDraft = (file.name as NSString).deletingPathExtension
-        renameTarget = file
-    }
-
-    private func commitRename() {
-        guard let target = renameTarget else { return }
-        let draft = renameDraft
-        renameTarget = nil
+    private func performRename(_ file: VaultFile, to newName: String) {
         Task {
             do {
-                try await session.renameFile(target, to: draft)
+                try await session.renameFile(file, to: newName)
+            } catch VaultSessionError.readFailed(let msg) {
+                operationError = msg
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performMove(_ file: VaultFile, to destination: URL) {
+        Task {
+            do {
+                try await session.moveFile(file, to: destination)
+            } catch VaultSessionError.readFailed(let msg) {
+                operationError = msg
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performDuplicate(_ file: VaultFile) {
+        Task {
+            do {
+                _ = try await session.duplicateFile(file)
             } catch VaultSessionError.readFailed(let msg) {
                 operationError = msg
             } catch {

--- a/Clearly/iOS/SidebarOutline_iOS.swift
+++ b/Clearly/iOS/SidebarOutline_iOS.swift
@@ -8,19 +8,28 @@ import ClearlyCore
 /// expansion state, files render as tappable leaf rows. Empty folders render
 /// as leaves so the disclosure indicator hides.
 ///
-/// Actions (open, rename, delete, create) are pushed back to the host view
-/// via callbacks so each platform can drive its own alert/confirmation chrome
-/// without the outline owning that state.
+/// File actions (open, rename, delete, move, duplicate) are pushed back to the
+/// host view via callbacks so each platform can drive its own sheet/dialog
+/// chrome without the outline owning that state. Rename is the exception —
+/// it edits inline within the row, so the outline owns just enough local
+/// state to swap a `Label` for a `TextField` and report the new name on
+/// commit.
 struct SidebarOutline_iOS: View {
     let nodes: [FileNode]
     let onSelectFile: (VaultFile) -> Void
-    let onRenameFile: (VaultFile) -> Void
+    let onRenameFile: (VaultFile, String) -> Void
     let onDeleteFile: (VaultFile) -> Void
+    let onMoveFile: (VaultFile) -> Void
+    let onDuplicateFile: (VaultFile) -> Void
     let onCreateFile: (URL) -> Void
     let onCreateFolder: (URL) -> Void
 
     @Environment(VaultSession.self) private var session
     @Environment(IOSExpansionState.self) private var expansion
+
+    @State private var renamingURL: URL?
+    @State private var renameDraft: String = ""
+    @FocusState private var renameFieldFocused: Bool
 
     var body: some View {
         ForEach(nodes) { node in
@@ -61,20 +70,29 @@ struct SidebarOutline_iOS: View {
         Label(node.name, systemImage: "folder")
     }
 
+    @ViewBuilder
     private func fileRow(_ node: FileNode) -> some View {
         let resolved = vaultFile(for: node)
+        if renamingURL == node.url {
+            renameRow(for: resolved)
+        } else {
+            displayRow(for: resolved, node: node)
+        }
+    }
+
+    private func displayRow(for file: VaultFile, node: FileNode) -> some View {
         let title = node.url.deletingPathExtension().lastPathComponent
         return Label(title, systemImage: "doc.text")
             .contentShape(Rectangle())
-            .onTapGesture { onSelectFile(resolved) }
+            .onTapGesture { onSelectFile(file) }
             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                 Button(role: .destructive) {
-                    onDeleteFile(resolved)
+                    onDeleteFile(file)
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
                 Button {
-                    onRenameFile(resolved)
+                    beginInlineRename(file)
                 } label: {
                     Label("Rename", systemImage: "pencil")
                 }
@@ -82,16 +100,49 @@ struct SidebarOutline_iOS: View {
             }
             .contextMenu {
                 Button {
-                    onRenameFile(resolved)
+                    beginInlineRename(file)
                 } label: {
                     Label("Rename", systemImage: "pencil")
                 }
+                Button {
+                    onMoveFile(file)
+                } label: {
+                    Label("Move\u{2026}", systemImage: "folder")
+                }
+                Button {
+                    onDuplicateFile(file)
+                } label: {
+                    Label("Duplicate", systemImage: "plus.square.on.square")
+                }
+                ShareLink(item: file.url)
+                Divider()
                 Button(role: .destructive) {
-                    onDeleteFile(resolved)
+                    onDeleteFile(file)
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
             }
+    }
+
+    private func renameRow(for file: VaultFile) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "doc.text")
+                .foregroundStyle(.secondary)
+            TextField("Name", text: $renameDraft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.done)
+                .focused($renameFieldFocused)
+                .onSubmit { commitInlineRename(file) }
+        }
+        .onChange(of: renameFieldFocused) { _, isFocused in
+            // Commit on focus loss (tap outside, swipe away). Guard against
+            // late callbacks after the row already committed and cleared
+            // `renamingURL`.
+            if !isFocused, renamingURL == file.url {
+                commitInlineRename(file)
+            }
+        }
     }
 
     @ViewBuilder
@@ -106,6 +157,29 @@ struct SidebarOutline_iOS: View {
         } label: {
             Label("New Folder", systemImage: "folder.badge.plus")
         }
+    }
+
+    // MARK: - Inline rename
+
+    private func beginInlineRename(_ file: VaultFile) {
+        renameDraft = (file.name as NSString).deletingPathExtension
+        renamingURL = file.url
+        // Defer focus so the TextField has been laid out before the keyboard
+        // raises — without the dispatch the focus often loses to the row's
+        // tap gesture in compact layouts.
+        DispatchQueue.main.async {
+            renameFieldFocused = true
+        }
+    }
+
+    private func commitInlineRename(_ file: VaultFile) {
+        let draft = renameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let original = (file.name as NSString).deletingPathExtension
+        renamingURL = nil
+        renameFieldFocused = false
+        renameDraft = ""
+        guard !draft.isEmpty, draft != original else { return }
+        onRenameFile(file, draft)
     }
 
     // MARK: - VaultFile lookup

--- a/Packages/ClearlyCore/Package.resolved
+++ b/Packages/ClearlyCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ff996990ec418e4ab8228f523af387cbb363a80bd86a3a27e3e912bc1f3e7751",
+  "originHash" : "f23aa48d481c2b683674c77aa860e7b54ea59ff55c2c76b6dc4e3bdf2fbfef41",
   "pins" : [
     {
       "identity" : "cmark-gfm",

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Sync/CoordinatedFileIO.swift
@@ -50,6 +50,21 @@ public enum CoordinatedFileIO {
         if let moveError { throw moveError }
     }
 
+    public static func copy(from src: URL, to dst: URL) throws {
+        var coordinatorError: NSError?
+        var copyError: Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(
+            readingItemAt: src, options: .withoutChanges,
+            writingItemAt: dst, options: .forReplacing,
+            error: &coordinatorError
+        ) { resolvedSrc, resolvedDst in
+            do { try FileManager.default.copyItem(at: resolvedSrc, to: resolvedDst) }
+            catch { copyError = error }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let copyError { throw copyError }
+    }
+
     public static func delete(at url: URL) throws {
         var coordinatorError: NSError?
         var deleteError: Error?

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -554,6 +554,53 @@ public final class VaultSession {
         refresh()
     }
 
+    /// Move a file into a different folder, preserving its filename. No-ops when
+    /// the destination folder is already the file's parent. Throws if a file with
+    /// the same name already exists at the destination.
+    public func moveFile(_ file: VaultFile, to destinationFolder: URL) async throws {
+        let currentParent = file.url.deletingLastPathComponent().standardizedFileURL
+        let target = destinationFolder.standardizedFileURL
+        if currentParent == target { return }
+        let destURL = destinationFolder.appendingPathComponent(file.url.lastPathComponent)
+        if FileManager.default.fileExists(atPath: destURL.path) {
+            throw VaultSessionError.readFailed("a file with that name already exists in the destination folder")
+        }
+        let src = file.url
+        try await Task.detached(priority: .userInitiated) {
+            try CoordinatedFileIO.move(from: src, to: destURL)
+        }.value
+        dropFromNavigationPath(file.url)
+        dropFromRecents(file.url)
+        refresh()
+    }
+
+    /// Duplicate a file in the same folder using Finder's "<stem> 2", "<stem> 3"
+    /// naming convention. Probes incrementing names until a free slot is found
+    /// (capped at 1000 to avoid runaway loops).
+    @discardableResult
+    public func duplicateFile(_ file: VaultFile) async throws -> VaultFile {
+        let parent = file.url.deletingLastPathComponent()
+        let stem = (file.url.lastPathComponent as NSString).deletingPathExtension
+        let ext = file.url.pathExtension.isEmpty ? "md" : file.url.pathExtension
+        var candidate: URL?
+        for n in 2...1000 {
+            let url = parent.appendingPathComponent("\(stem) \(n).\(ext)")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                candidate = url
+                break
+            }
+        }
+        guard let destURL = candidate else {
+            throw VaultSessionError.readFailed("could not find an unused duplicate name")
+        }
+        let src = file.url
+        try await Task.detached(priority: .userInitiated) {
+            try CoordinatedFileIO.copy(from: src, to: destURL)
+        }.value
+        refresh()
+        return VaultFile(url: destURL, name: destURL.lastPathComponent, modified: Date(), isPlaceholder: false)
+    }
+
     /// Delete a file from the vault. Prunes from `navigationPath` and recents.
     public func deleteFile(_ file: VaultFile) async throws {
         let url = file.url


### PR DESCRIPTION
## Summary

Adds a Files.app-style context menu to file rows in the iOS sidebar: **Rename / Move… / Duplicate / Share / Delete**. Rename edits inline within the row (replacing the previous alert), Move opens a vault-only folder picker sheet, Duplicate uses Finder's `<stem> 2.md` naming, and Share uses `ShareLink`. Backed by new `CoordinatedFileIO.copy` and `VaultSession.moveFile` / `duplicateFile` helpers; existing delete confirmation and minimal swipe actions are preserved.

Fixes #247

## Test plan

- [ ] Long-press a file → menu shows Rename / Move… / Duplicate / Share / Delete (Delete in red, divider above it)
- [ ] Inline rename: Return commits, tap-outside commits, blank/unchanged is a no-op
- [ ] Move: vault root + folders shown; current parent dimmed and unselectable; Move disabled until a different folder is picked
- [ ] Duplicate: produces `Foo 2.md`, then `Foo 3.md`
- [ ] Share opens iOS share sheet
- [ ] Delete confirmation dialog still appears
- [ ] Swipe still shows only Rename + Delete
- [ ] Renaming/moving a file currently open in the editor doesn't drop the editor (presenter handles `presentedItemDidMove`)