### PR TITLE
[mac] Show parent folder for Cmd+P recents and disambiguate same-name tabs

### DIFF
--- a/Clearly/Native/MacTabBar.swift
+++ b/Clearly/Native/MacTabBar.swift
@@ -13,8 +13,11 @@ struct MacTabBar: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 4) {
                     ForEach(workspace.openDocuments) { doc in
+                        let label = workspace.tabLabel(for: doc)
                         MacTabRow(
                             doc: doc,
+                            parentQualifier: label.parent,
+                            filename: label.filename,
                             isActive: doc.id == workspace.activeDocumentID,
                             isHovered: doc.id == workspace.hoveredTabID,
                             onSelect: { workspace.switchToDocument(doc.id) },
@@ -39,6 +42,8 @@ struct MacTabBar: View {
 
 private struct MacTabRow: View {
     let doc: OpenDocument
+    let parentQualifier: String?
+    let filename: String
     let isActive: Bool
     let isHovered: Bool
     let onSelect: () -> Void
@@ -52,10 +57,16 @@ private struct MacTabRow: View {
                     .fill(Color.secondary)
                     .frame(width: 6, height: 6)
             }
-            Text(doc.displayName)
-                .font(.subheadline)
-                .lineLimit(1)
-                .foregroundStyle(isActive ? .primary : .secondary)
+            HStack(spacing: 0) {
+                if let parent = parentQualifier {
+                    Text("\(parent)/")
+                        .foregroundStyle(.tertiary)
+                }
+                Text(filename)
+                    .foregroundStyle(isActive ? .primary : .secondary)
+            }
+            .font(.subheadline)
+            .lineLimit(1)
             if isHovered || isActive {
                 Button {
                     onClose()

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -246,9 +246,16 @@ final class QuickSwitcherManager: NSObject {
             let recents = WorkspaceManager.shared.recentFiles
             items = recents.compactMap { url in
                 let filename = url.deletingPathExtension().lastPathComponent
+                let relativePath: String
+                if let vaultRoot = WorkspaceManager.shared.containingVaultRoot(for: url) {
+                    relativePath = VaultIndex.relativePath(of: url, from: vaultRoot)
+                } else {
+                    let parent = url.deletingLastPathComponent().lastPathComponent
+                    relativePath = parent.isEmpty ? url.lastPathComponent : "\(parent)/\(url.lastPathComponent)"
+                }
                 return QuickSwitcherItem(
                     filename: filename,
-                    relativePath: url.lastPathComponent,
+                    relativePath: relativePath,
                     fullURL: url,
                     score: 100,
                     matchedRanges: [],

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -196,6 +196,50 @@ final class WorkspaceManager {
 
     // MARK: - Open Documents
 
+    /// Tab label parts for `doc`. Returns `(parent: nil, filename:)` when the
+    /// filename is unique among currently open tabs; otherwise returns the
+    /// shortest ancestor suffix that disambiguates the duplicate filename.
+    func tabLabel(for doc: OpenDocument) -> (parent: String?, filename: String) {
+        guard let url = doc.fileURL else { return (nil, doc.displayName) }
+        let filename = url.lastPathComponent
+        let duplicateURLs = openDocuments.compactMap { other -> URL? in
+            guard let otherURL = other.fileURL,
+                  otherURL.lastPathComponent.localizedCaseInsensitiveCompare(filename) == .orderedSame else {
+                return nil
+            }
+            return otherURL
+        }
+        guard duplicateURLs.count > 1 else { return (nil, filename) }
+
+        func parentComponents(for url: URL) -> [String] {
+            url.deletingLastPathComponent().standardizedFileURL.pathComponents.filter { $0 != "/" }
+        }
+
+        func suffixLabel(from components: [String], depth: Int) -> String {
+            components.suffix(min(depth, components.count)).joined(separator: "/")
+        }
+
+        let currentComponents = parentComponents(for: url)
+        let duplicateParentComponents = duplicateURLs.map(parentComponents)
+        let maxDepth = duplicateParentComponents.map(\.count).max() ?? 0
+
+        guard maxDepth > 0 else { return (nil, filename) }
+
+        for depth in 1...maxDepth {
+            let labels = duplicateParentComponents.map { suffixLabel(from: $0, depth: depth) }
+            let current = suffixLabel(from: currentComponents, depth: depth)
+            let matches = labels.filter {
+                $0.localizedCaseInsensitiveCompare(current) == .orderedSame
+            }
+            if !current.isEmpty, matches.count == 1 {
+                return (current, filename)
+            }
+        }
+
+        let parent = url.deletingLastPathComponent().standardizedFileURL.path
+        return (parent.isEmpty ? nil : parent, filename)
+    }
+
     @discardableResult
     func createUntitledDocument() -> Bool {
         guard saveFileBacked() else { return false }


### PR DESCRIPTION
## Summary

- Cmd+P recents now show the same tertiary-gray parent-folder hint that search results already render — recents were being created with `relativePath: url.lastPathComponent`, which made the row's `displayPath` empty. In-vault recents now use `VaultIndex.relativePath`; orphan recents fall back to the immediate parent folder name.
- Tabs gain a `parent/filename` qualifier (parent in tertiary) only when two open tabs share a filename, via a new `WorkspaceManager.tabLabel(for:)` helper modeled on the existing `wikiLinkTarget` collision pattern.

Fixes #254

## Test plan

- [ ] Cmd+P with no query: recent files show parent folder on the right (e.g. `SKILL  Notes`).
- [ ] Open two `SKILL.md` files in different folders: tabs render `Notes/SKILL.md` and `Projects/SKILL.md` with the folder portion in tertiary.
- [ ] Open a third uniquely-named file: its tab stays bare (no prefix).
- [ ] Close one of the colliding tabs: the survivor reverts to plain `SKILL.md`.
- [ ] Untitled tabs unaffected; window title still uses the plain filename.