### PR TITLE
[mac] Fix crash when removing vault folder from sidebar (#288)

### DIFF
--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -203,7 +203,7 @@ struct MacFolderSidebar: View {
                 }
                 Divider()
                 Button("Remove from List", systemImage: "minus.circle", role: .destructive) {
-                    workspace.removeLocationClosingOpenDocuments(location)
+                    removeLocation(location)
                 }
             }
             .dropDestination(for: URL.self) { urls, _ in
@@ -403,6 +403,34 @@ struct MacFolderSidebar: View {
 
     private func createNewFile(in folder: URL) {
         _ = workspace.createUntitledFileInFolder(folder)
+    }
+
+    /// Defer the structural mutation to a later runloop iteration so SwiftUI's
+    /// `List` (backed by `NSOutlineView`) can commit the selection clear before
+    /// it diffs the doomed subtree. `DispatchQueue.main.async` would batch into
+    /// the same SwiftUI transaction; the timer-backed delay forces a separate
+    /// iteration after the render observer fires. Without the gap, the diff
+    /// dereferences a freed `FileNode` in `NSOutlineView`'s item map (#288).
+    private func removeLocation(_ location: BookmarkedLocation) {
+        let rootPath = location.url.standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        let previousSelection = selectedFileURL
+        let clearedSelection: Bool
+        if let selectedPath = selectedFileURL?.standardizedFileURL.path,
+           selectedPath == rootPath || selectedPath.hasPrefix(prefix) {
+            selectedFileURL = nil
+            clearedSelection = true
+        } else {
+            clearedSelection = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            guard workspace.removeLocationClosingOpenDocuments(location) else {
+                if clearedSelection, selectedFileURL == nil {
+                    selectedFileURL = previousSelection
+                }
+                return
+            }
+        }
     }
 
     private func promptForNewFolder(in parent: URL) {

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -911,8 +911,21 @@ final class WorkspaceManager {
             location.url.stopAccessingSecurityScopedResource()
             accessedURLs.remove(location.url)
         }
+        removeDeletedItemReferences(at: location.url)
+        pruneExpandedFolderPaths(under: location.url)
         locations.removeAll { $0.id == location.id }
         persistLocations()
+    }
+
+    private func pruneExpandedFolderPaths(under url: URL) {
+        let rootPath = url.standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        let filtered = expandedFolderPaths.filter { path in
+            path != rootPath && !path.hasPrefix(prefix)
+        }
+        guard filtered != expandedFolderPaths else { return }
+        expandedFolderPaths = filtered
+        UserDefaults.standard.set(Array(expandedFolderPaths), forKey: Self.expandedFolderPathsKey)
     }
 
     /// Closes any open documents inside `location`, prompting save/discard for dirty


### PR DESCRIPTION
## Summary

Right-clicking a vault folder in the sidebar → **Remove from List** crashed the app with `EXC_BAD_ACCESS` inside `NSOutlineView`'s item map. `workspace.locations` was being mutated synchronously while SwiftUI's `List`-backed `NSOutlineView` still held a stale `FileNode` pointer, so its diff dereferenced freed memory.

The Remove handler now clears any selection rooted in the doomed subtree and defers `removeLocationClosingOpenDocuments` by one timer-backed runloop tick so the selection-clear commits in its own SwiftUI transaction before the structural diff runs (a plain `DispatchQueue.main.async` would batch into the same transaction). `WorkspaceManager.removeLocation` also prunes pinned, recents, and expanded-folder state under the removed location so the next launch can't restore orphan references that hit the same crash via the tracking-area cascade.

Fixes #288

## Test plan

- [ ] Add a vault folder in the sidebar; click a `.md` file inside it so the leaf is selected.
- [ ] Right-click the vault header → **Remove from List**. App should not crash; sidebar reflows and the file detail closes.
- [ ] Quit and relaunch — sidebar restores cleanly, no second-launch crash.
- [ ] Cancel the save prompt on a dirty doc inside the vault; the previous selection should be restored.