### PR TITLE
Find + Replace across editor surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ xcodebuild -scheme Clearly -configuration Debug build   # Build from CLI
 
 Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen first).
 
+**Worktree-local DerivedData (Conductor / parallel workspaces).** When working in a Conductor worktree, always pass `-derivedDataPath ./.build/DerivedData` to `xcodebuild`. Without it, `xcodebuild` writes to the shared `~/Library/Developer/Xcode/DerivedData` and silently picks up products from a different worktree or the main repo, and `open` then launches a stale or wrong-source app. The `/verify` skill enforces this; do the same for any direct `xcodebuild` invocation. The launched bundle path under `.build/DerivedData/Build/Products/Debug/Clearly Dev.app` should always match the worktree you're editing — verify with `lsappinfo info -only bundlepath "Clearly Dev"` if in doubt.
+
 - Deployment target: macOS 15.0 (raised from 14.0 to enable SwiftUI API parity with iPad shell and ship with macOS 26 SDK); iOS 17.0
 - Swift 5.9 app / Swift 5 language mode for ClearlyCore (tools 6.0 so we can declare `.macOS(.v15)`). Xcode 26+ required to compile against the macOS 26 SDK so Liquid Glass lights up automatically on stock SwiftUI chrome.
 - Dependencies: `cmark-gfm` (GFM markdown → HTML), `Sparkle` (auto-updates, direct distribution only), `GRDB` (SQLite + FTS5), `MCP` (Model Context Protocol SDK) via Swift Package Manager
@@ -81,6 +83,10 @@ Open in Xcode: `open Clearly.xcodeproj` (gitignored, so regenerate with xcodegen
 **Don't add subviews to `_NSHostingView` with Auto Layout constraints.** SwiftUI's hosting view manages subview layout internally and will override your frames/constraints, causing the subview to fill the entire hosting view. The same applies to `NSSplitView`, which treats added subviews as panes. If you need an AppKit overlay on top of SwiftUI content, subclass the underlying AppKit view instead (e.g., `DraggableWKWebView` in `PreviewView.swift` overrides `mouseDown` to enable window dragging in the top region).
 
 **NSViewRepresentable binding gotcha**: SwiftUI can call `updateNSView` at any time — layout passes, state changes, etc. — not just in response to binding changes. When the user types, the text view's content changes immediately but the `@Binding` update is async. If `updateNSView` fires in between, it sees a mismatch and overwrites the text view with the stale binding value, causing the cursor to jump. A simple `isUpdating` boolean set inside the async block does NOT protect against this because SwiftUI defers the actual `updateNSView` call past the flag's lifetime. The fix is `pendingBindingUpdates` — a counter incremented synchronously in `textDidChange` and decremented in the async block. `updateNSView` skips text replacement while this counter is > 0. This pattern applies to any `NSViewRepresentable` that pushes changes from the AppKit side back to SwiftUI bindings asynchronously.
+
+**`@Published` emits in `willSet` — the property hasn't been written yet at sink-fire time.** A `.sink` on `state.$prop` runs *before* the assignment completes on the same thread. Reading `state.prop` synchronously inside the sink returns the OLD value, so any code that re-derives behavior from current state (e.g., `performFind()` reading `findState.caseSensitive`) sees stale options. Two safe patterns: (1) capture the new value from the closure parameter and pass it through, like the existing `state.$query.sink { newQuery in self.performFind(query: newQuery) }` in `EditorView.Coordinator`; or (2) `DispatchQueue.main.async` inside the sink so the property is written by the time the work runs. The CombineLatest subscription on the find option toggles uses pattern (2).
+
+**SwiftUI `.keyboardShortcut(letter, modifiers: [.command, .option])` does not dispatch on this macOS** even though the menu item displays the shortcut. `.command` alone and `[.command, .shift]` work fine; the option modifier on a letter silently fails. For ⌥⌘-letter shortcuts, follow the `injectHideToolbarIfNeeded` pattern in `ClearlyAppDelegate.applicationWillUpdate`: build an `NSMenuItem` with `keyEquivalent: "x"` + `keyEquivalentModifierMask = [.command, .option]`, target an `@objc` selector or post a notification, and let `MacRootView` observe. Don't use `.keyboardShortcut(... [.command, .option])` from a SwiftUI `Button` and assume it dispatches.
 
 ## Dual Distribution: Sparkle + App Store
 
@@ -147,6 +153,10 @@ Use these instead:
 ### `ClearlyUITextView` must stay on TextKit 1, not TextKit 2
 
 `Clearly/iOS/ClearlyUITextView.swift` calls `super.init(frame:textContainer:)` with a manually-constructed `NSTextStorage` → `NSLayoutManager` → `NSTextContainer` chain. Passing a non-nil `textContainer` is what forces TextKit 1 on iOS 16+; the default `UITextView(frame:)` defaults to TextKit 2, where `textView.textStorage` is effectively dead. Every path that reaches into `textStorage` — `MarkdownSyntaxHighlighter.highlightAll` / `highlightAround`, typing attributes, `NSTextStorageDelegate`, future save path in Phase 6 — depends on TextKit 1. Don't "simplify" the init to `super.init(frame:)` or use `UITextView(usingTextLayoutManager: true)`; highlighting will silently stop working with no crash.
+
+### iOS find-style highlights need an explicit background-color wipe before each paint
+
+TextKit 1 on iOS has no `removeTemporaryAttribute` API like macOS, so transient highlights (find matches, etc.) must live on `textStorage` via `addAttribute(.backgroundColor, ...)`. Re-running the syntax highlighter to "reset" backgrounds is NOT enough — `MarkdownSyntaxHighlighter.highlightAll` only *adds* attributes, it never removes them. So old find backgrounds from previous keystrokes persist into the next paint as orphaned yellow fragments. Always do `storage.removeAttribute(.backgroundColor, range: fullRange)` first, *then* re-run the highlighter (which repaints `==highlight==` markdown backgrounds), *then* paint your new find ranges. `EditorView_iOS.Coordinator.resetBackgroundsThenRehighlight` is the canonical helper.
 
 ### Save failures on iOS must not unmount the editor
 

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -138,6 +138,12 @@ struct EditorView: NSViewRepresentable {
         findState?.editorNavigateToPrevious = { [weak coordinator] in
             coordinator?.navigateToPreviousMatch()
         }
+        findState?.editorPerformReplace = { [weak coordinator] in
+            coordinator?.performReplaceCurrent()
+        }
+        findState?.editorPerformReplaceAll = { [weak coordinator] in
+            coordinator?.performReplaceAll()
+        }
 
         // Wire up outline scroll-to
         outlineState?.scrollToRange = { [weak coordinator] range in
@@ -387,6 +393,7 @@ struct EditorView: NSViewRepresentable {
 
         // Find state tracking
         var matchRanges: [NSRange] = []
+        var lastMatches: [TextMatch] = []
         private var currentMatchIdx = 0 // 0-based internal index
         private var findCancellables = Set<AnyCancellable>()
 
@@ -550,6 +557,23 @@ struct EditorView: NSViewRepresentable {
                         self.performFind()
                     } else {
                         self.clearFindHighlights()
+                    }
+                }
+                .store(in: &findCancellables)
+
+            // Re-run find whenever an option toggle changes. `@Published`
+            // emits in `willSet`, so the property hasn't been updated yet on
+            // this dispatch — bounce to the next runloop tick so `performFind`
+            // reads the new value.
+            Publishers.CombineLatest(state.$caseSensitive, state.$useRegex)
+                .dropFirst()
+                .sink { [weak self] _, _ in
+                    DispatchQueue.main.async {
+                        guard let self,
+                              let findState = self.findState,
+                              findState.isVisible,
+                              findState.activeMode == .edit else { return }
+                        self.performFind()
                     }
                 }
                 .store(in: &findCancellables)
@@ -784,12 +808,27 @@ struct EditorView: NSViewRepresentable {
         // MARK: - Find
 
         func performFind(query overrideQuery: String? = nil) {
-            guard let textView, let findState else { return }
+            guard let textView else { return }
+            let didRecompute = recomputeMatches(query: overrideQuery)
+            guard didRecompute else { return }
+            applyFindHighlights()
+            if let first = matchRanges.first {
+                textView.scrollRangeToVisible(first)
+            }
+        }
+
+        /// Recomputes matches against the current text view and updates state,
+        /// but does NOT paint highlights or scroll. Returns false if the query
+        /// was empty / errored (in which case state was already reset).
+        @discardableResult
+        private func recomputeMatches(query overrideQuery: String? = nil) -> Bool {
+            guard let textView, let findState else { return false }
             let query = overrideQuery ?? findState.query
             clearFindHighlights()
 
             guard !query.isEmpty else {
                 matchRanges = []
+                lastMatches = []
                 currentMatchIdx = 0
                 DispatchQueue.main.async { [weak self] in
                     guard let self,
@@ -798,28 +837,54 @@ struct EditorView: NSViewRepresentable {
                     findState.matchCount = 0
                     findState.currentIndex = 0
                     findState.resultsAreStale = false
+                    findState.regexError = nil
+                    findState.lastReplaceCount = nil
                 }
-                return
+                return false
             }
 
-            let ranges = TextMatcher.ranges(of: query, in: textView.string)
-            matchRanges = ranges
-            currentMatchIdx = ranges.isEmpty ? 0 : 0
+            let options = TextMatchOptions(
+                caseSensitive: findState.caseSensitive,
+                useRegex: findState.useRegex
+            )
 
-            applyFindHighlights()
+            let matches: [TextMatch]
+            do {
+                matches = try TextMatcher.matches(of: query, in: textView.string, options: options)
+            } catch let TextMatcherError.invalidRegex(message) {
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                DispatchQueue.main.async { [weak self] in
+                    guard let self,
+                          let findState = self.findState,
+                          findState.activeMode == .edit else { return }
+                    findState.matchCount = 0
+                    findState.currentIndex = 0
+                    findState.resultsAreStale = false
+                    findState.regexError = message
+                    findState.lastReplaceCount = nil
+                }
+                return false
+            } catch {
+                matches = []
+            }
+
+            matchRanges = matches.map(\.range)
+            lastMatches = matches
+            currentMatchIdx = 0
 
             DispatchQueue.main.async { [weak self] in
                 guard let self,
                       let findState = self.findState,
                       findState.activeMode == .edit else { return }
-                findState.matchCount = ranges.count
-                findState.currentIndex = ranges.isEmpty ? 0 : 1
+                findState.matchCount = matches.count
+                findState.currentIndex = matches.isEmpty ? 0 : 1
                 findState.resultsAreStale = false
+                findState.regexError = nil
+                findState.lastReplaceCount = nil
             }
-
-            if !ranges.isEmpty {
-                textView.scrollRangeToVisible(ranges[0])
-            }
+            return true
         }
 
         func navigateToNextMatch() {
@@ -880,7 +945,81 @@ struct EditorView: NSViewRepresentable {
             let fullRange = NSRange(location: 0, length: storage.length)
             layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
             matchRanges = []
+            lastMatches = []
             currentMatchIdx = 0
+        }
+
+        // MARK: - Replace
+
+        func performReplaceCurrent() {
+            guard let textView, let findState,
+                  !lastMatches.isEmpty,
+                  currentMatchIdx < lastMatches.count else { return }
+            let match = lastMatches[currentMatchIdx]
+            let storage = textView.textStorage!
+            guard match.range.upperBound <= storage.length else { return }
+            let replacement = ReplaceEngine.substitution(for: match,
+                                                         in: textView.string,
+                                                         template: findState.replacementText,
+                                                         isRegex: findState.useRegex)
+            guard textView.shouldChangeText(in: match.range, replacementString: replacement) else { return }
+            let resumeLocation = match.range.location + (replacement as NSString).length
+            textView.replaceCharacters(in: match.range, with: replacement)
+            textView.didChangeText()
+            findState.lastReplaceCount = nil
+            // Silent rescan — advanceToMatchAtOrAfter handles the single
+            // applyFindHighlights + scroll, so we don't double-paint.
+            recomputeMatches()
+            advanceToMatchAtOrAfter(location: resumeLocation)
+        }
+
+        /// After a single-match replace, jump to the first remaining match at or
+        /// after `location`. Skips any new match the replacement string may have
+        /// introduced inside its own range, so consecutive Replace presses walk
+        /// forward instead of cycling on the same spot.
+        private func advanceToMatchAtOrAfter(location: Int) {
+            guard !lastMatches.isEmpty else {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, let findState = self.findState, findState.activeMode == .edit else { return }
+                    findState.currentIndex = 0
+                }
+                return
+            }
+            let nextIdx = lastMatches.firstIndex(where: { $0.range.location >= location }) ?? 0
+            currentMatchIdx = nextIdx
+            applyFindHighlights()
+            textView?.scrollRangeToVisible(matchRanges[currentMatchIdx])
+            let publishedIdx = currentMatchIdx + 1
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let findState = self.findState, findState.activeMode == .edit else { return }
+                findState.currentIndex = publishedIdx
+            }
+        }
+
+        func performReplaceAll() {
+            guard let textView, let findState, !lastMatches.isEmpty else { return }
+            let oldText = textView.string
+            let nsOldText = oldText as NSString
+            let newText = ReplaceEngine.applyAll(matches: lastMatches,
+                                                 in: oldText,
+                                                 template: findState.replacementText,
+                                                 isRegex: findState.useRegex)
+            let fullRange = NSRange(location: 0, length: nsOldText.length)
+            guard textView.shouldChangeText(in: fullRange, replacementString: newText) else { return }
+            let replaceCount = lastMatches.count
+            textView.replaceCharacters(in: fullRange, with: newText)
+            textView.didChangeText()
+            DispatchQueue.main.async { [weak findState] in
+                findState?.lastReplaceCount = replaceCount
+            }
+            // Clear the "Replaced N occurrences" label after a beat so it
+            // doesn't linger across an unrelated session. If a later action
+            // already changed `lastReplaceCount`, leave that one alone.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak findState] in
+                if findState?.lastReplaceCount == replaceCount {
+                    findState?.lastReplaceCount = nil
+                }
+            }
         }
     }
 }

--- a/Clearly/FindBarView.swift
+++ b/Clearly/FindBarView.swift
@@ -4,10 +4,47 @@ import ClearlyCore
 struct FindBarView: View {
     @ObservedObject var findState: FindState
     @State private var isFieldFocused = false
+    @State private var isReplaceFieldFocused = false
     @Environment(\.colorScheme) private var colorScheme
 
+    private var hasRegexError: Bool { findState.activeMode == .edit && findState.regexError != nil }
+    private var isReplaceVisible: Bool { findState.showReplace && findState.activeMode == .edit }
+
     var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            findRow
+            if isReplaceVisible {
+                replaceRow
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Theme.backgroundColorSwiftUI)
+        .animation(Theme.Motion.smooth, value: findState.showReplace)
+        .onAppear { isFieldFocused = true }
+        .onChange(of: findState.focusRequest) { _, _ in
+            isFieldFocused = true
+            isReplaceFieldFocused = false
+        }
+        .onChange(of: findState.replaceFocusRequest) { _, _ in
+            isReplaceFieldFocused = true
+            isFieldFocused = false
+        }
+    }
+
+    private var findRow: some View {
         HStack(spacing: 8) {
+            DisclosureChevron(isExpanded: isReplaceVisible) {
+                if findState.activeMode == .preview {
+                    WorkspaceManager.shared.currentViewMode = .edit
+                    findState.showReplace = true
+                } else {
+                    findState.showReplace.toggle()
+                }
+                findState.lastReplaceCount = nil
+            }
+
             HStack(spacing: 4) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.tertiary)
@@ -19,22 +56,16 @@ struct FindBarView: View {
                     isFocused: $isFieldFocused,
                     onSubmitNext: { findState.navigateToNext?() },
                     onSubmitPrevious: { findState.navigateToPrevious?() },
-                    onEscape: { findState.isVisible = false }
+                    onEscape: { findState.dismiss() }
                 )
                 .frame(minWidth: 120)
 
-                if !findState.query.isEmpty && !findState.resultsAreStale {
-                    if findState.matchCount > 0 {
-                        Text("\(findState.currentIndex) of \(findState.matchCount)")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    } else {
-                        Text("No results")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                    }
+                if findState.activeMode == .edit {
+                    FindOptionToggle(label: "Aa", isOn: $findState.caseSensitive)
+                    FindOptionToggle(label: ".*", isOn: $findState.useRegex)
                 }
+
+                statusText
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
@@ -44,9 +75,11 @@ struct FindBarView: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(Color.accentColor.opacity(isFieldFocused ? 0.4 : 0), lineWidth: 1)
+                    .strokeBorder(borderColor, lineWidth: 1)
                     .animation(Theme.Motion.hover, value: isFieldFocused)
+                    .animation(Theme.Motion.hover, value: hasRegexError)
             )
+            .help(hasRegexError ? (findState.regexError ?? "") : "")
 
             HStack(spacing: 2) {
                 FindNavButton(icon: "chevron.left", disabled: !findState.canNavigate) {
@@ -64,15 +97,150 @@ struct FindBarView: View {
             .font(.system(size: 12, weight: .medium))
             .foregroundStyle(Color.accentColor)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 6)
-        .background(Theme.backgroundColorSwiftUI)
-        .onAppear {
-            isFieldFocused = true
+    }
+
+    private var replaceRow: some View {
+        HStack(spacing: 8) {
+            // Invisible spacer that matches the chevron column width so the
+            // replace field aligns horizontally with the find field.
+            Color.clear.frame(width: 20, height: 20)
+
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.uturn.forward")
+                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 12))
+
+                ReplaceField(
+                    text: $findState.replacementText,
+                    focusRequest: findState.replaceFocusRequest,
+                    isFocused: $isReplaceFieldFocused,
+                    onReplace: { findState.editorPerformReplace?() },
+                    onReplaceAll: { findState.editorPerformReplaceAll?() },
+                    onSubmitPrevious: { findState.navigateToPrevious?() },
+                    onEscape: { findState.dismiss() }
+                )
+                .frame(minWidth: 120)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.accentColor.opacity(isReplaceFieldFocused ? 0.4 : 0), lineWidth: 1)
+                    .animation(Theme.Motion.hover, value: isReplaceFieldFocused)
+            )
+
+            Button("Replace All") { findState.editorPerformReplaceAll?() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(findState.canReplaceAll ? Color.accentColor : Color.secondary)
+                .disabled(!findState.canReplaceAll)
+
+            Button("Replace") { findState.editorPerformReplace?() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(findState.canReplace ? Color.accentColor : Color.secondary)
+                .disabled(!findState.canReplace)
         }
-        .onChange(of: findState.focusRequest) { _, _ in
-            isFieldFocused = true
+    }
+
+    @ViewBuilder
+    private var statusText: some View {
+        if let count = findState.lastReplaceCount {
+            Text(count == 1 ? "Replaced 1 occurrence" : "Replaced \(count) occurrences")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        } else if hasRegexError, let error = findState.regexError {
+            Text(error)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.red.opacity(0.8))
+                .lineLimit(1)
+        } else if !findState.query.isEmpty && !findState.resultsAreStale {
+            if findState.matchCount > 0 {
+                Text("\(findState.currentIndex) of \(findState.matchCount)")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            } else {
+                Text("No results")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
         }
+    }
+
+    private var borderColor: Color {
+        if hasRegexError { return Color.red.opacity(0.5) }
+        if isFieldFocused { return Color.accentColor.opacity(0.4) }
+        return Color.clear
+    }
+}
+
+private struct DisclosureChevron: View {
+    let isExpanded: Bool
+    let action: () -> Void
+    @State private var isHovering = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(isHovering ? .primary : .secondary)
+                .frame(width: 20, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(isHovering
+                            ? Color.primary.opacity(colorScheme == .dark ? Theme.hoverOpacityDark : Theme.hoverOpacity)
+                            : Color.clear)
+                )
+                .contentShape(Rectangle())
+                .animation(Theme.Motion.smooth, value: isExpanded)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(Theme.Motion.hover) { isHovering = hovering }
+        }
+        .help(isExpanded ? "Hide replace" : "Show replace")
+    }
+}
+
+private struct FindOptionToggle: View {
+    let label: String
+    @Binding var isOn: Bool
+    @State private var isHovering = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: { isOn.toggle() }) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundStyle(isOn ? Color.accentColor : (isHovering ? .primary : .secondary))
+                .frame(width: 20, height: 18)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(backgroundFill)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(Theme.Motion.hover) { isHovering = hovering }
+        }
+    }
+
+    private var backgroundFill: Color {
+        if isOn {
+            return Color.accentColor.opacity(0.18)
+        }
+        if isHovering {
+            return Color.primary.opacity(colorScheme == .dark ? Theme.hoverOpacityDark : Theme.hoverOpacity)
+        }
+        return Color.clear
     }
 }
 
@@ -230,6 +398,133 @@ private struct FindQueryField: NSViewRepresentable {
                     parent.onSubmitPrevious()
                 } else {
                     parent.onSubmitNext()
+                }
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+private struct ReplaceField: NSViewRepresentable {
+    @Binding var text: String
+    let focusRequest: UUID
+    @Binding var isFocused: Bool
+    let onReplace: () -> Void
+    let onReplaceAll: () -> Void
+    let onSubmitPrevious: () -> Void
+    let onEscape: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField(string: text)
+        textField.isBordered = false
+        textField.isBezeled = false
+        textField.drawsBackground = false
+        textField.focusRingType = .none
+        textField.font = .systemFont(ofSize: 13)
+        textField.placeholderString = "Replace"
+        textField.lineBreakMode = .byClipping
+        textField.delegate = context.coordinator
+        context.coordinator.attach(textField)
+        return textField
+    }
+
+    func updateNSView(_ textField: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.attach(textField)
+        if textField.stringValue != text {
+            context.coordinator.isApplyingSwiftUpdate = true
+            textField.stringValue = text
+            context.coordinator.isApplyingSwiftUpdate = false
+        }
+        if context.coordinator.lastFocusRequest != focusRequest {
+            context.coordinator.lastFocusRequest = focusRequest
+            DispatchQueue.main.async {
+                guard let window = textField.window else { return }
+                window.makeFirstResponder(textField)
+                textField.currentEditor()?.selectAll(nil)
+            }
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: ReplaceField
+        var lastFocusRequest: UUID?
+        var isApplyingSwiftUpdate = false
+        weak var textField: NSTextField?
+        private var commandMonitor: Any?
+
+        init(parent: ReplaceField) { self.parent = parent }
+
+        deinit {
+            if let commandMonitor { NSEvent.removeMonitor(commandMonitor) }
+        }
+
+        func attach(_ textField: NSTextField) {
+            self.textField = textField
+            guard commandMonitor == nil else { return }
+            commandMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self,
+                      self.parent.isFocused,
+                      let textField = self.textField,
+                      textField.window?.isKeyWindow == true else { return event }
+
+                let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                let chars = event.charactersIgnoringModifiers ?? ""
+
+                // ⌃⌥Return = Replace All
+                if (chars == "\r" || chars == "\u{3}") && modifiers.contains(.control) && modifiers.contains(.option) {
+                    self.parent.onReplaceAll()
+                    return nil
+                }
+
+                switch (modifiers, chars) {
+                case (.command, "a"):
+                    textField.window?.makeFirstResponder(textField)
+                    textField.currentEditor()?.selectAll(nil)
+                    return nil
+                case (.command, "v"):
+                    guard let pasted = NSPasteboard.general.string(forType: .string) else { return event }
+                    textField.window?.makeFirstResponder(textField)
+                    if let editor = textField.currentEditor() {
+                        editor.insertText(pasted)
+                        self.parent.text = textField.stringValue
+                    } else {
+                        textField.stringValue = pasted
+                        self.parent.text = pasted
+                    }
+                    return nil
+                default:
+                    return event
+                }
+            }
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) { parent.isFocused = true }
+        func controlTextDidEndEditing(_ obj: Notification) { parent.isFocused = false }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard !isApplyingSwiftUpdate, let field = obj.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            switch commandSelector {
+            case #selector(NSResponder.cancelOperation(_:)):
+                parent.onEscape()
+                return true
+            case #selector(NSResponder.insertNewline(_:)),
+                 #selector(NSResponder.insertLineBreak(_:)):
+                let modifiers = NSApp.currentEvent?.modifierFlags ?? []
+                if modifiers.contains(.shift) {
+                    parent.onSubmitPrevious()
+                } else {
+                    parent.onReplace()
                 }
                 return true
             default:

--- a/Clearly/LiveEditorView.swift
+++ b/Clearly/LiveEditorView.swift
@@ -115,6 +115,7 @@ struct LiveEditorView: NSViewRepresentable {
         private var lastKnownDocumentID: UUID?
         private var lastThemeSignature = ""
         private var lastFindQuery = ""
+        private var lastFindSignature = ""
         private var lastFindVisibility = false
         private var findCancellables = Set<AnyCancellable>()
         /// Local event monitor that intercepts Cmd+V and routes it through
@@ -207,6 +208,16 @@ struct LiveEditorView: NSViewRepresentable {
                 findState.editorNavigateToPrevious = { [weak self] in
                     self?.call(function: "applyCommand", payload: ["command": "findPrevious"])
                 }
+                findState.editorPerformReplace = { [weak self, weak findState] in
+                    guard let self, let findState else { return }
+                    self.syncFindState(findState, force: true)
+                    self.call(function: "applyCommand", payload: ["command": "replaceCurrent"])
+                }
+                findState.editorPerformReplaceAll = { [weak self, weak findState] in
+                    guard let self, let findState else { return }
+                    self.syncFindState(findState, force: true)
+                    self.call(function: "applyCommand", payload: ["command": "replaceAll"])
+                }
             }
 
             outlineState?.scrollToRange = { [weak self] range in
@@ -247,19 +258,40 @@ struct LiveEditorView: NSViewRepresentable {
             }
 
             if parent.findState?.isVisible == true {
-                let query = parent.findState?.query ?? ""
-                if query != lastFindQuery || !lastFindVisibility {
-                    lastFindQuery = query
-                    lastFindVisibility = true
-                    call(function: "setFindQuery", payload: ["query": query])
+                if let findState = parent.findState {
+                    if !lastFindVisibility {
+                        lastFindVisibility = true
+                    }
+                    syncFindState(findState)
                 }
             } else {
                 if lastFindVisibility || !lastFindQuery.isEmpty {
                     lastFindQuery = ""
+                    lastFindSignature = ""
                     lastFindVisibility = false
                     call(function: "setFindQuery", payload: ["query": ""])
                 }
             }
+        }
+
+        private func syncFindState(_ state: FindState, force: Bool = false) {
+            let query = state.isVisible && state.activeMode == .edit ? state.query : ""
+            let signature = [
+                query,
+                state.replacementText,
+                state.caseSensitive ? "1" : "0",
+                state.useRegex ? "1" : "0"
+            ].joined(separator: "\u{1f}")
+            guard force || signature != lastFindSignature else { return }
+            lastFindQuery = query
+            lastFindSignature = signature
+            call(function: "setFindQuery", payload: [
+                "query": query,
+                "replacement": state.replacementText,
+                "caseSensitive": state.caseSensitive,
+                "wholeWord": false,
+                "useRegex": state.useRegex
+            ])
         }
 
         func observeFindState(_ state: FindState) {
@@ -267,24 +299,43 @@ struct LiveEditorView: NSViewRepresentable {
 
             state.$query
                 .removeDuplicates()
-                .sink { [weak self] query in
-                    guard let self,
-                          state.isVisible,
-                          state.activeMode == .edit else { return }
-                    self.lastFindQuery = query
-                    self.call(function: "setFindQuery", payload: ["query": query])
+                .sink { [weak self, weak state] _ in
+                    DispatchQueue.main.async {
+                        guard let self, let state, state.isVisible, state.activeMode == .edit else { return }
+                        self.syncFindState(state)
+                    }
                 }
                 .store(in: &findCancellables)
 
             state.$isVisible
                 .removeDuplicates()
-                .sink { [weak self] visible in
-                    guard let self else { return }
-                    self.lastFindVisibility = visible
-                    (self.webView as? LiveEditorWebView)?.allowsDOMFocusForwarding = !visible
-                    let query = visible && state.activeMode == .edit ? state.query : ""
-                    self.lastFindQuery = query
-                    self.call(function: "setFindQuery", payload: ["query": query])
+                .sink { [weak self, weak state] visible in
+                    DispatchQueue.main.async {
+                        guard let self, let state else { return }
+                        self.lastFindVisibility = visible
+                        (self.webView as? LiveEditorWebView)?.allowsDOMFocusForwarding = !visible
+                        self.syncFindState(state, force: true)
+                    }
+                }
+                .store(in: &findCancellables)
+
+            Publishers.CombineLatest(state.$caseSensitive, state.$useRegex)
+                .dropFirst()
+                .sink { [weak self, weak state] _, _ in
+                    DispatchQueue.main.async {
+                        guard let self, let state, state.isVisible, state.activeMode == .edit else { return }
+                        self.syncFindState(state)
+                    }
+                }
+                .store(in: &findCancellables)
+
+            state.$replacementText
+                .removeDuplicates()
+                .sink { [weak self, weak state] _ in
+                    DispatchQueue.main.async {
+                        guard let self, let state, state.isVisible, state.activeMode == .edit else { return }
+                        self.syncFindState(state)
+                    }
                 }
                 .store(in: &findCancellables)
         }
@@ -425,11 +476,26 @@ struct LiveEditorView: NSViewRepresentable {
                 guard LiveEditorSession.matches(documentID: parent.documentID),
                       let matchCount = body["matchCount"] as? Int,
                       let currentIndex = body["currentIndex"] as? Int else { return }
+                let regexError = body["regexError"] as? String
                 DispatchQueue.main.async {
                     guard self.parent.findState?.activeMode == .edit || self.parent.findState?.isVisible == false else { return }
                     self.parent.findState?.matchCount = matchCount
                     self.parent.findState?.currentIndex = currentIndex
                     self.parent.findState?.resultsAreStale = false
+                    self.parent.findState?.regexError = regexError
+                    self.parent.findState?.lastReplaceCount = nil
+                }
+
+            case "replaceStatus":
+                guard LiveEditorSession.matches(documentID: parent.documentID),
+                      let replaceCount = body["replaceCount"] as? Int else { return }
+                DispatchQueue.main.async {
+                    guard self.parent.findState?.activeMode == .edit else { return }
+                    self.parent.findState?.lastReplaceCount = replaceCount
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+                    guard let self, self.parent.findState?.lastReplaceCount == replaceCount else { return }
+                    self.parent.findState?.lastReplaceCount = nil
                 }
 
             case "openLink":

--- a/Clearly/iOS/EditorView_iOS.swift
+++ b/Clearly/iOS/EditorView_iOS.swift
@@ -66,7 +66,9 @@ struct EditorView_iOS: UIViewRepresentable {
         private weak var attachedFindState: FindState?
         private var lastFindQuery: String = ""
         private var lastFindVisible: Bool = false
+        private var lastFindOptions: TextMatchOptions = TextMatchOptions()
         private var matchRanges: [NSRange] = []
+        private var lastMatches: [TextMatch] = []
         private var currentMatchIdx: Int = 0
 
         init(parent: EditorView_iOS) {
@@ -93,6 +95,8 @@ struct EditorView_iOS: UIViewRepresentable {
                 attachedFindState = state
                 state?.editorNavigateToNext = { [weak self] in self?.navigateToNextMatch() }
                 state?.editorNavigateToPrevious = { [weak self] in self?.navigateToPreviousMatch() }
+                state?.editorPerformReplace = { [weak self] in self?.performReplaceCurrent() }
+                state?.editorPerformReplaceAll = { [weak self] in self?.performReplaceAll() }
             }
             guard let state else {
                 if lastFindVisible {
@@ -110,31 +114,71 @@ struct EditorView_iOS: UIViewRepresentable {
                 lastFindQuery = ""
                 return
             }
-            if !lastFindVisible || state.query != lastFindQuery {
+            let currentOptions = TextMatchOptions(
+                caseSensitive: state.caseSensitive,
+                useRegex: state.useRegex
+            )
+            if !lastFindVisible || state.query != lastFindQuery || currentOptions != lastFindOptions {
                 lastFindVisible = true
                 lastFindQuery = state.query
+                lastFindOptions = currentOptions
                 performFind(for: state)
             }
         }
 
         private func performFind(for state: FindState) {
             guard let textView else { return }
-            let ranges = TextMatcher.ranges(of: state.query, in: textView.text ?? "")
-            matchRanges = ranges
-            currentMatchIdx = 0
+            guard recomputeMatches(for: state) else { return }
             applyFindHighlights()
-
-            DispatchQueue.main.async { [weak self, weak state] in
-                guard let state, state.activeMode == .edit else { return }
-                state.matchCount = ranges.count
-                state.currentIndex = ranges.isEmpty ? 0 : 1
-                state.resultsAreStale = false
-                _ = self
-            }
-
-            if let first = ranges.first {
+            if let first = matchRanges.first {
                 textView.scrollRangeToVisible(first)
             }
+        }
+
+        /// Recomputes matches without painting highlights or scrolling.
+        /// Returns false on empty/error so the caller can short-circuit.
+        @discardableResult
+        private func recomputeMatches(for state: FindState) -> Bool {
+            guard let textView else { return false }
+            let options = TextMatchOptions(
+                caseSensitive: state.caseSensitive,
+                useRegex: state.useRegex
+            )
+
+            let matches: [TextMatch]
+            do {
+                matches = try TextMatcher.matches(of: state.query, in: textView.text ?? "", options: options)
+            } catch let TextMatcherError.invalidRegex(message) {
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                clearFindHighlights()
+                DispatchQueue.main.async { [weak state] in
+                    guard let state, state.activeMode == .edit else { return }
+                    state.matchCount = 0
+                    state.currentIndex = 0
+                    state.resultsAreStale = false
+                    state.regexError = message
+                    state.lastReplaceCount = nil
+                }
+                return false
+            } catch {
+                matches = []
+            }
+
+            matchRanges = matches.map(\.range)
+            lastMatches = matches
+            currentMatchIdx = 0
+
+            DispatchQueue.main.async { [weak state] in
+                guard let state, state.activeMode == .edit else { return }
+                state.matchCount = matches.count
+                state.currentIndex = matches.isEmpty ? 0 : 1
+                state.resultsAreStale = false
+                state.regexError = nil
+                state.lastReplaceCount = nil
+            }
+            return true
         }
 
         private func navigateToNextMatch() {
@@ -180,7 +224,7 @@ struct EditorView_iOS: UIViewRepresentable {
         private func applyFindHighlights() {
             guard let textView else { return }
             let storage = textView.textStorage
-            rerunSyntaxHighlighter(on: storage)
+            resetBackgroundsThenRehighlight(storage: storage)
             storage.beginEditing()
             for (i, range) in matchRanges.enumerated() {
                 guard range.upperBound <= storage.length else { continue }
@@ -192,9 +236,119 @@ struct EditorView_iOS: UIViewRepresentable {
 
         private func clearFindHighlights() {
             guard let textView else { return }
-            rerunSyntaxHighlighter(on: textView.textStorage)
+            resetBackgroundsThenRehighlight(storage: textView.textStorage)
             matchRanges = []
+            lastMatches = []
             currentMatchIdx = 0
+        }
+
+        /// Wipe every `.backgroundColor` attribute, then re-run the syntax
+        /// highlighter so `==highlight==` markdown backgrounds get repainted.
+        /// Without the explicit wipe, find paints from previous queries (e.g.
+        /// the partial matches on each keystroke) stay attached to text storage
+        /// since the highlighter only adds attributes, never clears them.
+        private func resetBackgroundsThenRehighlight(storage: NSTextStorage) {
+            let fullRange = NSRange(location: 0, length: storage.length)
+            storage.beginEditing()
+            storage.removeAttribute(.backgroundColor, range: fullRange)
+            storage.endEditing()
+            rerunSyntaxHighlighter(on: storage)
+        }
+
+        // MARK: - Replace
+
+        private func performReplaceCurrent() {
+            guard let textView, let state = attachedFindState,
+                  !lastMatches.isEmpty,
+                  currentMatchIdx < lastMatches.count else { return }
+            let match = lastMatches[currentMatchIdx]
+            let oldText = textView.text ?? ""
+            let nsText = oldText as NSString
+            guard match.range.upperBound <= nsText.length else { return }
+            let replacement = ReplaceEngine.substitution(for: match,
+                                                         in: oldText,
+                                                         template: state.replacementText,
+                                                         isRegex: state.useRegex)
+            let resumeLocation = match.range.location + (replacement as NSString).length
+            applyTextReplacement(in: textView, fullOldText: oldText,
+                                 replaceRange: match.range,
+                                 replacement: replacement,
+                                 actionName: "Replace")
+            // Silent rescan against the now-updated text, then highlight + scroll
+            // to the first remaining match at-or-after the replacement end. Skips
+            // any match the replacement string itself may have introduced and
+            // avoids the double-paint that calling performFind would cause.
+            recomputeMatches(for: state)
+            guard !lastMatches.isEmpty else { return }
+            currentMatchIdx = lastMatches.firstIndex(where: { $0.range.location >= resumeLocation }) ?? 0
+            applyFindHighlights()
+            textView.scrollRangeToVisible(matchRanges[currentMatchIdx])
+            let idx = currentMatchIdx
+            DispatchQueue.main.async { [weak state] in
+                guard let state, state.activeMode == .edit else { return }
+                state.currentIndex = idx + 1
+            }
+        }
+
+        private func performReplaceAll() {
+            guard let textView, let state = attachedFindState, !lastMatches.isEmpty else { return }
+            let oldText = textView.text ?? ""
+            let nsOldText = oldText as NSString
+            let newText = ReplaceEngine.applyAll(matches: lastMatches,
+                                                 in: oldText,
+                                                 template: state.replacementText,
+                                                 isRegex: state.useRegex)
+            let fullRange = NSRange(location: 0, length: nsOldText.length)
+            let replaceCount = lastMatches.count
+            applyTextReplacement(in: textView, fullOldText: oldText,
+                                 replaceRange: fullRange,
+                                 replacement: newText,
+                                 actionName: "Replace All")
+            DispatchQueue.main.async { [weak state] in
+                state?.lastReplaceCount = replaceCount
+            }
+            // Clear the "Replaced N" label after a beat so it doesn't linger.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak state] in
+                if state?.lastReplaceCount == replaceCount {
+                    state?.lastReplaceCount = nil
+                }
+            }
+        }
+
+        /// Apply a programmatic edit that's reversible via UndoManager.
+        /// Single full-text replace produces one undo step and one
+        /// `textViewDidChange` pass that runs the highlighter end-to-end.
+        /// The textViewDidChange callback bumps `pendingBindingUpdates` itself,
+        /// so this method doesn't need to touch that counter.
+        private func applyTextReplacement(in textView: ClearlyUITextView,
+                                          fullOldText: String,
+                                          replaceRange: NSRange,
+                                          replacement: String,
+                                          actionName: String) {
+            let nsOld = fullOldText as NSString
+            let newText = nsOld.replacingCharacters(in: replaceRange, with: replacement)
+            let undoManager = textView.undoManager
+            undoManager?.beginUndoGrouping()
+            undoManager?.registerUndo(withTarget: textView) { [weak self] tv in
+                self?.applyUndoneText(in: tv, restoredText: fullOldText)
+            }
+            undoManager?.setActionName(actionName)
+            textView.text = newText
+            textView.delegate?.textViewDidChange?(textView)
+            undoManager?.endUndoGrouping()
+        }
+
+        /// Inverse of `applyTextReplacement` — restores the prior text and
+        /// re-registers the redo so the next ⌘⇧Z plays the change back.
+        private func applyUndoneText(in textView: UITextView, restoredText: String) {
+            guard let ctv = textView as? ClearlyUITextView else { return }
+            let currentText = ctv.text ?? ""
+            let undoManager = ctv.undoManager
+            undoManager?.registerUndo(withTarget: ctv) { [weak self] tv in
+                self?.applyUndoneText(in: tv, restoredText: currentText)
+            }
+            ctv.text = restoredText
+            ctv.delegate?.textViewDidChange?(ctv)
         }
 
         private func rerunSyntaxHighlighter(on storage: NSTextStorage) {
@@ -233,8 +387,9 @@ struct EditorView_iOS: UIViewRepresentable {
             lastAppliedText = newText
 
             // External text replacement (file load/revert) — old match ranges are stale.
-            if !matchRanges.isEmpty {
+            if !matchRanges.isEmpty || !lastMatches.isEmpty {
                 matchRanges = []
+                lastMatches = []
                 currentMatchIdx = 0
                 if let state = attachedFindState, state.isVisible, state.activeMode == .edit {
                     DispatchQueue.main.async { [weak state] in

--- a/Clearly/iOS/FindOverlay_iOS.swift
+++ b/Clearly/iOS/FindOverlay_iOS.swift
@@ -4,11 +4,41 @@ import ClearlyCore
 
 struct FindOverlay_iOS: View {
     @ObservedObject var findState: FindState
-    @FocusState private var isFieldFocused: Bool
+    @FocusState private var focus: Field?
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private enum Field: Hashable { case find, replace }
+
+    private var hasRegexError: Bool { findState.regexError != nil }
+    private var isCompact: Bool { horizontalSizeClass == .compact }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            findRow
+            if findState.showReplace {
+                replaceRow
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Theme.backgroundColorSwiftUI)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Theme.separatorColor(inDark: colorScheme == .dark))
+                .frame(height: 1)
+        }
+        .animation(Theme.Motion.smooth, value: findState.showReplace)
+        .onAppear { focus = .find }
+        .onChange(of: findState.focusRequest) { _, _ in focus = .find }
+        .onChange(of: findState.replaceFocusRequest) { _, _ in focus = .replace }
+    }
+
+    private var findRow: some View {
         HStack(spacing: 8) {
+            chevronButton
+
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.tertiary)
@@ -20,26 +50,18 @@ struct FindOverlay_iOS: View {
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .submitLabel(.search)
-                    .focused($isFieldFocused)
+                    .focused($focus, equals: .find)
                     .onSubmit { findState.navigateToNext?() }
 
-                if !findState.query.isEmpty && !findState.resultsAreStale {
-                    if findState.matchCount > 0 {
-                        Text("\(findState.currentIndex) of \(findState.matchCount)")
-                            .font(Theme.Typography.findCount)
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    } else {
-                        Text("No results")
-                            .font(Theme.Typography.findCount)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                FindOptionToggle_iOS(label: "Aa", help: "Match case", isOn: $findState.caseSensitive)
+                FindOptionToggle_iOS(label: ".*", help: "Regular expression", isOn: $findState.useRegex)
+
+                statusText
 
                 if !findState.query.isEmpty {
                     Button {
                         findState.query = ""
-                        isFieldFocused = true
+                        focus = .find
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(.tertiary)
@@ -57,16 +79,21 @@ struct FindOverlay_iOS: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(Theme.accentColorSwiftUI.opacity(isFieldFocused ? 0.4 : 0), lineWidth: 1)
-                    .animation(Theme.Motion.hover, value: isFieldFocused)
+                    .strokeBorder(borderColor, lineWidth: 1)
+                    .animation(Theme.Motion.hover, value: focus)
+                    .animation(Theme.Motion.hover, value: hasRegexError)
             )
 
-            HStack(spacing: 2) {
-                FindNavButton_iOS(icon: "chevron.up", disabled: !findState.canNavigate) {
-                    findState.navigateToPrevious?()
-                }
-                FindNavButton_iOS(icon: "chevron.down", disabled: !findState.canNavigate) {
-                    findState.navigateToNext?()
+            // Compact-width: drop prev/next from row 1 when replace is open;
+            // the replace row already gives Replace+advance and Replace All.
+            if !(isCompact && findState.showReplace) {
+                HStack(spacing: 2) {
+                    FindNavButton_iOS(icon: "chevron.up", disabled: !findState.canNavigate) {
+                        findState.navigateToPrevious?()
+                    }
+                    FindNavButton_iOS(icon: "chevron.down", disabled: !findState.canNavigate) {
+                        findState.navigateToNext?()
+                    }
                 }
             }
 
@@ -77,18 +104,101 @@ struct FindOverlay_iOS: View {
             .font(.system(size: 14, weight: .medium))
             .foregroundStyle(Theme.accentColorSwiftUI)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(Theme.backgroundColorSwiftUI)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(Theme.separatorColor(inDark: colorScheme == .dark))
-                .frame(height: 1)
+    }
+
+    private var replaceRow: some View {
+        HStack(spacing: 8) {
+            chevronSpacer
+
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.uturn.forward")
+                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 13))
+
+                TextField("Replace", text: $findState.replacementText)
+                    .textFieldStyle(.plain)
+                    .font(Theme.Typography.findField)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .submitLabel(.done)
+                    .focused($focus, equals: .replace)
+                    .onSubmit { findState.editorPerformReplace?() }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Theme.accentColorSwiftUI.opacity(focus == .replace ? 0.4 : 0), lineWidth: 1)
+                    .animation(Theme.Motion.hover, value: focus)
+            )
+
+            Button("All") { findState.editorPerformReplaceAll?() }
+                .buttonStyle(.plain)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(findState.canReplaceAll ? Theme.accentColorSwiftUI : Color.secondary)
+                .disabled(!findState.canReplaceAll)
+
+            Button("Replace") { findState.editorPerformReplace?() }
+                .buttonStyle(.plain)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(findState.canReplace ? Theme.accentColorSwiftUI : Color.secondary)
+                .disabled(!findState.canReplace)
         }
-        .onAppear { isFieldFocused = true }
-        .onChange(of: findState.focusRequest) { _, _ in
-            isFieldFocused = true
+    }
+
+    private var chevronButton: some View {
+        Button {
+            findState.showReplace.toggle()
+            findState.lastReplaceCount = nil
+        } label: {
+            Image(systemName: findState.showReplace ? "chevron.down" : "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 24, height: 32)
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(findState.showReplace ? "Hide replace" : "Show replace")
+    }
+
+    private var chevronSpacer: some View {
+        Color.clear.frame(width: 24, height: 32)
+    }
+
+    @ViewBuilder
+    private var statusText: some View {
+        if let count = findState.lastReplaceCount {
+            Text(count == 1 ? "Replaced 1" : "Replaced \(count)")
+                .font(Theme.Typography.findCount)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        } else if let error = findState.regexError {
+            Text(error)
+                .font(Theme.Typography.findCount)
+                .foregroundStyle(.red.opacity(0.8))
+                .lineLimit(1)
+        } else if !findState.query.isEmpty && !findState.resultsAreStale {
+            if findState.matchCount > 0 {
+                Text("\(findState.currentIndex) of \(findState.matchCount)")
+                    .font(Theme.Typography.findCount)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            } else {
+                Text("No results")
+                    .font(Theme.Typography.findCount)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var borderColor: Color {
+        if hasRegexError { return Color.red.opacity(0.5) }
+        if focus == .find { return Theme.accentColorSwiftUI.opacity(0.4) }
+        return Color.clear
     }
 }
 
@@ -107,6 +217,27 @@ private struct FindNavButton_iOS: View {
         }
         .buttonStyle(.plain)
         .disabled(disabled)
+    }
+}
+
+private struct FindOptionToggle_iOS: View {
+    let label: String
+    let help: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Button(action: { isOn.toggle() }) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(isOn ? Theme.accentColorSwiftUI : Color.secondary)
+                .frame(width: 22, height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isOn ? Theme.accentColorSwiftUI.opacity(0.18) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(help)
     }
 }
 #endif

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -7,7 +7,9 @@ import {
   SearchQuery,
   setSearchQuery,
   findNext,
-  findPrevious
+  findPrevious,
+  replaceNext,
+  replaceAll
 } from "@codemirror/search";
 import {
   Decoration,
@@ -25,7 +27,7 @@ declare global {
       mount: (payload: MountPayload) => void;
       setDocument: (payload: { markdown: string }) => void;
       setTheme: (payload: ThemePayload) => void;
-      setFindQuery: (payload: { query: string }) => void;
+      setFindQuery: (payload: FindQueryPayload) => void;
       applyCommand: (payload: { command: string }) => void;
       scrollToLine: (payload: { line: number }) => void;
       scrollToOffset: (payload: { offset: number }) => void;
@@ -70,6 +72,13 @@ type ThemePayload = {
 };
 
 type ActiveRange = { from: number; to: number };
+type FindQueryPayload = {
+  query: string;
+  replacement?: string;
+  caseSensitive?: boolean;
+  wholeWord?: boolean;
+  useRegex?: boolean;
+};
 
 const root = document.getElementById("editor");
 const themeCompartment = new Compartment();
@@ -79,6 +88,10 @@ const markdownIt = new MarkdownIt({ html: true, linkify: true, breaks: false });
 let editor: EditorView | null = null;
 let currentFilePath = "";
 let currentQuery = "";
+let currentReplacement = "";
+let currentCaseSensitive = false;
+let currentWholeWord = false;
+let currentUseRegex = false;
 let currentAppearance: "light" | "dark" = "light";
 let currentFontSize = 16;
 let isApplyingHostUpdate = false;
@@ -732,44 +745,69 @@ function sliceBetweenLines(state: EditorState, startLineNumber: number, endLineN
   return state.sliceDoc(state.doc.line(startLineNumber).from, state.doc.line(endLineNumber).to);
 }
 
-function updateFindStatus(state: EditorState) {
+function currentSearchQuery() {
+  return new SearchQuery({
+    search: currentQuery,
+    replace: currentReplacement,
+    caseSensitive: currentCaseSensitive,
+    wholeWord: currentWholeWord,
+    regexp: currentUseRegex,
+    literal: !currentUseRegex
+  });
+}
+
+function collectMatches(state: EditorState) {
   if (!currentQuery) {
-    postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0 });
-    return;
+    return { matches: [] as ActiveRange[], regexError: undefined as string | undefined };
   }
 
-  const text = state.doc.toString();
-  const query = currentQuery.toLowerCase();
-  const lower = text.toLowerCase();
-  const positions: number[] = [];
-  let start = 0;
+  const query = currentSearchQuery();
+  if (!query.valid) {
+    return { matches: [] as ActiveRange[], regexError: "Invalid regular expression" };
+  }
 
-  while (start < lower.length) {
-    const found = lower.indexOf(query, start);
-    if (found === -1) {
-      break;
+  const cursor = query.getCursor(state);
+  const matches: ActiveRange[] = [];
+  for (let result = cursor.next(); !result.done; result = cursor.next()) {
+    const match = result.value as ActiveRange;
+    if (match.to > match.from) {
+      matches.push({ from: match.from, to: match.to });
     }
-    positions.push(found);
-    start = found + Math.max(1, query.length);
+  }
+  return { matches, regexError: undefined as string | undefined };
+}
+
+function currentMatch(state: EditorState) {
+  const { matches } = collectMatches(state);
+  if (!matches.length) {
+    return null;
   }
 
-  if (!positions.length) {
-    postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0 });
+  const selection = state.selection.main;
+  return matches.find((match) => match.from === selection.from && match.to === selection.to)
+    ?? matches.find((match) => match.from >= selection.from)
+    ?? matches[0];
+}
+
+function updateFindStatus(state: EditorState) {
+  const { matches, regexError } = collectMatches(state);
+  if (!currentQuery || regexError || !matches.length) {
+    postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0, regexError });
     return;
   }
 
-  const anchor = state.selection.main.from;
-  let currentIndex = positions.findIndex((position) => position === anchor);
+  const selection = state.selection.main;
+  let currentIndex = matches.findIndex((match) => match.from === selection.from && match.to === selection.to);
   if (currentIndex === -1) {
-    currentIndex = positions.findIndex((position) => position >= anchor);
+    currentIndex = matches.findIndex((match) => match.from >= selection.from);
   }
   if (currentIndex === -1) {
-    currentIndex = positions.length - 1;
+    currentIndex = matches.length - 1;
   }
 
   postMessage({
     type: "findStatus",
-    matchCount: positions.length,
+    matchCount: matches.length,
     currentIndex: currentIndex + 1
   });
 }
@@ -1048,6 +1086,28 @@ function applyFormattingCommand(command: string) {
       findPrevious(editor);
       updateFindStatus(editor.state);
       break;
+    case "replaceCurrent": {
+      const match = currentMatch(editor.state);
+      if (!match) {
+        updateFindStatus(editor.state);
+        break;
+      }
+      editor.dispatch({ selection: { anchor: match.from, head: match.to } });
+      replaceNext(editor);
+      updateFindStatus(editor.state);
+      break;
+    }
+    case "replaceAll": {
+      const replaceCount = collectMatches(editor.state).matches.length;
+      if (!replaceCount) {
+        updateFindStatus(editor.state);
+        break;
+      }
+      replaceAll(editor);
+      updateFindStatus(editor.state);
+      postMessage({ type: "replaceStatus", replaceCount });
+      break;
+    }
     default:
       log(`Unknown command: ${command}`);
   }
@@ -1908,18 +1968,18 @@ function setTheme(payload: ThemePayload) {
   });
 }
 
-function setFindQuery(query: string) {
-  currentQuery = query;
+function setFindQuery(payload: FindQueryPayload | string) {
+  const next = typeof payload === "string" ? { query: payload } : payload;
+  currentQuery = next.query;
+  currentReplacement = next.replacement ?? currentReplacement;
+  currentCaseSensitive = next.caseSensitive ?? currentCaseSensitive;
+  currentWholeWord = next.wholeWord ?? currentWholeWord;
+  currentUseRegex = next.useRegex ?? currentUseRegex;
   if (!editor) {
     return;
   }
   editor.dispatch({
-    effects: setSearchQuery.of(new SearchQuery({
-      search: query,
-      caseSensitive: false,
-      regexp: false,
-      literal: true
-    }))
+    effects: setSearchQuery.of(currentSearchQuery())
   });
   updateFindStatus(editor.state);
 }
@@ -1989,8 +2049,8 @@ window.clearlyLiveEditor = {
     setTheme(payload);
   },
 
-  setFindQuery(payload: { query: string }) {
-    setFindQuery(payload.query);
+  setFindQuery(payload: FindQueryPayload) {
+    setFindQuery(payload);
   },
 
   applyCommand(payload: { command: string }) {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/FindState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/FindState.swift
@@ -9,15 +9,33 @@ public final class FindState: ObservableObject {
     @Published public var currentIndex = 0 // 1-based, 0 = no matches
     @Published public var resultsAreStale = false
     @Published public var focusRequest = UUID()
+    @Published public var replaceFocusRequest = UUID()
     public var activeMode: ViewMode = .edit
+
+    @Published public var replacementText = ""
+    @Published public var showReplace = false
+    @Published public var caseSensitive = false
+    @Published public var useRegex = false
+    @Published public var regexError: String?
+    @Published public var lastReplaceCount: Int?
 
     public var editorNavigateToNext: (() -> Void)?
     public var editorNavigateToPrevious: (() -> Void)?
     public var previewNavigateToNext: (() -> Void)?
     public var previewNavigateToPrevious: (() -> Void)?
+    public var editorPerformReplace: (() -> Void)?
+    public var editorPerformReplaceAll: (() -> Void)?
 
     public var canNavigate: Bool {
-        !query.isEmpty && (resultsAreStale || matchCount > 0)
+        !query.isEmpty && (activeMode == .preview || regexError == nil) && (resultsAreStale || matchCount > 0)
+    }
+
+    public var canReplace: Bool {
+        activeMode == .edit && regexError == nil && !query.isEmpty && matchCount > 0
+    }
+
+    public var canReplaceAll: Bool {
+        activeMode == .edit && regexError == nil && !query.isEmpty && matchCount > 0
     }
 
     public var navigateToNext: (() -> Void)? {
@@ -53,5 +71,6 @@ public final class FindState: ObservableObject {
 
     public func dismiss() {
         isVisible = false
+        lastReplaceCount = nil
     }
 }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/ReplaceEngine.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/ReplaceEngine.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum ReplaceEngine {
+    public static func substitution(for match: TextMatch, in text: String,
+                                    template: String, isRegex: Bool) -> String {
+        guard isRegex else { return template }
+        let captures = captureStrings(for: match, in: text)
+        return expandTemplate(template, captures: captures)
+    }
+
+    public static func applyAll(matches: [TextMatch], in text: String,
+                                template: String, isRegex: Bool) -> String {
+        guard !matches.isEmpty else { return text }
+        let result = NSMutableString(string: text)
+        for match in matches.reversed() {
+            let replacement: String
+            if isRegex {
+                replacement = expandTemplate(template, captures: captureStrings(for: match, in: text))
+            } else {
+                replacement = template
+            }
+            result.replaceCharacters(in: match.range, with: replacement)
+        }
+        return result as String
+    }
+
+    private static func captureStrings(for match: TextMatch, in text: String) -> [String] {
+        let nsText = text as NSString
+        return match.captureRanges.map { range in
+            guard range.location != NSNotFound else { return "" }
+            return nsText.substring(with: range)
+        }
+    }
+
+    /// Expand `$0`–`$9` and `\\`, `\$` escapes inside `template` using captured groups.
+    /// Matches NSRegularExpression template semantics for the single-digit cases users
+    /// will reach for in a find-bar replacement field.
+    private static func expandTemplate(_ template: String, captures: [String]) -> String {
+        var output = ""
+        output.reserveCapacity(template.count)
+        let chars = Array(template)
+        var i = 0
+        while i < chars.count {
+            let ch = chars[i]
+            if ch == "\\", i + 1 < chars.count {
+                output.append(chars[i + 1])
+                i += 2
+                continue
+            }
+            if ch == "$", i + 1 < chars.count, let digit = chars[i + 1].wholeNumberValue, chars[i + 1].isASCII {
+                if digit < captures.count {
+                    output.append(captures[digit])
+                }
+                i += 2
+                continue
+            }
+            output.append(ch)
+            i += 1
+        }
+        return output
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/TextMatcher.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/TextMatcher.swift
@@ -1,19 +1,98 @@
 import Foundation
 
+public struct TextMatch: Equatable, Sendable {
+    public let range: NSRange
+    public let captureRanges: [NSRange]
+
+    public init(range: NSRange, captureRanges: [NSRange] = []) {
+        self.range = range
+        self.captureRanges = captureRanges
+    }
+}
+
+public struct TextMatchOptions: Equatable, Sendable {
+    public var caseSensitive: Bool
+    public var wholeWord: Bool
+    public var useRegex: Bool
+
+    public init(caseSensitive: Bool = false, wholeWord: Bool = false, useRegex: Bool = false) {
+        self.caseSensitive = caseSensitive
+        self.wholeWord = wholeWord
+        self.useRegex = useRegex
+    }
+}
+
+public enum TextMatcherError: Error, Equatable {
+    case invalidRegex(String)
+}
+
 public enum TextMatcher {
-    public static func ranges(of query: String, in text: String, caseSensitive: Bool = false) -> [NSRange] {
+    public static func matches(of query: String, in text: String,
+                               options: TextMatchOptions = TextMatchOptions()) throws -> [TextMatch] {
         guard !query.isEmpty else { return [] }
-        let nsText = text as NSString
-        var ranges: [NSRange] = []
-        var searchRange = NSRange(location: 0, length: nsText.length)
-        let options: NSString.CompareOptions = caseSensitive ? [] : .caseInsensitive
-        while searchRange.location < nsText.length {
-            let found = nsText.range(of: query, options: options, range: searchRange)
-            if found.location == NSNotFound { break }
-            ranges.append(found)
-            searchRange.location = found.upperBound
-            searchRange.length = nsText.length - searchRange.location
+
+        let pattern: String
+        if options.useRegex {
+            pattern = options.wholeWord ? "\\b(?:\(query))\\b" : query
+        } else {
+            let escaped = NSRegularExpression.escapedPattern(for: query)
+            pattern = options.wholeWord ? "\\b\(escaped)\\b" : escaped
         }
-        return ranges
+
+        var regexOptions: NSRegularExpression.Options = []
+        if !options.caseSensitive { regexOptions.insert(.caseInsensitive) }
+
+        let regex: NSRegularExpression
+        do {
+            regex = try compiledRegex(pattern: pattern, options: regexOptions)
+        } catch {
+            throw TextMatcherError.invalidRegex(error.localizedDescription)
+        }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var results: [TextMatch] = []
+        regex.enumerateMatches(in: text, options: [], range: fullRange) { result, _, _ in
+            guard let result = result, result.range.location != NSNotFound, result.range.length > 0 else { return }
+            var captures: [NSRange] = []
+            captures.reserveCapacity(result.numberOfRanges)
+            for i in 0..<result.numberOfRanges {
+                captures.append(result.range(at: i))
+            }
+            results.append(TextMatch(range: result.range, captureRanges: captures))
+        }
+        return results
+    }
+
+    public static func ranges(of query: String, in text: String, caseSensitive: Bool = false) -> [NSRange] {
+        let opts = TextMatchOptions(caseSensitive: caseSensitive, wholeWord: false, useRegex: false)
+        return (try? matches(of: query, in: text, options: opts).map(\.range)) ?? []
+    }
+
+    private struct RegexCacheKey: Hashable {
+        let pattern: String
+        let options: UInt
+    }
+
+    private static let cacheLock = NSLock()
+    nonisolated(unsafe) private static var regexCache: [RegexCacheKey: NSRegularExpression] = [:]
+    private static let cacheLimit = 32
+
+    private static func compiledRegex(pattern: String, options: NSRegularExpression.Options) throws -> NSRegularExpression {
+        let key = RegexCacheKey(pattern: pattern, options: options.rawValue)
+        cacheLock.lock()
+        if let cached = regexCache[key] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let regex = try NSRegularExpression(pattern: pattern, options: options)
+
+        cacheLock.lock()
+        if regexCache.count >= cacheLimit { regexCache.removeAll(keepingCapacity: true) }
+        regexCache[key] = regex
+        cacheLock.unlock()
+        return regex
     }
 }

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ReplaceEngineTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ReplaceEngineTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import ClearlyCore
+
+final class ReplaceEngineTests: XCTestCase {
+    func testPlainSubstitutionIgnoresTemplateMetacharacters() {
+        let match = TextMatch(range: NSRange(location: 0, length: 3), captureRanges: [])
+        XCTAssertEqual(
+            ReplaceEngine.substitution(for: match, in: "foo bar", template: "$1!", isRegex: false),
+            "$1!"
+        )
+    }
+
+    func testRegexCaptureGroupSubstitution() throws {
+        let matches = try TextMatcher.matches(of: "(\\w+)@(\\w+)",
+                                              in: "hi alice@example world",
+                                              options: TextMatchOptions(useRegex: true))
+        XCTAssertEqual(matches.count, 1)
+        let result = ReplaceEngine.substitution(for: matches[0],
+                                                in: "hi alice@example world",
+                                                template: "<$1 at $2>",
+                                                isRegex: true)
+        XCTAssertEqual(result, "<alice at example>")
+    }
+
+    func testReplaceAllPreservesOrderAndIndices() throws {
+        let text = "ab ab ab"
+        let matches = try TextMatcher.matches(of: "ab", in: text, options: TextMatchOptions())
+        XCTAssertEqual(matches.count, 3)
+        let out = ReplaceEngine.applyAll(matches: matches, in: text, template: "X", isRegex: false)
+        XCTAssertEqual(out, "X X X")
+    }
+
+    func testReplaceAllRegexExpandsCaptures() throws {
+        let text = "alpha beta gamma"
+        let matches = try TextMatcher.matches(of: "(\\w+)", in: text, options: TextMatchOptions(useRegex: true))
+        XCTAssertEqual(matches.count, 3)
+        let out = ReplaceEngine.applyAll(matches: matches, in: text, template: "[$1]", isRegex: true)
+        XCTAssertEqual(out, "[alpha] [beta] [gamma]")
+    }
+
+    func testEscapedDollarSignIsLiteral() throws {
+        let matches = try TextMatcher.matches(of: "(\\w+)", in: "hello", options: TextMatchOptions(useRegex: true))
+        let out = ReplaceEngine.substitution(for: matches[0], in: "hello", template: "\\$1=$1", isRegex: true)
+        XCTAssertEqual(out, "$1=hello")
+    }
+
+    func testWholeWordOptionMatchesOnlyWordBoundaries() throws {
+        let matches = try TextMatcher.matches(
+            of: "cat",
+            in: "concatenate the cat",
+            options: TextMatchOptions(wholeWord: true)
+        )
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches[0].range, NSRange(location: 16, length: 3))
+    }
+
+    func testInvalidRegexThrows() {
+        XCTAssertThrowsError(
+            try TextMatcher.matches(of: "[invalid", in: "anything", options: TextMatchOptions(useRegex: true))
+        ) { error in
+            guard case TextMatcherError.invalidRegex = error else {
+                return XCTFail("Expected invalidRegex, got \(error)")
+            }
+        }
+    }
+}

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -31324,6 +31324,10 @@
   var editor = null;
   var currentFilePath = "";
   var currentQuery = "";
+  var currentReplacement = "";
+  var currentCaseSensitive = false;
+  var currentWholeWord = false;
+  var currentUseRegex = false;
   var currentAppearance = "light";
   var currentFontSize = 16;
   var isApplyingHostUpdate = false;
@@ -31866,39 +31870,59 @@
     }
     return state.sliceDoc(state.doc.line(startLineNumber).from, state.doc.line(endLineNumber).to);
   }
-  function updateFindStatus(state) {
+  function currentSearchQuery() {
+    return new SearchQuery({
+      search: currentQuery,
+      replace: currentReplacement,
+      caseSensitive: currentCaseSensitive,
+      wholeWord: currentWholeWord,
+      regexp: currentUseRegex,
+      literal: !currentUseRegex
+    });
+  }
+  function collectMatches(state) {
     if (!currentQuery) {
-      postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0 });
-      return;
+      return { matches: [], regexError: void 0 };
     }
-    const text2 = state.doc.toString();
-    const query = currentQuery.toLowerCase();
-    const lower = text2.toLowerCase();
-    const positions = [];
-    let start = 0;
-    while (start < lower.length) {
-      const found = lower.indexOf(query, start);
-      if (found === -1) {
-        break;
+    const query = currentSearchQuery();
+    if (!query.valid) {
+      return { matches: [], regexError: "Invalid regular expression" };
+    }
+    const cursor = query.getCursor(state);
+    const matches = [];
+    for (let result = cursor.next(); !result.done; result = cursor.next()) {
+      const match2 = result.value;
+      if (match2.to > match2.from) {
+        matches.push({ from: match2.from, to: match2.to });
       }
-      positions.push(found);
-      start = found + Math.max(1, query.length);
     }
-    if (!positions.length) {
-      postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0 });
+    return { matches, regexError: void 0 };
+  }
+  function currentMatch(state) {
+    const { matches } = collectMatches(state);
+    if (!matches.length) {
+      return null;
+    }
+    const selection = state.selection.main;
+    return matches.find((match2) => match2.from === selection.from && match2.to === selection.to) ?? matches.find((match2) => match2.from >= selection.from) ?? matches[0];
+  }
+  function updateFindStatus(state) {
+    const { matches, regexError } = collectMatches(state);
+    if (!currentQuery || regexError || !matches.length) {
+      postMessage({ type: "findStatus", matchCount: 0, currentIndex: 0, regexError });
       return;
     }
-    const anchor = state.selection.main.from;
-    let currentIndex = positions.findIndex((position) => position === anchor);
+    const selection = state.selection.main;
+    let currentIndex = matches.findIndex((match2) => match2.from === selection.from && match2.to === selection.to);
     if (currentIndex === -1) {
-      currentIndex = positions.findIndex((position) => position >= anchor);
+      currentIndex = matches.findIndex((match2) => match2.from >= selection.from);
     }
     if (currentIndex === -1) {
-      currentIndex = positions.length - 1;
+      currentIndex = matches.length - 1;
     }
     postMessage({
       type: "findStatus",
-      matchCount: positions.length,
+      matchCount: matches.length,
       currentIndex: currentIndex + 1
     });
   }
@@ -32161,6 +32185,28 @@ $$`);
         findPrevious(editor);
         updateFindStatus(editor.state);
         break;
+      case "replaceCurrent": {
+        const match2 = currentMatch(editor.state);
+        if (!match2) {
+          updateFindStatus(editor.state);
+          break;
+        }
+        editor.dispatch({ selection: { anchor: match2.from, head: match2.to } });
+        replaceNext(editor);
+        updateFindStatus(editor.state);
+        break;
+      }
+      case "replaceAll": {
+        const replaceCount = collectMatches(editor.state).matches.length;
+        if (!replaceCount) {
+          updateFindStatus(editor.state);
+          break;
+        }
+        replaceAll(editor);
+        updateFindStatus(editor.state);
+        postMessage({ type: "replaceStatus", replaceCount });
+        break;
+      }
       default:
         log(`Unknown command: ${command2}`);
     }
@@ -32942,18 +32988,18 @@ $$`);
       effects: themeCompartment.reconfigure(livePreviewTheme(payload.appearance, payload.fontSize))
     });
   }
-  function setFindQuery(query) {
-    currentQuery = query;
+  function setFindQuery(payload) {
+    const next = typeof payload === "string" ? { query: payload } : payload;
+    currentQuery = next.query;
+    currentReplacement = next.replacement ?? currentReplacement;
+    currentCaseSensitive = next.caseSensitive ?? currentCaseSensitive;
+    currentWholeWord = next.wholeWord ?? currentWholeWord;
+    currentUseRegex = next.useRegex ?? currentUseRegex;
     if (!editor) {
       return;
     }
     editor.dispatch({
-      effects: setSearchQuery.of(new SearchQuery({
-        search: query,
-        caseSensitive: false,
-        regexp: false,
-        literal: true
-      }))
+      effects: setSearchQuery.of(currentSearchQuery())
     });
     updateFindStatus(editor.state);
   }
@@ -33012,7 +33058,7 @@ $$`);
       setTheme(payload);
     },
     setFindQuery(payload) {
-      setFindQuery(payload.query);
+      setFindQuery(payload);
     },
     applyCommand(payload) {
       applyFormattingCommand(payload.command);


### PR DESCRIPTION
## Summary
- Adds find + replace + Replace All to Clearly. The existing find bar gains a chevron-toggleable replace row, case-sensitive (`Aa`) and regex (`.*`) toggles, and Replace / Replace All buttons on Mac, iOS, and the live-preview editor; ClearlyCore gets a regex-capable `TextMatcher` and a new `ReplaceEngine` (literal + `\$0`–`\$9` capture-group templates).
- iOS gains its first `UndoManager`-backed programmatic-edit path so Replace / Replace All produce a single undoable step that restores both text and syntax-highlight state.
- Documents four session learnings in `CLAUDE.md`: `@Published` willSet timing for Combine sinks, the SwiftUI `.keyboardShortcut` ⌥⌘-letter dispatch bug (with the existing `NSMenuItem` injection workaround), the iOS find-highlight `removeAttribute(.backgroundColor)` wipe requirement, and the worktree-local `-derivedDataPath` rule.

Fixes #250

## Test plan
- [ ] ⌘F shows the single-row find bar; chevron expands the replace row.
- [ ] Type a query, click Replace → replaces current match and advances to the next at-or-after the replacement end; click Replace All → all replaced in one ⌘Z step; \"Replaced N occurrences\" inline label clears after ~2.5s.
- [ ] Toggle `Aa` and `.*` after typing a query → matches re-compute live; invalid regex shows a red border.
- [ ] iOS: same flows on the simulator with hardware keyboard; verify ⌘Z after Replace All restores text *and* highlights, and that successive keystrokes don't leave stale yellow fragments behind.
- [ ] `swift test --package-path Packages/ClearlyCore` — 172/172 pass (9 existing TextMatcher + 7 new ReplaceEngine).