### PR TITLE
[shared] Foldable code blocks in preview and Live Preview

### DIFF
--- a/Clearly/LiveEditorView.swift
+++ b/Clearly/LiveEditorView.swift
@@ -114,6 +114,7 @@ struct LiveEditorView: NSViewRepresentable {
         private var hasReceivedDocChanged = false
         private var lastKnownDocumentID: UUID?
         private var lastThemeSignature = ""
+        private var lastFoldFilePath = ""
         private var lastFindQuery = ""
         private var lastFindSignature = ""
         private var lastFindVisibility = false
@@ -237,6 +238,12 @@ struct LiveEditorView: NSViewRepresentable {
                 lastKnownDocumentID = parent.documentID
                 hasReceivedDocChanged = false
             }
+            let foldFilePath = parent.fileURL?.standardizedFileURL.path ?? ""
+            var shouldApplyFolds = false
+            if foldFilePath != lastFoldFilePath {
+                lastFoldFilePath = foldFilePath
+                shouldApplyFolds = true
+            }
 
             let appearance = parent.colorScheme == .dark ? "dark" : "light"
             let themeSignature = "\(appearance)|\(parent.fontSize)|\(parent.fileURL?.path ?? "")"
@@ -255,6 +262,11 @@ struct LiveEditorView: NSViewRepresentable {
             if parent.text != lastSyncedText {
                 lastSyncedText = parent.text
                 call(function: "setDocument", payload: ["markdown": parent.text, "epoch": parent.documentEpoch])
+                shouldApplyFolds = true
+            }
+
+            if shouldApplyFolds {
+                applyPersistedFolds()
             }
 
             if parent.findState?.isVisible == true {
@@ -421,6 +433,7 @@ struct LiveEditorView: NSViewRepresentable {
             lastSyncedText = ""
             hasReceivedDocChanged = false
             lastThemeSignature = ""
+            lastFoldFilePath = ""
             call(
                 function: "mount",
                 payload: [
@@ -525,9 +538,20 @@ struct LiveEditorView: NSViewRepresentable {
                     DiagnosticLog.log("LiveEditor: \(message)")
                 }
 
+            case "foldToggle":
+                guard let id = body["key"] as? String,
+                      let folded = body["folded"] as? Bool,
+                      let foldKey = FoldKey(stableID: id) else { return }
+                FoldStateStore.shared.setFolded(folded, key: foldKey, for: parent.fileURL)
+
             default:
                 break
             }
+        }
+
+        private func applyPersistedFolds() {
+            let foldedIDs = FoldStateStore.shared.foldedKeyIDs(for: parent.fileURL)
+            call(function: "applyFolds", payload: ["keys": foldedIDs])
         }
 
         private func call(function: String, payload: [String: Any]? = nil) {

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -63,8 +63,9 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "scrollSync")
         config.userContentController.add(context.coordinator, name: "copyToClipboard")
         config.userContentController.add(context.coordinator, name: "taskToggle")
+        config.userContentController.add(context.coordinator, name: "foldToggle")
         config.userContentController.add(context.coordinator, name: "selectionCapture")
-        config.userContentController.addUserScript(Self.copyButtonUserScript())
+        config.userContentController.addUserScript(PreviewUserScripts.codeBlockChromeScript())
         let webView = DraggableWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.underPageBackgroundColor = Theme.backgroundColor
@@ -147,6 +148,8 @@ struct PreviewView: NSViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "scrollSync")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "foldToggle")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "selectionCapture")
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
@@ -706,6 +709,7 @@ struct PreviewView: NSViewRepresentable {
                 didInitialLoad = true
             }
             webView.alphaValue = 1
+            applyPersistedFolds(in: webView)
             // Restore scroll position after HTML reload
             if scrollFraction > 0.01 {
                 let js = "var ms=Math.max(1,document.body.scrollHeight-window.innerHeight);window.scrollTo(0,\(scrollFraction)*ms);"
@@ -720,6 +724,19 @@ struct PreviewView: NSViewRepresentable {
             }
             scrollToPendingLine()
             applyPendingHighlight()
+        }
+
+        private func applyPersistedFolds(in webView: WKWebView) {
+            let foldedIDs = FoldStateStore.shared.foldedKeyIDs(for: fileURL)
+            guard !foldedIDs.isEmpty else { return }
+            let payload: String
+            if let data = try? JSONSerialization.data(withJSONObject: foldedIDs),
+               let str = String(data: data, encoding: .utf8) {
+                payload = str
+            } else {
+                return
+            }
+            webView.evaluateJavaScript("window.clearlyApplyFolds && window.clearlyApplyFolds(\(payload));")
         }
 
         private func resolvedLinkURL(for href: String) -> URL? {
@@ -787,6 +804,19 @@ struct PreviewView: NSViewRepresentable {
                 return
             }
 
+            if message.name == "foldToggle",
+               let body = message.body as? [String: Any],
+               let id = body["key"] as? String,
+               let folded = body["folded"] as? Bool,
+               let foldKey = FoldKey(stableID: id) {
+                // No skipNextReload here: folding doesn't change markdown, so
+                // contentKey doesn't change and no reload is pending. The user
+                // script + applyPersistedFolds re-paint correctly on any
+                // future genuine reload.
+                FoldStateStore.shared.setFolded(folded, key: foldKey, for: fileURL)
+                return
+            }
+
             if message.name == "selectionCapture",
                let body = message.body as? [String: Any],
                let text = body["text"] as? String {
@@ -803,61 +833,4 @@ struct PreviewView: NSViewRepresentable {
         }
     }
 
-    private static func copyButtonUserScript() -> WKUserScript {
-        let copyIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"18\" height=\"18\" viewBox=\"0 0 18 18\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"M12.25 5.75H13.75C14.8546 5.75 15.75 6.6454 15.75 7.75V13.75C15.75 14.8546 14.8546 15.75 13.75 15.75H7.75C6.6454 15.75 5.75 14.8546 5.75 13.75V12.25\"></path><path d=\"M10.25 2.25H4.25C3.14543 2.25 2.25 3.14543 2.25 4.25V10.25C2.25 11.3546 3.14543 12.25 4.25 12.25H10.25C11.3546 12.25 12.25 11.3546 12.25 10.25V4.25C12.25 3.14543 11.3546 2.25 10.25 2.25Z\"></path></g></svg>"#
-        let checkIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"12\" height=\"12\" viewBox=\"0 0 12 12\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"m1.76,7.004l2.25,3L10.24,1.746\"></path></g></svg>"#
-        let source = """
-        (function() {
-            var copyIcon = '\(copyIcon)';
-            var checkIcon = '\(checkIcon)';
-            document.querySelectorAll('pre').forEach(function(pre) {
-                if (pre.closest('.frontmatter') || pre.closest('.code-block-wrapper')) return;
-                var wrapper = document.createElement('div');
-                wrapper.className = 'code-block-wrapper';
-                var prev = pre.previousElementSibling;
-                var hasFilename = prev && prev.classList.contains('code-filename');
-                if (hasFilename) {
-                    pre.parentNode.insertBefore(wrapper, prev);
-                    wrapper.appendChild(prev);
-                } else {
-                    pre.parentNode.insertBefore(wrapper, pre);
-                }
-                wrapper.appendChild(pre);
-                var btn = document.createElement('button');
-                btn.className = 'code-copy-btn';
-                if (hasFilename) {
-                    btn.style.top = (prev.offsetHeight + 6) + 'px';
-                }
-                btn.type = 'button';
-                btn.setAttribute('aria-label', 'Copy code');
-                btn.innerHTML = copyIcon;
-                btn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    var code = pre.querySelector('code');
-                    var lines = code ? code.querySelectorAll('.code-line') : null;
-                    var text;
-                    if (lines && lines.length > 0) {
-                        text = Array.from(lines).map(function(l) { return l.textContent; }).join('\\n');
-                    } else {
-                        text = code ? code.textContent : pre.textContent;
-                    }
-                    window.webkit.messageHandlers.copyToClipboard.postMessage(text);
-                    btn.classList.add('copied');
-                    btn.innerHTML = checkIcon;
-                    setTimeout(function() {
-                        btn.classList.remove('copied');
-                        btn.innerHTML = copyIcon;
-                    }, 1500);
-                });
-                wrapper.appendChild(btn);
-            });
-        })();
-        """
-        return WKUserScript(
-            source: source,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-    }
 }

--- a/Clearly/iOS/PreviewView_iOS.swift
+++ b/Clearly/iOS/PreviewView_iOS.swift
@@ -37,7 +37,7 @@ struct PreviewView_iOS: UIViewRepresentable {
     }
 
     private var contentKey: String {
-        "\(fontSize)|\(fontFamily)|\(hideFrontmatter)|\(markdown.hashValue)"
+        "\(fontSize)|\(fontFamily)|\(hideFrontmatter)|\(LocalImageSupport.fileURLKeyFragment(fileURL))|\(markdown.hashValue)"
     }
 
     func makeCoordinator() -> Coordinator {
@@ -49,6 +49,9 @@ struct PreviewView_iOS: UIViewRepresentable {
         config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         config.userContentController.add(context.coordinator, name: "linkClicked")
         config.userContentController.add(context.coordinator, name: "taskToggle")
+        config.userContentController.add(context.coordinator, name: "foldToggle")
+        config.userContentController.add(context.coordinator, name: "copyToClipboard")
+        config.userContentController.addUserScript(PreviewUserScripts.codeBlockChromeScript())
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
@@ -90,6 +93,8 @@ struct PreviewView_iOS: UIViewRepresentable {
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "foldToggle")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "copyToClipboard")
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
@@ -229,6 +234,31 @@ struct PreviewView_iOS: UIViewRepresentable {
                 }
                 return
             }
+
+            if message.name == "foldToggle",
+               let body = message.body as? [String: Any],
+               let id = body["key"] as? String,
+               let folded = body["folded"] as? Bool,
+               let foldKey = FoldKey(stableID: id) {
+                // Folding doesn't change markdown; no reload to skip. The
+                // user script + applyPersistedFolds repaint on any future
+                // reload.
+                FoldStateStore.shared.setFolded(folded, key: foldKey, for: fileURL)
+                return
+            }
+
+            if message.name == "copyToClipboard", let text = message.body as? String {
+                UIPasteboard.general.string = text
+                return
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            let foldedIDs = FoldStateStore.shared.foldedKeyIDs(for: fileURL)
+            guard !foldedIDs.isEmpty,
+                  let data = try? JSONSerialization.data(withJSONObject: foldedIDs),
+                  let payload = String(data: data, encoding: .utf8) else { return }
+            webView.evaluateJavaScript("window.clearlyApplyFolds && window.clearlyApplyFolds(\(payload));")
         }
 
         private func resolvedLinkURL(for href: String) -> URL? {

--- a/ClearlyLiveEditorWeb/package-lock.json
+++ b/ClearlyLiveEditorWeb/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@codemirror/commands": "6.10.3",
         "@codemirror/lang-markdown": "6.5.0",
+        "@codemirror/language": "6.11.3",
         "@codemirror/search": "6.6.0",
         "@codemirror/state": "6.6.0",
         "@codemirror/view": "6.41.0",
@@ -101,14 +102,14 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
-      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.5.0",
+        "@lezer/common": "^1.1.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"

--- a/ClearlyLiveEditorWeb/package.json
+++ b/ClearlyLiveEditorWeb/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@codemirror/commands": "6.10.3",
     "@codemirror/lang-markdown": "6.5.0",
+    "@codemirror/language": "6.11.3",
     "@codemirror/search": "6.6.0",
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.41.0",

--- a/ClearlyLiveEditorWeb/src/index.ts
+++ b/ClearlyLiveEditorWeb/src/index.ts
@@ -1,5 +1,13 @@
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
+import {
+  codeFolding,
+  foldEffect,
+  foldedRanges,
+  foldService,
+  syntaxTree,
+  unfoldEffect
+} from "@codemirror/language";
 import { EditorState, RangeSetBuilder, Compartment, StateEffect, StateField, type Extension } from "@codemirror/state";
 import {
   search,
@@ -34,6 +42,7 @@ declare global {
       insertText: (payload: { text: string }) => void;
       focus: () => void;
       getDocument: () => string;
+      applyFolds: (payload: { keys: string[] }) => void;
     };
     webkit?: {
       messageHandlers?: {
@@ -1444,6 +1453,250 @@ const livePreviewDecorations = StateField.define<DecorationSet>({
   provide: (field) => EditorView.decorations.from(field)
 });
 
+// --- Foldable code blocks --------------------------------------------------
+
+type FoldKeyData = { headingPath: string[]; indexUnderHeading: number };
+
+function stripInlineMarkdown(text: string): string {
+  let r = text;
+  r = r.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1");
+  r = r.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  r = r.replace(/(\*\*|__)(.+?)\1/g, "$2");
+  r = r.replace(/(?<![\w*])[*_](.+?)[*_](?![\w*])/g, "$1");
+  r = r.replace(/~~(.+?)~~/g, "$1");
+  r = r.replace(/`([^`]+)`/g, "$1");
+  return r.trim();
+}
+
+function headingTitleFromText(rawHeadingLine: string): string {
+  // Strip leading hashes + space (ATX), trailing optional `#+` closing fence,
+  // then any trailing whitespace. Matches what cmark renders into a heading's
+  // textContent on the preview side.
+  let r = rawHeadingLine.replace(/^#+\s*/, "");
+  r = r.replace(/\s+#+\s*$/, "");
+  return stripInlineMarkdown(r.trim());
+}
+
+/// Walks the syntax tree once and returns, for each FencedCode node, the
+/// stable key string identical to what the preview's DOM walker produces.
+/// Only top-level nodes (direct children of Document) are considered, mirroring
+/// the DOM walker's body.firstElementChild iteration. Returns Map<startOffset, keyString>.
+function deriveFoldKeys(state: EditorState): Map<number, string> {
+  const result = new Map<number, string>();
+  const tree = syntaxTree(state);
+  const headingStack: { level: number; title: string }[] = [];
+  const counters: number[] = [];
+  let rootCounter = 0;
+
+  // Walk direct children of the Document root only.
+  const root = tree.topNode;
+  let child = root.firstChild;
+  while (child) {
+    const name = child.name;
+    const headingMatch = /^(?:ATXHeading|SetextHeading)([1-6])$/.exec(name);
+    if (headingMatch) {
+      const level = parseInt(headingMatch[1], 10);
+      while (headingStack.length > 0 && headingStack[headingStack.length - 1].level >= level) {
+        headingStack.pop();
+        counters.pop();
+      }
+      const lineFrom = state.doc.lineAt(child.from).from;
+      const lineTo = state.doc.lineAt(child.from).to;
+      const lineText = state.doc.sliceString(lineFrom, lineTo);
+      headingStack.push({ level, title: headingTitleFromText(lineText) });
+      counters.push(0);
+    } else if (name === "FencedCode") {
+      let idx;
+      if (counters.length === 0) {
+        idx = rootCounter;
+        rootCounter += 1;
+      } else {
+        idx = counters[counters.length - 1];
+        counters[counters.length - 1] = idx + 1;
+      }
+      const key: FoldKeyData = {
+        headingPath: headingStack.map((h) => h.title),
+        indexUnderHeading: idx
+      };
+      // Match Swift JSONEncoder.OutputFormatting.sortedKeys: alphabetical order.
+      result.set(child.from, JSON.stringify({ headingPath: key.headingPath, indexUnderHeading: key.indexUnderHeading }));
+    }
+    child = child.nextSibling;
+  }
+  return result;
+}
+
+/// Returns the body range of a FencedCode at `lineStart` — the text inside the
+/// fences but excluding the opening and closing fence lines themselves. This
+/// is the range that gets collapsed when folded.
+function fencedCodeBodyRange(state: EditorState, lineStart: number): { from: number; to: number } | null {
+  const tree = syntaxTree(state);
+  const node = tree.resolveInner(lineStart, 1);
+  let cur: typeof node | null = node;
+  while (cur) {
+    if (cur.name === "FencedCode") break;
+    cur = cur.parent;
+  }
+  if (!cur) return null;
+  const startLine = state.doc.lineAt(cur.from);
+  const endLine = state.doc.lineAt(cur.to);
+  if (endLine.number <= startLine.number) return null;
+  // Body = end of opening-fence line .. start of closing-fence line
+  const from = startLine.to;
+  const to = state.doc.line(endLine.number).from;
+  if (to <= from) return null;
+  return { from, to };
+}
+
+const fencedFoldService = foldService.of((state, lineStart, lineEnd) => {
+  // Only fold from the opening-fence line.
+  const tree = syntaxTree(state);
+  const node = tree.resolveInner(lineStart, 1);
+  let cur: typeof node | null = node;
+  while (cur) {
+    if (cur.name === "FencedCode") break;
+    cur = cur.parent;
+  }
+  if (!cur) return null;
+  if (state.doc.lineAt(cur.from).from !== lineStart) return null;
+  return fencedCodeBodyRange(state, lineStart);
+});
+
+class FoldChevronWidget extends WidgetType {
+  constructor(private readonly lineStart: number, private readonly initiallyFolded: boolean) {
+    super();
+  }
+  eq(other: FoldChevronWidget) {
+    return this.lineStart === other.lineStart && this.initiallyFolded === other.initiallyFolded;
+  }
+  toDOM(view: EditorView) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "cm-fold-chevron";
+    btn.setAttribute("aria-label", this.initiallyFolded ? "Unfold code block" : "Fold code block");
+    btn.setAttribute("aria-expanded", this.initiallyFolded ? "false" : "true");
+    btn.innerHTML =
+      '<svg width="14" height="14" viewBox="0 0 14 14"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M3.5 5l3.5 3.5L10.5 5"></path></svg>';
+    if (this.initiallyFolded) btn.classList.add("is-folded");
+    btn.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleFoldAtLineStart(view, this.lineStart);
+    });
+    return btn;
+  }
+  ignoreEvent() {
+    return false;
+  }
+}
+
+function toggleFoldAtLineStart(view: EditorView, lineStart: number) {
+  const range = fencedCodeBodyRange(view.state, lineStart);
+  if (!range) return;
+  const folded = foldedRanges(view.state);
+  let alreadyFolded = false;
+  folded.between(range.from, range.to, (from, to) => {
+    if (from <= range.from && to >= range.to) {
+      alreadyFolded = true;
+      return false;
+    }
+  });
+  const willBeFolded = !alreadyFolded;
+  view.dispatch({
+    effects: alreadyFolded ? unfoldEffect.of(range) : foldEffect.of(range)
+  });
+  // Notify native.
+  const keys = deriveFoldKeys(view.state);
+  const key = keys.get(getEnclosingFencedFrom(view.state, lineStart));
+  if (key) {
+    postMessage({ type: "foldToggle", key, folded: willBeFolded });
+  }
+}
+
+function getEnclosingFencedFrom(state: EditorState, lineStart: number): number {
+  const tree = syntaxTree(state);
+  const node = tree.resolveInner(lineStart, 1);
+  let cur: typeof node | null = node;
+  while (cur) {
+    if (cur.name === "FencedCode") return cur.from;
+    cur = cur.parent;
+  }
+  return -1;
+}
+
+const foldChevronDecorations = StateField.define<DecorationSet>({
+  create(state) {
+    return buildFoldChevronDecorations(state);
+  },
+  update(value, transaction) {
+    if (transaction.docChanged) {
+      return buildFoldChevronDecorations(transaction.state);
+    }
+    // Rebuild when fold state changes (effects from foldEffect/unfoldEffect)
+    for (const effect of transaction.effects) {
+      if (effect.is(foldEffect) || effect.is(unfoldEffect)) {
+        return buildFoldChevronDecorations(transaction.state);
+      }
+    }
+    return value;
+  },
+  provide: (field) => EditorView.decorations.from(field)
+});
+
+function buildFoldChevronDecorations(state: EditorState): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = syntaxTree(state);
+  const folded = foldedRanges(state);
+  // Only top-level fenced code blocks get chevrons, matching the preview's
+  // DOM walker which iterates direct children of <body>. Nested fenced codes
+  // (inside callouts, lists, blockquotes) don't get persisted fold keys, so
+  // showing a chevron for them would offer state that can't round-trip.
+  let child = tree.topNode.firstChild;
+  while (child) {
+    if (child.name === "FencedCode") {
+      const lineStart = state.doc.lineAt(child.from).from;
+      const range = fencedCodeBodyRange(state, lineStart);
+      if (!range) {
+        child = child.nextSibling;
+        continue;
+      }
+      let isFolded = false;
+      folded.between(range.from, range.to, (from, to) => {
+        if (from <= range.from && to >= range.to) {
+          isFolded = true;
+          return false;
+        }
+      });
+      builder.add(lineStart, lineStart, Decoration.widget({
+        widget: new FoldChevronWidget(lineStart, isFolded),
+        side: -1
+      }));
+    }
+    child = child.nextSibling;
+  }
+  return builder.finish();
+}
+
+const codeFoldingExtension = codeFolding();
+
+function applyFoldsByKeys(keys: string[]) {
+  if (!editor) return;
+  const lookup = new Set(keys);
+  const derived = deriveFoldKeys(editor.state);
+  const effects: StateEffect<unknown>[] = [];
+  foldedRanges(editor.state).between(0, editor.state.doc.length, (from, to) => {
+    effects.push(unfoldEffect.of({ from, to }));
+  });
+  derived.forEach((key, fencedFrom) => {
+    if (lookup.has(key)) {
+      const lineStart = editor!.state.doc.lineAt(fencedFrom).from;
+      const range = fencedCodeBodyRange(editor!.state, lineStart);
+      if (range) effects.push(foldEffect.of(range));
+    }
+  });
+  if (effects.length) editor.dispatch({ effects });
+}
+
 function livePreviewTheme(appearance: "light" | "dark", fontSize: number): Extension {
   const isDark = appearance === "dark";
   const background = isDark ? "#323236" : "#FFFFFF";
@@ -1630,6 +1883,46 @@ function livePreviewTheme(appearance: "light" | "dark", fontSize: number): Exten
     ".cm-live-task-checkbox": {
       transform: "translateY(1px)",
       marginRight: "0.45rem"
+    },
+    ".cm-fold-chevron": {
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: "20px",
+      height: "20px",
+      padding: "8px",
+      margin: "0 0.35rem 0 -0.6rem",
+      verticalAlign: "middle",
+      border: "none",
+      borderRadius: "5px",
+      background: buttonBackground,
+      color: muted,
+      cursor: "pointer",
+      opacity: "0.6",
+      transition: "opacity 0.15s ease, transform 0.15s ease",
+      // Position widget element relative to text baseline so it doesn't push the line down.
+      boxSizing: "content-box"
+    },
+    ".cm-fold-chevron:hover": {
+      opacity: "1",
+      background: buttonHover
+    },
+    ".cm-fold-chevron:active": {
+      background: buttonActive
+    },
+    ".cm-fold-chevron.is-folded": {
+      transform: "rotate(-90deg)",
+      opacity: "1"
+    },
+    ".cm-foldPlaceholder": {
+      fontFamily: '"SF Mono", SFMono-Regular, Menlo, monospace',
+      backgroundColor: preBackground,
+      color: muted,
+      padding: "0.25em 0.6em",
+      borderRadius: "5px",
+      cursor: "pointer",
+      fontSize: "0.85em",
+      margin: "0 0.15em"
     },
     ".cm-live-block": {
       display: "block",
@@ -1886,6 +2179,9 @@ function createEditor(payload: MountPayload) {
     ]),
     themeCompartment.of(livePreviewTheme(payload.appearance, payload.fontSize)),
     livePreviewCompartment.of(livePreviewDecorations),
+    codeFoldingExtension,
+    fencedFoldService,
+    foldChevronDecorations,
     EditorView.domEventHandlers({
       mousedown(event) {
         const target = (event.target as HTMLElement | null)?.closest<HTMLElement>("[data-live-link-kind]");
@@ -2086,6 +2382,10 @@ window.clearlyLiveEditor = {
 
   getDocument() {
     return editor?.state.doc.toString() ?? "";
+  },
+
+  applyFolds(payload: { keys: string[] }) {
+    applyFoldsByKeys(payload.keys || []);
   }
 };
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
@@ -331,6 +331,9 @@ public enum PreviewCSS {
 
         let exportStructural = forExport ? """
         .code-copy-btn { display: none !important; }
+        .code-fold-btn { display: none !important; }
+        .code-block-wrapper.is-folded > pre { display: block !important; }
+        .code-block-wrapper.is-folded > .code-fold-summary { display: none !important; }
         .table-copy-btn { display: none !important; }
         .sort-indicator { display: none !important; }
         thead { position: static !important; display: table-header-group; }
@@ -603,6 +606,104 @@ public enum PreviewCSS {
 
         .frontmatter .code-copy-btn {
             display: none;
+        }
+
+        .code-fold-btn {
+            position: absolute;
+            top: 6px;
+            right: 40px;
+            z-index: 1;
+            width: 28px;
+            height: 28px;
+            padding: 0;
+            margin: 0;
+            border: none;
+            border-radius: 6px;
+            background: var(--c-btn-bg);
+            color: var(--c-btn-fg);
+            cursor: pointer;
+            opacity: 0;
+            transition: opacity 0.15s ease, transform 0.15s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            line-height: 1;
+        }
+
+        .code-block-wrapper:hover .code-fold-btn,
+        .code-block-wrapper.is-folded .code-fold-btn {
+            opacity: 1;
+        }
+
+        .code-block-wrapper.is-folded .code-fold-btn {
+            transform: rotate(-90deg);
+        }
+
+        .code-fold-btn:hover {
+            background: var(--c-btn-bg-hover);
+        }
+
+        .code-fold-btn:active {
+            background: var(--c-btn-bg-active);
+        }
+
+        .code-fold-btn:focus-visible {
+            outline: 2px solid var(--c-link);
+            outline-offset: 2px;
+        }
+
+        .frontmatter .code-fold-btn {
+            display: none;
+        }
+
+        .code-block-wrapper.is-folded > pre {
+            display: none;
+        }
+
+        .code-block-wrapper.is-folded > .code-filename {
+            border-radius: 10px 10px 0 0;
+        }
+
+        .code-fold-summary {
+            display: none;
+            font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
+            font-size: 0.8em;
+            padding: 1.125em 1.25em;
+            background-color: var(--c-pre-bg);
+            color: var(--c-pre-fg);
+            border-radius: 10px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0.85;
+            cursor: pointer;
+        }
+
+        .code-block-wrapper.is-folded > .code-fold-summary {
+            display: block;
+        }
+
+        .code-block-wrapper.is-folded > .code-filename + .code-fold-summary {
+            border-radius: 0 0 10px 10px;
+        }
+
+        .code-fold-lang {
+            display: inline-block;
+            padding: 0 0.5em;
+            margin-right: 0.5em;
+            border-radius: 4px;
+            background: var(--c-code-filename-bg);
+            color: var(--c-code-filename-fg);
+        }
+
+        .code-fold-firstline {
+            opacity: 0.85;
+        }
+
+        .code-fold-meta {
+            margin-left: 0.5em;
+            opacity: 0.65;
         }
 
         pre code {
@@ -1121,6 +1222,9 @@ public enum PreviewCSS {
                 print-color-adjust: exact;
             }
             .code-copy-btn { display: none !important; }
+            .code-fold-btn { display: none !important; }
+            .code-block-wrapper.is-folded > pre { display: block !important; }
+            .code-block-wrapper.is-folded > .code-fold-summary { display: none !important; }
             .table-copy-btn { display: none !important; }
             .sort-indicator { display: none !important; }
             thead { position: static !important; display: table-header-group; }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewUserScripts.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewUserScripts.swift
@@ -1,0 +1,292 @@
+import Foundation
+import WebKit
+
+/// Shared user scripts injected into both Mac and iOS preview WKWebViews.
+/// These run at `atDocumentEnd` after each `loadHTMLString`, walking the
+/// rendered DOM to install the code-block chrome (copy + fold buttons),
+/// stamp heading-scoped fold keys, and wire postMessage handlers.
+public enum PreviewUserScripts {
+
+    /// Single combined script: wraps each `<pre>` in `.code-block-wrapper`,
+    /// stamps `data-fold-key`, injects fold chevron + copy button, and
+    /// registers click handlers that talk to native handlers
+    /// `copyToClipboard` and `foldToggle`.
+    public static func codeBlockChromeScript() -> WKUserScript {
+        let copyIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"18\" height=\"18\" viewBox=\"0 0 18 18\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"M12.25 5.75H13.75C14.8546 5.75 15.75 6.6454 15.75 7.75V13.75C15.75 14.8546 14.8546 15.75 13.75 15.75H7.75C6.6454 15.75 5.75 14.8546 5.75 13.75V12.25\"></path><path d=\"M10.25 2.25H4.25C3.14543 2.25 2.25 3.14543 2.25 4.25V10.25C2.25 11.3546 3.14543 12.25 4.25 12.25H10.25C11.3546 12.25 12.25 11.3546 12.25 10.25V4.25C12.25 3.14543 11.3546 2.25 10.25 2.25Z\"></path></g></svg>"#
+        let checkIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"12\" height=\"12\" viewBox=\"0 0 12 12\"><g fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" stroke=\"currentColor\"><path d=\"m1.76,7.004l2.25,3L10.24,1.746\"></path></g></svg>"#
+        let chevronIcon = #"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" viewBox=\"0 0 14 14\"><path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.75\" d=\"M3.5 5l3.5 3.5L10.5 5\"></path></svg>"#
+
+        let source = """
+        (function() {
+            var copyIcon = '\(copyIcon)';
+            var checkIcon = '\(checkIcon)';
+            var chevronIcon = '\(chevronIcon)';
+
+            // --- Fold-key derivation: walk DOM in order, track heading stack. ---
+            var headingStack = []; // [{level, title}]
+            var counterStack = []; // counters[i] = blocks under headingStack[i]
+            var rootCounter = 0;
+
+            function popToLevel(level) {
+                while (headingStack.length > 0 &&
+                       headingStack[headingStack.length - 1].level >= level) {
+                    headingStack.pop();
+                    counterStack.pop();
+                }
+            }
+
+            function nextIndexUnderHeading() {
+                if (counterStack.length === 0) {
+                    var idx = rootCounter;
+                    rootCounter += 1;
+                    return idx;
+                }
+                var idx = counterStack[counterStack.length - 1];
+                counterStack[counterStack.length - 1] = idx + 1;
+                return idx;
+            }
+
+            function currentHeadingPath() {
+                return headingStack.map(function(h) { return h.title; });
+            }
+
+            function buildFoldKey() {
+                var key = {
+                    headingPath: currentHeadingPath(),
+                    indexUnderHeading: nextIndexUnderHeading()
+                };
+                // Match Swift JSONEncoder.OutputFormatting.sortedKeys: keys
+                // in alphabetical order. Hand-build the JSON to guarantee it.
+                return JSON.stringify({
+                    headingPath: key.headingPath,
+                    indexUnderHeading: key.indexUnderHeading
+                });
+            }
+
+            // Single in-order traversal of body's direct descendants.
+            // Headings under nested elements (e.g. inside callouts) are not
+            // stack-pushed; this matches the Swift outline parser's behavior
+            // of only treating top-level headings as scope-defining.
+            // Persisted fold keys are only stamped on top-level blocks, but
+            // every rendered <pre> still gets copy/fold chrome below.
+            var topLevelFoldKeys = new WeakMap();
+
+            for (let el = document.body.firstElementChild; el; el = el.nextElementSibling) {
+                let tag = el.tagName;
+                if (/^H[1-6]$/.test(tag)) {
+                    let level = parseInt(tag.charAt(1), 10);
+                    popToLevel(level);
+                    headingStack.push({ level: level, title: (el.textContent || '').trim() });
+                    counterStack.push(0);
+                    continue;
+                }
+                // We only care about <pre> blocks that aren't inside a frontmatter wrapper.
+                let pre = null;
+                if (tag === 'PRE') {
+                    pre = el;
+                } else if (el.classList && el.classList.contains('code-filename')) {
+                    // The next sibling should be a <pre>; we'll process it on its own iteration.
+                    continue;
+                }
+                if (!pre) continue;
+                if (pre.closest && pre.closest('.frontmatter')) continue;
+                if (pre.closest && pre.closest('.code-block-wrapper')) continue;
+                topLevelFoldKeys.set(pre, buildFoldKey());
+            }
+
+            document.querySelectorAll('pre').forEach(function(pre) {
+                if (pre.closest && pre.closest('.frontmatter')) return;
+                if (pre.closest && pre.closest('.code-block-wrapper')) return;
+
+                // Wrap <pre> (possibly with preceding .code-filename) in .code-block-wrapper.
+                let wrapper = document.createElement('div');
+                wrapper.className = 'code-block-wrapper';
+                let prev = pre.previousElementSibling;
+                let hasFilename = prev && prev.classList && prev.classList.contains('code-filename');
+                if (hasFilename) {
+                    pre.parentNode.insertBefore(wrapper, prev);
+                    wrapper.appendChild(prev);
+                } else {
+                    pre.parentNode.insertBefore(wrapper, pre);
+                }
+                wrapper.appendChild(pre);
+
+                // Stamp fold key.
+                let foldKey = topLevelFoldKeys.get(pre) || '';
+                if (foldKey) wrapper.setAttribute('data-fold-key', foldKey);
+
+                // Detect language from <code class="language-xxx"> if present.
+                let codeEl = pre.querySelector('code');
+                let lang = '';
+                if (codeEl && codeEl.classList) {
+                    for (let c = 0; c < codeEl.classList.length; c++) {
+                        let cls = codeEl.classList[c];
+                        if (cls.indexOf('language-') === 0) {
+                            lang = cls.substring(9);
+                            break;
+                        }
+                    }
+                }
+
+                // Fold button.
+                let foldBtn = document.createElement('button');
+                foldBtn.className = 'code-fold-btn';
+                foldBtn.type = 'button';
+                foldBtn.setAttribute('aria-label', 'Fold code block');
+                foldBtn.setAttribute('aria-expanded', 'true');
+                foldBtn.innerHTML = chevronIcon;
+                if (hasFilename) {
+                    foldBtn.style.top = (prev.offsetHeight + 6) + 'px';
+                }
+                foldBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    toggleFold(wrapper, foldBtn, /*notifyNative=*/true);
+                });
+                foldBtn.addEventListener('keydown', function(e) {
+                    if (e.key === ' ' || e.key === 'Enter') {
+                        e.preventDefault();
+                        toggleFold(wrapper, foldBtn, /*notifyNative=*/true);
+                    }
+                });
+                wrapper.appendChild(foldBtn);
+
+                // Copy button (existing behavior).
+                let copyBtn = document.createElement('button');
+                copyBtn.className = 'code-copy-btn';
+                copyBtn.type = 'button';
+                copyBtn.setAttribute('aria-label', 'Copy code');
+                copyBtn.innerHTML = copyIcon;
+                if (hasFilename) {
+                    copyBtn.style.top = (prev.offsetHeight + 6) + 'px';
+                }
+                copyBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    let lines = codeEl ? codeEl.querySelectorAll('.code-line') : null;
+                    let text;
+                    if (lines && lines.length > 0) {
+                        text = Array.from(lines).map(function(l) { return l.textContent; }).join('\\n');
+                    } else {
+                        text = codeEl ? codeEl.textContent : pre.textContent;
+                    }
+                    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.copyToClipboard) {
+                        window.webkit.messageHandlers.copyToClipboard.postMessage(text);
+                    }
+                    copyBtn.classList.add('copied');
+                    copyBtn.innerHTML = checkIcon;
+                    setTimeout(function() {
+                        copyBtn.classList.remove('copied');
+                        copyBtn.innerHTML = copyIcon;
+                    }, 1500);
+                });
+                wrapper.appendChild(copyBtn);
+
+                // Build the fold summary (lang + first non-blank line + count).
+                let summary = document.createElement('div');
+                summary.className = 'code-fold-summary';
+                summary.setAttribute('role', 'button');
+                summary.setAttribute('tabindex', '0');
+                summary.setAttribute('aria-label', 'Unfold code block');
+                let langEl = document.createElement('span');
+                langEl.className = 'code-fold-lang';
+                langEl.textContent = lang || 'code';
+                let firstLineEl = document.createElement('span');
+                firstLineEl.className = 'code-fold-firstline';
+                let metaEl = document.createElement('span');
+                metaEl.className = 'code-fold-meta';
+
+                let summaryComputed = computeSummaryParts(pre, codeEl);
+                firstLineEl.textContent = summaryComputed.firstLine;
+                metaEl.textContent = summaryComputed.totalLines > 1
+                    ? '+' + (summaryComputed.totalLines - 1) + ' more line' + (summaryComputed.totalLines - 1 === 1 ? '' : 's')
+                    : '';
+
+                summary.appendChild(langEl);
+                summary.appendChild(firstLineEl);
+                if (metaEl.textContent) summary.appendChild(metaEl);
+                summary.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    toggleFold(wrapper, foldBtn, /*notifyNative=*/true);
+                });
+                wrapper.appendChild(summary);
+            });
+
+            function computeSummaryParts(pre, codeEl) {
+                var lines = codeEl ? codeEl.querySelectorAll('.code-line') : null;
+                var first = '';
+                var total = 0;
+                if (lines && lines.length > 0) {
+                    total = lines.length;
+                    for (var i = 0; i < lines.length; i++) {
+                        var t = (lines[i].textContent || '').trim();
+                        if (t.length) { first = t; break; }
+                    }
+                    if (!first && lines.length) first = (lines[0].textContent || '');
+                } else {
+                    var raw = (codeEl ? codeEl.textContent : pre.textContent) || '';
+                    var parts = raw.split('\\n');
+                    total = parts.length;
+                    for (var j = 0; j < parts.length; j++) {
+                        if (parts[j].trim().length) { first = parts[j].trim(); break; }
+                    }
+                    if (!first && parts.length) first = parts[0];
+                }
+                if (first.length > 80) first = first.substring(0, 77) + '…';
+                return { firstLine: first, totalLines: total };
+            }
+
+            function toggleFold(wrapper, btn, notifyNative) {
+                var folded = !wrapper.classList.contains('is-folded');
+                applyFold(wrapper, btn, folded);
+                if (notifyNative) {
+                    var key = wrapper.getAttribute('data-fold-key') || '';
+                    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.foldToggle) {
+                        window.webkit.messageHandlers.foldToggle.postMessage({ key: key, folded: folded });
+                    }
+                }
+            }
+
+            function applyFold(wrapper, btn, folded) {
+                if (folded) {
+                    wrapper.classList.add('is-folded');
+                    if (btn) {
+                        btn.setAttribute('aria-expanded', 'false');
+                        btn.setAttribute('aria-label', 'Unfold code block');
+                    }
+                } else {
+                    wrapper.classList.remove('is-folded');
+                    if (btn) {
+                        btn.setAttribute('aria-expanded', 'true');
+                        btn.setAttribute('aria-label', 'Fold code block');
+                    }
+                }
+            }
+
+            // Expose an API for native code to apply persisted fold state
+            // after didFinish.
+            window.clearlyApplyFolds = function(foldedKeys) {
+                if (!foldedKeys || foldedKeys.length === 0) return;
+                var lookup = {};
+                for (var i = 0; i < foldedKeys.length; i++) {
+                    lookup[foldedKeys[i]] = true;
+                }
+                var wrappers = document.querySelectorAll('.code-block-wrapper[data-fold-key]');
+                for (var w = 0; w < wrappers.length; w++) {
+                    var wrapper = wrappers[w];
+                    var key = wrapper.getAttribute('data-fold-key');
+                    if (key && lookup[key]) {
+                        var btn = wrapper.querySelector('.code-fold-btn');
+                        applyFold(wrapper, btn, true);
+                    }
+                }
+            };
+        })();
+        """
+        return WKUserScript(
+            source: source,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/FoldStateStore.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/FoldStateStore.swift
@@ -1,0 +1,109 @@
+import Foundation
+import CryptoKit
+
+/// Identifies a fenced code block by the heading it lives under and its
+/// position among siblings in that section. Survives unrelated edits to
+/// the document. Breaks if the enclosing heading is renamed or if the
+/// block's relative order under that heading changes — accepted tradeoffs.
+public struct FoldKey: Codable, Hashable, Sendable {
+    public let headingPath: [String]
+    public let indexUnderHeading: Int
+
+    public init(headingPath: [String], indexUnderHeading: Int) {
+        self.headingPath = headingPath
+        self.indexUnderHeading = indexUnderHeading
+    }
+
+    /// Stable, JSON-encoded string representation suitable for use as a
+    /// dictionary key over the JS↔Swift bridge. JSON ordering is fixed by
+    /// the encoder's keyEncodingStrategy default (alphabetical via
+    /// JSONEncoder.OutputFormatting.sortedKeys).
+    public var stableID: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(self),
+              let string = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return string
+    }
+
+    public init?(stableID: String) {
+        guard let data = stableID.data(using: .utf8) else { return nil }
+        let decoder = JSONDecoder()
+        guard let key = try? decoder.decode(FoldKey.self, from: data) else { return nil }
+        self = key
+    }
+}
+
+/// Per-file fold state, keyed by file path. Backed by UserDefaults.
+/// Entries are stored under "clearly.fold.<sha>" where <sha> is a stable
+/// hash of the file path, so renames clear the state (acceptable).
+public final class FoldStateStore: @unchecked Sendable {
+    public static let shared = FoldStateStore(defaults: .standard)
+
+    private let defaults: UserDefaults
+    private let queue = DispatchQueue(label: "com.sabotage.clearly.foldstate", attributes: .concurrent)
+
+    public init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    public func folds(for fileURL: URL?) -> [FoldKey: Bool] {
+        guard let key = Self.storageKey(for: fileURL) else { return [:] }
+        return queue.sync {
+            guard let data = defaults.data(forKey: key),
+                  let raw = try? JSONDecoder().decode([String: Bool].self, from: data) else {
+                return [:]
+            }
+            var result: [FoldKey: Bool] = [:]
+            for (id, folded) in raw {
+                if let foldKey = FoldKey(stableID: id) {
+                    result[foldKey] = folded
+                }
+            }
+            return result
+        }
+    }
+
+    public func setFolded(_ folded: Bool, key: FoldKey, for fileURL: URL?) {
+        guard let storageKey = Self.storageKey(for: fileURL) else { return }
+        queue.async(flags: .barrier) {
+            var raw: [String: Bool] = {
+                guard let data = self.defaults.data(forKey: storageKey),
+                      let decoded = try? JSONDecoder().decode([String: Bool].self, from: data) else {
+                    return [:]
+                }
+                return decoded
+            }()
+            if folded {
+                raw[key.stableID] = true
+            } else {
+                raw.removeValue(forKey: key.stableID)
+            }
+            if raw.isEmpty {
+                self.defaults.removeObject(forKey: storageKey)
+            } else if let data = try? JSONEncoder().encode(raw) {
+                self.defaults.set(data, forKey: storageKey)
+            }
+        }
+    }
+
+    /// Folded keys, encoded as their stableIDs. Convenient for sending
+    /// over the JS bridge.
+    public func foldedKeyIDs(for fileURL: URL?) -> [String] {
+        folds(for: fileURL).filter { $0.value }.map { $0.key.stableID }
+    }
+
+    private static func storageKey(for fileURL: URL?) -> String? {
+        guard let url = fileURL else { return nil }
+        let path = url.standardizedFileURL.path
+        guard !path.isEmpty else { return nil }
+        return "clearly.fold." + Self.shortHash(path)
+    }
+
+    private static func shortHash(_ string: String) -> String {
+        let digest = SHA256.hash(data: Data(string.utf8))
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Shared/Resources/live-editor/live-editor.js
+++ b/Shared/Resources/live-editor/live-editor.js
@@ -15460,7 +15460,7 @@
   function topNodeAt(state, pos, side) {
     let topLang = state.facet(language), tree = syntaxTree(state).topNode;
     if (!topLang || topLang.allowsNesting) {
-      for (let node = tree; node; node = node.enter(pos, side, IterMode.ExcludeBuffers | IterMode.EnterBracketed))
+      for (let node = tree; node; node = node.enter(pos, side, IterMode.ExcludeBuffers))
         if (node.type.isTop)
           tree = node;
     }
@@ -16232,6 +16232,157 @@
     let first = node.firstChild, last = node.lastChild;
     return first && first.to < last.from ? { from: first.to, to: last.type.isError ? node.to : last.from } : null;
   }
+  function mapRange(range, mapping) {
+    let from = mapping.mapPos(range.from, 1), to = mapping.mapPos(range.to, -1);
+    return from >= to ? void 0 : { from, to };
+  }
+  var foldEffect = /* @__PURE__ */ StateEffect.define({ map: mapRange });
+  var unfoldEffect = /* @__PURE__ */ StateEffect.define({ map: mapRange });
+  var foldState = /* @__PURE__ */ StateField.define({
+    create() {
+      return Decoration.none;
+    },
+    update(folded, tr) {
+      if (tr.isUserEvent("delete"))
+        tr.changes.iterChangedRanges((fromA, toA) => folded = clearTouchedFolds(folded, fromA, toA));
+      folded = folded.map(tr.changes);
+      for (let e of tr.effects) {
+        if (e.is(foldEffect) && !foldExists(folded, e.value.from, e.value.to)) {
+          let { preparePlaceholder } = tr.state.facet(foldConfig);
+          let widget = !preparePlaceholder ? foldWidget : Decoration.replace({ widget: new PreparedFoldWidget(preparePlaceholder(tr.state, e.value)) });
+          folded = folded.update({ add: [widget.range(e.value.from, e.value.to)] });
+        } else if (e.is(unfoldEffect)) {
+          folded = folded.update({
+            filter: (from, to) => e.value.from != from || e.value.to != to,
+            filterFrom: e.value.from,
+            filterTo: e.value.to
+          });
+        }
+      }
+      if (tr.selection)
+        folded = clearTouchedFolds(folded, tr.selection.main.head);
+      return folded;
+    },
+    provide: (f) => EditorView.decorations.from(f),
+    toJSON(folded, state) {
+      let ranges = [];
+      folded.between(0, state.doc.length, (from, to) => {
+        ranges.push(from, to);
+      });
+      return ranges;
+    },
+    fromJSON(value) {
+      if (!Array.isArray(value) || value.length % 2)
+        throw new RangeError("Invalid JSON for fold state");
+      let ranges = [];
+      for (let i = 0; i < value.length; ) {
+        let from = value[i++], to = value[i++];
+        if (typeof from != "number" || typeof to != "number")
+          throw new RangeError("Invalid JSON for fold state");
+        ranges.push(foldWidget.range(from, to));
+      }
+      return Decoration.set(ranges, true);
+    }
+  });
+  function clearTouchedFolds(folded, from, to = from) {
+    let touched = false;
+    folded.between(from, to, (a, b) => {
+      if (a < to && b > from)
+        touched = true;
+    });
+    return !touched ? folded : folded.update({
+      filterFrom: from,
+      filterTo: to,
+      filter: (a, b) => a >= to || b <= from
+    });
+  }
+  function foldedRanges(state) {
+    return state.field(foldState, false) || RangeSet.empty;
+  }
+  function findFold(state, from, to) {
+    var _a3;
+    let found = null;
+    (_a3 = state.field(foldState, false)) === null || _a3 === void 0 ? void 0 : _a3.between(from, to, (from2, to2) => {
+      if (!found || found.from > from2)
+        found = { from: from2, to: to2 };
+    });
+    return found;
+  }
+  function foldExists(folded, from, to) {
+    let found = false;
+    folded.between(from, from, (a, b) => {
+      if (a == from && b == to)
+        found = true;
+    });
+    return found;
+  }
+  var defaultConfig = {
+    placeholderDOM: null,
+    preparePlaceholder: null,
+    placeholderText: "\u2026"
+  };
+  var foldConfig = /* @__PURE__ */ Facet.define({
+    combine(values2) {
+      return combineConfig(values2, defaultConfig);
+    }
+  });
+  function codeFolding(config2) {
+    let result = [foldState, baseTheme$12];
+    if (config2)
+      result.push(foldConfig.of(config2));
+    return result;
+  }
+  function widgetToDOM(view, prepared) {
+    let { state } = view, conf = state.facet(foldConfig);
+    let onclick = (event) => {
+      let line = view.lineBlockAt(view.posAtDOM(event.target));
+      let folded = findFold(view.state, line.from, line.to);
+      if (folded)
+        view.dispatch({ effects: unfoldEffect.of(folded) });
+      event.preventDefault();
+    };
+    if (conf.placeholderDOM)
+      return conf.placeholderDOM(view, onclick, prepared);
+    let element = document.createElement("span");
+    element.textContent = conf.placeholderText;
+    element.setAttribute("aria-label", state.phrase("folded code"));
+    element.title = state.phrase("unfold");
+    element.className = "cm-foldPlaceholder";
+    element.onclick = onclick;
+    return element;
+  }
+  var foldWidget = /* @__PURE__ */ Decoration.replace({ widget: /* @__PURE__ */ new class extends WidgetType {
+    toDOM(view) {
+      return widgetToDOM(view, null);
+    }
+  }() });
+  var PreparedFoldWidget = class extends WidgetType {
+    constructor(value) {
+      super();
+      this.value = value;
+    }
+    eq(other) {
+      return this.value == other.value;
+    }
+    toDOM(view) {
+      return widgetToDOM(view, this.value);
+    }
+  };
+  var baseTheme$12 = /* @__PURE__ */ EditorView.baseTheme({
+    ".cm-foldPlaceholder": {
+      backgroundColor: "#eee",
+      border: "1px solid #ddd",
+      color: "#888",
+      borderRadius: ".2em",
+      margin: "0 1px",
+      padding: "0 1px",
+      cursor: "pointer"
+    },
+    ".cm-foldGutter span": {
+      padding: "0 1px",
+      cursor: "pointer"
+    }
+  });
   var HighlightStyle = class _HighlightStyle {
     constructor(specs, options) {
       this.specs = specs;
@@ -16409,8 +16560,6 @@
     return { start: firstToken, matched: false };
   }
   function matchPlainBrackets(state, pos, dir, tree, tokenType, maxScanDistance, brackets) {
-    if (dir < 0 ? !pos : pos == state.doc.length)
-      return null;
     let startCh = dir < 0 ? state.sliceDoc(pos - 1, pos) : state.sliceDoc(pos, pos + 1);
     let bracket2 = brackets.indexOf(startCh);
     if (bracket2 < 0 || bracket2 % 2 == 0 != dir > 0)
@@ -32485,6 +32634,216 @@ $$`);
     },
     provide: (field) => EditorView.decorations.from(field)
   });
+  function stripInlineMarkdown(text2) {
+    let r = text2;
+    r = r.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1");
+    r = r.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+    r = r.replace(/(\*\*|__)(.+?)\1/g, "$2");
+    r = r.replace(new RegExp("(?<![\\w*])[*_](.+?)[*_](?![\\w*])", "g"), "$1");
+    r = r.replace(/~~(.+?)~~/g, "$1");
+    r = r.replace(/`([^`]+)`/g, "$1");
+    return r.trim();
+  }
+  function headingTitleFromText(rawHeadingLine) {
+    let r = rawHeadingLine.replace(/^#+\s*/, "");
+    r = r.replace(/\s+#+\s*$/, "");
+    return stripInlineMarkdown(r.trim());
+  }
+  function deriveFoldKeys(state) {
+    const result = /* @__PURE__ */ new Map();
+    const tree = syntaxTree(state);
+    const headingStack = [];
+    const counters = [];
+    let rootCounter = 0;
+    const root2 = tree.topNode;
+    let child = root2.firstChild;
+    while (child) {
+      const name2 = child.name;
+      const headingMatch = /^(?:ATXHeading|SetextHeading)([1-6])$/.exec(name2);
+      if (headingMatch) {
+        const level = parseInt(headingMatch[1], 10);
+        while (headingStack.length > 0 && headingStack[headingStack.length - 1].level >= level) {
+          headingStack.pop();
+          counters.pop();
+        }
+        const lineFrom = state.doc.lineAt(child.from).from;
+        const lineTo = state.doc.lineAt(child.from).to;
+        const lineText = state.doc.sliceString(lineFrom, lineTo);
+        headingStack.push({ level, title: headingTitleFromText(lineText) });
+        counters.push(0);
+      } else if (name2 === "FencedCode") {
+        let idx;
+        if (counters.length === 0) {
+          idx = rootCounter;
+          rootCounter += 1;
+        } else {
+          idx = counters[counters.length - 1];
+          counters[counters.length - 1] = idx + 1;
+        }
+        const key = {
+          headingPath: headingStack.map((h) => h.title),
+          indexUnderHeading: idx
+        };
+        result.set(child.from, JSON.stringify({ headingPath: key.headingPath, indexUnderHeading: key.indexUnderHeading }));
+      }
+      child = child.nextSibling;
+    }
+    return result;
+  }
+  function fencedCodeBodyRange(state, lineStart) {
+    const tree = syntaxTree(state);
+    const node = tree.resolveInner(lineStart, 1);
+    let cur = node;
+    while (cur) {
+      if (cur.name === "FencedCode") break;
+      cur = cur.parent;
+    }
+    if (!cur) return null;
+    const startLine = state.doc.lineAt(cur.from);
+    const endLine = state.doc.lineAt(cur.to);
+    if (endLine.number <= startLine.number) return null;
+    const from = startLine.to;
+    const to = state.doc.line(endLine.number).from;
+    if (to <= from) return null;
+    return { from, to };
+  }
+  var fencedFoldService = foldService.of((state, lineStart, lineEnd2) => {
+    const tree = syntaxTree(state);
+    const node = tree.resolveInner(lineStart, 1);
+    let cur = node;
+    while (cur) {
+      if (cur.name === "FencedCode") break;
+      cur = cur.parent;
+    }
+    if (!cur) return null;
+    if (state.doc.lineAt(cur.from).from !== lineStart) return null;
+    return fencedCodeBodyRange(state, lineStart);
+  });
+  var FoldChevronWidget = class extends WidgetType {
+    constructor(lineStart, initiallyFolded) {
+      super();
+      this.lineStart = lineStart;
+      this.initiallyFolded = initiallyFolded;
+    }
+    lineStart;
+    initiallyFolded;
+    eq(other) {
+      return this.lineStart === other.lineStart && this.initiallyFolded === other.initiallyFolded;
+    }
+    toDOM(view) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "cm-fold-chevron";
+      btn.setAttribute("aria-label", this.initiallyFolded ? "Unfold code block" : "Fold code block");
+      btn.setAttribute("aria-expanded", this.initiallyFolded ? "false" : "true");
+      btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 14 14"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M3.5 5l3.5 3.5L10.5 5"></path></svg>';
+      if (this.initiallyFolded) btn.classList.add("is-folded");
+      btn.addEventListener("mousedown", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleFoldAtLineStart(view, this.lineStart);
+      });
+      return btn;
+    }
+    ignoreEvent() {
+      return false;
+    }
+  };
+  function toggleFoldAtLineStart(view, lineStart) {
+    const range = fencedCodeBodyRange(view.state, lineStart);
+    if (!range) return;
+    const folded = foldedRanges(view.state);
+    let alreadyFolded = false;
+    folded.between(range.from, range.to, (from, to) => {
+      if (from <= range.from && to >= range.to) {
+        alreadyFolded = true;
+        return false;
+      }
+    });
+    const willBeFolded = !alreadyFolded;
+    view.dispatch({
+      effects: alreadyFolded ? unfoldEffect.of(range) : foldEffect.of(range)
+    });
+    const keys = deriveFoldKeys(view.state);
+    const key = keys.get(getEnclosingFencedFrom(view.state, lineStart));
+    if (key) {
+      postMessage({ type: "foldToggle", key, folded: willBeFolded });
+    }
+  }
+  function getEnclosingFencedFrom(state, lineStart) {
+    const tree = syntaxTree(state);
+    const node = tree.resolveInner(lineStart, 1);
+    let cur = node;
+    while (cur) {
+      if (cur.name === "FencedCode") return cur.from;
+      cur = cur.parent;
+    }
+    return -1;
+  }
+  var foldChevronDecorations = StateField.define({
+    create(state) {
+      return buildFoldChevronDecorations(state);
+    },
+    update(value, transaction) {
+      if (transaction.docChanged) {
+        return buildFoldChevronDecorations(transaction.state);
+      }
+      for (const effect of transaction.effects) {
+        if (effect.is(foldEffect) || effect.is(unfoldEffect)) {
+          return buildFoldChevronDecorations(transaction.state);
+        }
+      }
+      return value;
+    },
+    provide: (field) => EditorView.decorations.from(field)
+  });
+  function buildFoldChevronDecorations(state) {
+    const builder = new RangeSetBuilder();
+    const tree = syntaxTree(state);
+    const folded = foldedRanges(state);
+    let child = tree.topNode.firstChild;
+    while (child) {
+      if (child.name === "FencedCode") {
+        const lineStart = state.doc.lineAt(child.from).from;
+        const range = fencedCodeBodyRange(state, lineStart);
+        if (!range) {
+          child = child.nextSibling;
+          continue;
+        }
+        let isFolded = false;
+        folded.between(range.from, range.to, (from, to) => {
+          if (from <= range.from && to >= range.to) {
+            isFolded = true;
+            return false;
+          }
+        });
+        builder.add(lineStart, lineStart, Decoration.widget({
+          widget: new FoldChevronWidget(lineStart, isFolded),
+          side: -1
+        }));
+      }
+      child = child.nextSibling;
+    }
+    return builder.finish();
+  }
+  var codeFoldingExtension = codeFolding();
+  function applyFoldsByKeys(keys) {
+    if (!editor) return;
+    const lookup = new Set(keys);
+    const derived = deriveFoldKeys(editor.state);
+    const effects = [];
+    foldedRanges(editor.state).between(0, editor.state.doc.length, (from, to) => {
+      effects.push(unfoldEffect.of({ from, to }));
+    });
+    derived.forEach((key, fencedFrom) => {
+      if (lookup.has(key)) {
+        const lineStart = editor.state.doc.lineAt(fencedFrom).from;
+        const range = fencedCodeBodyRange(editor.state, lineStart);
+        if (range) effects.push(foldEffect.of(range));
+      }
+    });
+    if (effects.length) editor.dispatch({ effects });
+  }
   function livePreviewTheme(appearance, fontSize) {
     const isDark = appearance === "dark";
     const background = isDark ? "#323236" : "#FFFFFF";
@@ -32668,6 +33027,46 @@ $$`);
       ".cm-live-task-checkbox": {
         transform: "translateY(1px)",
         marginRight: "0.45rem"
+      },
+      ".cm-fold-chevron": {
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "20px",
+        height: "20px",
+        padding: "8px",
+        margin: "0 0.35rem 0 -0.6rem",
+        verticalAlign: "middle",
+        border: "none",
+        borderRadius: "5px",
+        background: buttonBackground,
+        color: muted,
+        cursor: "pointer",
+        opacity: "0.6",
+        transition: "opacity 0.15s ease, transform 0.15s ease",
+        // Position widget element relative to text baseline so it doesn't push the line down.
+        boxSizing: "content-box"
+      },
+      ".cm-fold-chevron:hover": {
+        opacity: "1",
+        background: buttonHover
+      },
+      ".cm-fold-chevron:active": {
+        background: buttonActive
+      },
+      ".cm-fold-chevron.is-folded": {
+        transform: "rotate(-90deg)",
+        opacity: "1"
+      },
+      ".cm-foldPlaceholder": {
+        fontFamily: '"SF Mono", SFMono-Regular, Menlo, monospace',
+        backgroundColor: preBackground,
+        color: muted,
+        padding: "0.25em 0.6em",
+        borderRadius: "5px",
+        cursor: "pointer",
+        fontSize: "0.85em",
+        margin: "0 0.15em"
       },
       ".cm-live-block": {
         display: "block",
@@ -32918,6 +33317,9 @@ $$`);
       ]),
       themeCompartment.of(livePreviewTheme(payload.appearance, payload.fontSize)),
       livePreviewCompartment.of(livePreviewDecorations),
+      codeFoldingExtension,
+      fencedFoldService,
+      foldChevronDecorations,
       EditorView.domEventHandlers({
         mousedown(event) {
           const target = event.target?.closest("[data-live-link-kind]");
@@ -33090,6 +33492,9 @@ $$`);
     },
     getDocument() {
       return editor?.state.doc.toString() ?? "";
+    },
+    applyFolds(payload) {
+      applyFoldsByKeys(payload.keys || []);
     }
   };
   postMessage({ type: "ready" });


### PR DESCRIPTION
## Summary
- Adds a per-block fold chevron in the WKWebView preview (Mac + iOS) and CodeMirror Live Preview, with `lang · first line · +N more lines` summaries.
- Persists fold state per-file across reopens, keyed by heading-scoped index (`{headingPath, indexUnderHeading}`) so unrelated edits don't lose state.
- Mac and iOS share a new `PreviewUserScripts` injector; Live Preview uses CodeMirror's `foldService` over `FencedCode` nodes; PDF export and QuickLook always render expanded.

## Test plan
- [ ] Preview (⌘2) on demo.md: click chevron on each block, verify the right block folds and the summary shows lang + first line + count.
- [ ] Switch files / quit and relaunch: folded blocks stay folded.
- [ ] Live Preview: fold a block, type elsewhere — block stays folded; renaming the enclosing heading expands it.
- [ ] iOS simulator: chevron is tappable, folds persist.
- [ ] Export PDF and QuickLook a file with folded blocks: both render fully expanded.

Fixes #297