### PR TITLE
[mac] Add ⌘⇧T shortcut for Format → Todo + line-prefix consistency

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -911,6 +911,7 @@ struct ClearlyApp: App {
                 Button("Todo") {
                     performFormattingCommand(.todoList, selector: #selector(ClearlyTextView.toggleTodoList(_:)))
                 }
+                .keyboardShortcut("t", modifiers: [.command, .shift])
 
                 Divider()
 

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -394,15 +394,31 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     @objc func toggleNumberedList(_ sender: Any?) {
         let range = selectedRange()
-        let selected = (string as NSString).substring(with: range)
+        let nsString = string as NSString
+        let selected = nsString.substring(with: range)
         if selected.isEmpty {
-            insertText("1. list item", replacementRange: range)
-            let start = range.location + "1. ".utf16.count
-            setSelectedRange(NSRange(location: start, length: "list item".utf16.count))
+            let lineRange = nsString.lineRange(for: range)
+            let line = nsString.substring(with: lineRange)
+            let hasTrailingNewline = line.hasSuffix("\n")
+            let lineBody = hasTrailingNewline ? String(line.dropLast()) : line
+
+            if lineBody.isEmpty {
+                insertText("1. list item", replacementRange: range)
+                let start = range.location + "1. ".utf16.count
+                setSelectedRange(NSRange(location: start, length: "list item".utf16.count))
+                return
+            }
+
+            if lineBody.range(of: #"^\d+\. "#, options: .regularExpression) != nil { return }
+
+            let cursorOffset = min(range.location - lineRange.location, lineBody.utf16.count)
+            let newLine = "1. \(lineBody)" + (hasTrailingNewline ? "\n" : "")
+            insertText(newLine, replacementRange: lineRange)
+            setSelectedRange(NSRange(location: lineRange.location + "1. ".utf16.count + cursorOffset, length: 0))
             return
         }
-        let lineRange = (string as NSString).lineRange(for: range)
-        let block = (string as NSString).substring(with: lineRange)
+        let lineRange = nsString.lineRange(for: range)
+        let block = nsString.substring(with: lineRange)
         let lines = block.components(separatedBy: "\n")
         var result: [String] = []
         var num = 1
@@ -528,18 +544,38 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
 
     private func toggleLinePrefix(prefix: String, placeholder: String) {
         let range = selectedRange()
-        let selected = (string as NSString).substring(with: range)
+        let nsString = string as NSString
+        let selected = nsString.substring(with: range)
         if selected.isEmpty {
-            let text = "\(prefix)\(placeholder)"
-            insertText(text, replacementRange: range)
-            let start = range.location + prefix.utf16.count
-            setSelectedRange(NSRange(location: start, length: placeholder.utf16.count))
+            let lineRange = nsString.lineRange(for: range)
+            let line = nsString.substring(with: lineRange)
+            let hasTrailingNewline = line.hasSuffix("\n")
+            let lineBody = hasTrailingNewline ? String(line.dropLast()) : line
+
+            if lineBody.isEmpty {
+                let text = "\(prefix)\(placeholder)"
+                insertText(text, replacementRange: range)
+                let start = range.location + prefix.utf16.count
+                setSelectedRange(NSRange(location: start, length: placeholder.utf16.count))
+                return
+            }
+
+            if lineBody.hasPrefix(prefix) { return }
+
+            let cursorOffset = min(range.location - lineRange.location, lineBody.utf16.count)
+            let newLine = "\(prefix)\(lineBody)" + (hasTrailingNewline ? "\n" : "")
+            insertText(newLine, replacementRange: lineRange)
+            setSelectedRange(NSRange(location: lineRange.location + prefix.utf16.count + cursorOffset, length: 0))
             return
         }
-        let lineRange = (string as NSString).lineRange(for: range)
-        let block = (string as NSString).substring(with: lineRange)
+        let lineRange = nsString.lineRange(for: range)
+        let block = nsString.substring(with: lineRange)
         let lines = block.components(separatedBy: "\n")
-        let result = lines.map { $0.isEmpty ? $0 : "\(prefix)\($0)" }
+        let result = lines.map { line -> String in
+            if line.isEmpty { return line }
+            if line.hasPrefix(prefix) { return line }
+            return "\(prefix)\(line)"
+        }
         insertText(result.joined(separator: "\n"), replacementRange: lineRange)
     }
 

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -819,16 +819,30 @@ function toggleLinePrefix(view: EditorView, prefix: string, placeholder: string)
   const selection = view.state.selection.main;
   const selected = view.state.sliceDoc(selection.from, selection.to);
   if (!selected) {
+    const line = view.state.doc.lineAt(selection.from);
+    if (!line.text) {
+      view.dispatch({
+        changes: {
+          from: selection.from,
+          to: selection.to,
+          insert: `${prefix}${placeholder}`
+        },
+        selection: {
+          anchor: selection.from + prefix.length,
+          head: selection.from + prefix.length + placeholder.length
+        }
+      });
+      view.focus();
+      return;
+    }
+    if (line.text.startsWith(prefix)) {
+      view.focus();
+      return;
+    }
+    const cursorOffset = selection.from - line.from;
     view.dispatch({
-      changes: {
-        from: selection.from,
-        to: selection.to,
-        insert: `${prefix}${placeholder}`
-      },
-      selection: {
-        anchor: selection.from + prefix.length,
-        head: selection.from + prefix.length + placeholder.length
-      }
+      changes: { from: line.from, to: line.to, insert: `${prefix}${line.text}` },
+      selection: { anchor: line.from + prefix.length + cursorOffset }
     });
     view.focus();
     return;
@@ -836,7 +850,13 @@ function toggleLinePrefix(view: EditorView, prefix: string, placeholder: string)
 
   const range = selectedLineRange(view);
   const lines = view.state.sliceDoc(range.from, range.to).split("\n");
-  const result = lines.map((line) => (line ? `${prefix}${line}` : line)).join("\n");
+  const result = lines
+    .map((line) => {
+      if (!line) return line;
+      if (line.startsWith(prefix)) return line;
+      return `${prefix}${line}`;
+    })
+    .join("\n");
   view.dispatch({
     changes: { from: range.from, to: range.to, insert: result }
   });
@@ -847,10 +867,24 @@ function toggleNumberedList(view: EditorView) {
   const selection = view.state.selection.main;
   const selected = view.state.sliceDoc(selection.from, selection.to);
   if (!selected) {
-    const text = "1. list item";
+    const line = view.state.doc.lineAt(selection.from);
+    if (!line.text) {
+      const text = "1. list item";
+      view.dispatch({
+        changes: { from: selection.from, to: selection.to, insert: text },
+        selection: { anchor: selection.from + 3, head: selection.from + text.length }
+      });
+      view.focus();
+      return;
+    }
+    if (/^\d+\. /.test(line.text)) {
+      view.focus();
+      return;
+    }
+    const cursorOffset = selection.from - line.from;
     view.dispatch({
-      changes: { from: selection.from, to: selection.to, insert: text },
-      selection: { anchor: selection.from + 3, head: selection.from + text.length }
+      changes: { from: line.from, to: line.to, insert: `1. ${line.text}` },
+      selection: { anchor: line.from + 3 + cursorOffset }
     });
     view.focus();
     return;

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -31941,23 +31941,41 @@
     const selection = view.state.selection.main;
     const selected = view.state.sliceDoc(selection.from, selection.to);
     if (!selected) {
+      const line = view.state.doc.lineAt(selection.from);
+      if (!line.text) {
+        view.dispatch({
+          changes: {
+            from: selection.from,
+            to: selection.to,
+            insert: `${prefix}${placeholder}`
+          },
+          selection: {
+            anchor: selection.from + prefix.length,
+            head: selection.from + prefix.length + placeholder.length
+          }
+        });
+        view.focus();
+        return;
+      }
+      if (line.text.startsWith(prefix)) {
+        view.focus();
+        return;
+      }
+      const cursorOffset = selection.from - line.from;
       view.dispatch({
-        changes: {
-          from: selection.from,
-          to: selection.to,
-          insert: `${prefix}${placeholder}`
-        },
-        selection: {
-          anchor: selection.from + prefix.length,
-          head: selection.from + prefix.length + placeholder.length
-        }
+        changes: { from: line.from, to: line.to, insert: `${prefix}${line.text}` },
+        selection: { anchor: line.from + prefix.length + cursorOffset }
       });
       view.focus();
       return;
     }
     const range = selectedLineRange(view);
     const lines = view.state.sliceDoc(range.from, range.to).split("\n");
-    const result = lines.map((line) => line ? `${prefix}${line}` : line).join("\n");
+    const result = lines.map((line) => {
+      if (!line) return line;
+      if (line.startsWith(prefix)) return line;
+      return `${prefix}${line}`;
+    }).join("\n");
     view.dispatch({
       changes: { from: range.from, to: range.to, insert: result }
     });
@@ -31967,10 +31985,24 @@
     const selection = view.state.selection.main;
     const selected = view.state.sliceDoc(selection.from, selection.to);
     if (!selected) {
-      const text2 = "1. list item";
+      const line = view.state.doc.lineAt(selection.from);
+      if (!line.text) {
+        const text2 = "1. list item";
+        view.dispatch({
+          changes: { from: selection.from, to: selection.to, insert: text2 },
+          selection: { anchor: selection.from + 3, head: selection.from + text2.length }
+        });
+        view.focus();
+        return;
+      }
+      if (/^\d+\. /.test(line.text)) {
+        view.focus();
+        return;
+      }
+      const cursorOffset = selection.from - line.from;
       view.dispatch({
-        changes: { from: selection.from, to: selection.to, insert: text2 },
-        selection: { anchor: selection.from + 3, head: selection.from + text2.length }
+        changes: { from: line.from, to: line.to, insert: `1. ${line.text}` },
+        selection: { anchor: line.from + 3 + cursorOffset }
       });
       view.focus();
       return;


### PR DESCRIPTION
## Summary

- Binds **⌘⇧T** to Format → Todo (`⌘T` and `⌘⌃T` are taken; `⌘⇧T` was free).
- Format line-prefix items (Todo, Bullet List, Quote, Numbered List) now turn the **current line** into the marked-up form when triggered with no selection — previously they injected `prefix + placeholder` mid-line.
- Same items are now idempotent: re-triggering on a line that already has the marker is a no-op (no more `- [ ] - [ ] - [ ] ...` stacking).
- Caret offset within the line is preserved across the prefix insertion.
- Same fixes applied to the Live Preview (Experimental) editor (`ClearlyLiveEditorWeb`) so behavior matches across both engines; bundle regenerated.

## Test plan

- [ ] Format menu shows ⌘⇧T next to "Todo".
- [ ] Caret on a non-empty line + ⌘⇧T → line becomes `- [ ] <text>`, caret stays at relative offset.
- [ ] Caret on a blank line + ⌘⇧T → inserts `- [ ] task` with `task` selected.
- [ ] Spamming ⌘⇧T on the same line produces exactly one `- [ ] `.
- [ ] Bullet List, Numbered List, Quote behave the same way (idempotent, line-aware).
- [ ] Switch to Settings → Editor → Live Preview (Experimental) and repeat the checks above.