### PR TITLE
[mac] Detect nvm-installed Claude/Codex and exec them via PATH-aware env

### DIFF
--- a/Clearly/Wiki/AgentDiscovery.swift
+++ b/Clearly/Wiki/AgentDiscovery.swift
@@ -45,22 +45,66 @@ enum AgentDiscovery {
 
     private static var claudeCandidatePaths: [String] {
         let home = realUserHome() ?? NSHomeDirectory()
-        return [
+        var paths = [
             "\(home)/.local/bin/claude",
             "\(home)/Library/Application Support/com.anthropic.claude/bin/claude",
             "/usr/local/bin/claude",
             "/opt/homebrew/bin/claude",
         ]
+        if let nvmPath = nvmBinaryPath(for: "claude", home: home) {
+            paths.append(nvmPath)
+        }
+        return paths
     }
 
     private static var codexCandidatePaths: [String] {
         let home = realUserHome() ?? NSHomeDirectory()
-        return [
+        var paths = [
             "\(home)/.codex/bin/codex",
             "\(home)/.local/bin/codex",
             "/usr/local/bin/codex",
             "/opt/homebrew/bin/codex",
         ]
+        if let nvmPath = nvmBinaryPath(for: "codex", home: home) {
+            paths.append(nvmPath)
+        }
+        return paths
+    }
+
+    /// Returns `<home>/.nvm/versions/node/<newest>/bin/<binary>` if it exists
+    /// and is executable. Walks installed node versions newest-first by parsed
+    /// semver (`vMAJOR.MINOR.PATCH`); falls through to older versions when the
+    /// newest doesn't have the binary installed (e.g. user just bumped node
+    /// but hasn't re-run `npm i -g`). Names that don't parse as semver are
+    /// skipped.
+    private static func nvmBinaryPath(for binary: String, home: String) -> String? {
+        let versionsDir = "\(home)/.nvm/versions/node"
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: versionsDir) else { return nil }
+        let sorted = entries
+            .compactMap { name -> (name: String, version: (Int, Int, Int))? in
+                guard let v = parseSemver(name) else { return nil }
+                return (name, v)
+            }
+            .sorted { $0.version > $1.version }
+        for entry in sorted {
+            let path = "\(versionsDir)/\(entry.name)/bin/\(binary)"
+            if fm.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    private static func parseSemver(_ name: String) -> (Int, Int, Int)? {
+        guard name.hasPrefix("v") else { return nil }
+        let parts = name.dropFirst().split(separator: ".")
+        guard parts.count == 3,
+              let major = Int(parts[0]),
+              let minor = Int(parts[1]),
+              let patch = Int(parts[2])
+        else { return nil }
+        return (major, minor, patch)
     }
 
     /// Resolve the user's REAL home directory, bypassing the sandbox redirect.

--- a/Clearly/Wiki/ClaudeCLIAgentRunner.swift
+++ b/Clearly/Wiki/ClaudeCLIAgentRunner.swift
@@ -98,7 +98,8 @@ struct ClaudeCLIAgentRunner: AgentRunner {
             // hand it the real user home so subscription auth works.
             let resolvedEnv = Self.environmentForSubprocess(
                 base: environment,
-                currentDirectory: process.currentDirectoryURL
+                currentDirectory: process.currentDirectoryURL,
+                binaryURL: binaryURL
             )
             process.environment = resolvedEnv
 
@@ -147,7 +148,8 @@ struct ClaudeCLIAgentRunner: AgentRunner {
     /// state inside Clearly's container or inherit Claude's own SDK mode flags.
     static func environmentForSubprocess(
         base: [String: String],
-        currentDirectory: URL? = nil
+        currentDirectory: URL? = nil,
+        binaryURL: URL? = nil
     ) -> [String: String] {
         var env = base
         for key in [
@@ -169,6 +171,18 @@ struct ClaudeCLIAgentRunner: AgentRunner {
         env["LOGNAME"] = user
         if let currentDirectory {
             env["PWD"] = currentDirectory.path
+        }
+        // npm-installed CLIs (Codex, Claude pre-Bun) ship as `#!/usr/bin/env node`
+        // scripts. Apps launched from the Dock inherit a minimal PATH
+        // (`/usr/bin:/bin:/usr/sbin:/sbin`) which doesn't include the node
+        // alongside the CLI in the same bin dir — so `env` fails to find
+        // `node`. Prepend the binary's parent dir so the shebang resolves.
+        if let binaryURL {
+            let binDir = binaryURL.deletingLastPathComponent().path
+            let existing = env["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+            if !existing.split(separator: ":").contains(Substring(binDir)) {
+                env["PATH"] = "\(binDir):\(existing)"
+            }
         }
         return env
     }

--- a/Clearly/Wiki/CodexCLIAgentRunner.swift
+++ b/Clearly/Wiki/CodexCLIAgentRunner.swift
@@ -98,7 +98,8 @@ struct CodexCLIAgentRunner: AgentRunner {
             // env can point CLI auth lookups at the wrong home.
             process.environment = ClaudeCLIAgentRunner.environmentForSubprocess(
                 base: environment,
-                currentDirectory: process.currentDirectoryURL
+                currentDirectory: process.currentDirectoryURL,
+                binaryURL: binaryURL
             )
 
             let stdin = Pipe()


### PR DESCRIPTION
## Summary
- Settings → Wiki → Detection reported "Not detected" for npm-installed Codex CLI under nvm; `AgentDiscovery` now walks `~/.nvm/versions/node/*/bin/<cli>` newest-semver-first as a final fallback for both Claude and Codex.
- `environmentForSubprocess` now prepends the resolved binary's parent dir to `PATH` so `#!/usr/bin/env node` shebangs resolve under the Dock-launched app's minimal inherited PATH — otherwise detection would have green-checked but exec would fail with `env: node: No such file or directory`.
- Sandbox already covers `~/.nvm/` reads via the existing `home-relative-path.read-only = ["/"]` exception; no entitlement, `project.yml`, or UI changes.

## Test plan
- [x] Build & run Debug: Settings → Wiki → Detection shows Codex green at `/Users/joshpigford/.nvm/versions/node/v24.6.0/bin/codex`; Claude still resolves to `~/.local/bin/claude`.
- [x] Confirmed `env -i PATH=…/v24.6.0/bin:/usr/bin:/bin… codex --version` returns `codex-cli 0.120.0` (was `env: node: No such file or directory` without the PATH prepend).
- [ ] Trigger a Wiki agent action with Runner=Codex and confirm the subprocess actually runs end-to-end (not just exec'd).