### PR TITLE
[mac] Vault-aware CLI/MCP: status, search operators, find_related, move_note, public docs

### DIFF
--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -1109,14 +1109,18 @@ final class WorkspaceManager {
         return performVaultMove(from: sourceURL, to: destURL, kind: "Moved")
     }
 
-    /// Vault-aware move/rename. When the source falls under a managed
-    /// vault, every inbound `[[wiki-link]]` is rewritten to the new path
-    /// before the file moves, and the SQLite index is updated without
-    /// losing inbound link relationships. Outside any managed vault we
-    /// fall through to a plain `FileManager.moveItem`.
+    /// Vault-aware move/rename. When BOTH source and destination fall
+    /// under the same managed vault, every inbound `[[wiki-link]]` is
+    /// rewritten to the new path before the file moves, and the SQLite
+    /// index is updated without losing inbound link relationships.
+    /// Cross-vault moves and moves outside any managed vault fall
+    /// through to a plain `FileManager.moveItem` — the source vault's
+    /// link graph genuinely shouldn't follow a file that's leaving it,
+    /// and the destination vault's watcher will pick the new file up.
     private func performVaultMove(from url: URL, to newURL: URL, kind: String) -> URL? {
         if let (location, rootURL) = containingLocationAndRoot(for: url),
-           let index = vaultIndexes[location.id] {
+           let index = vaultIndexes[location.id],
+           isURL(newURL, under: rootURL) {
             let oldRelative = VaultIndex.relativePath(of: url, from: rootURL)
             let newRelative = VaultIndex.relativePath(of: newURL, from: rootURL)
             do {
@@ -1148,6 +1152,12 @@ final class WorkspaceManager {
             DiagnosticLog.log("Failed to \(kind.lowercased()): \(error.localizedDescription)")
             return nil
         }
+    }
+
+    private func isURL(_ url: URL, under root: URL) -> Bool {
+        let urlPath = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return urlPath == rootPath || urlPath.hasPrefix(rootPath + "/")
     }
 
     // MARK: - Sidebar drop handling

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -1095,15 +1095,7 @@ final class WorkspaceManager {
 
     func renameItem(at url: URL, to newName: String) -> URL? {
         let newURL = url.deletingLastPathComponent().appendingPathComponent(newName)
-        do {
-            try FileManager.default.moveItem(at: url, to: newURL)
-            rewriteMovedItemReferences(from: url, to: newURL)
-            DiagnosticLog.log("Renamed: \(url.lastPathComponent) → \(newName)")
-            return newURL
-        } catch {
-            DiagnosticLog.log("Failed to rename: \(error.localizedDescription)")
-            return nil
-        }
+        return performVaultMove(from: url, to: newURL, kind: "Renamed")
     }
 
     func moveItem(at sourceURL: URL, into folderURL: URL) -> URL? {
@@ -1114,13 +1106,46 @@ final class WorkspaceManager {
             return nil
         }
 
+        return performVaultMove(from: sourceURL, to: destURL, kind: "Moved")
+    }
+
+    /// Vault-aware move/rename. When the source falls under a managed
+    /// vault, every inbound `[[wiki-link]]` is rewritten to the new path
+    /// before the file moves, and the SQLite index is updated without
+    /// losing inbound link relationships. Outside any managed vault we
+    /// fall through to a plain `FileManager.moveItem`.
+    private func performVaultMove(from url: URL, to newURL: URL, kind: String) -> URL? {
+        if let (location, rootURL) = containingLocationAndRoot(for: url),
+           let index = vaultIndexes[location.id] {
+            let oldRelative = VaultIndex.relativePath(of: url, from: rootURL)
+            let newRelative = VaultIndex.relativePath(of: newURL, from: rootURL)
+            do {
+                try VaultMover.move(
+                    index: index,
+                    vaultRootURL: rootURL,
+                    oldRelativePath: oldRelative,
+                    newRelativePath: newRelative
+                )
+                rewriteMovedItemReferences(from: url, to: newURL)
+                DiagnosticLog.log("\(kind): \(url.lastPathComponent) → \(newURL.lastPathComponent)")
+                return newURL
+            } catch VaultMover.MoveError.sourceNotIndexed {
+                // File wasn't in the index yet (e.g. an untitled save that
+                // raced ahead of the watcher) — fall through to a plain
+                // move and let the watcher catch up.
+            } catch {
+                DiagnosticLog.log("Vault-aware \(kind.lowercased()) failed for \(url.lastPathComponent): \(error.localizedDescription)")
+                return nil
+            }
+        }
+
         do {
-            try FileManager.default.moveItem(at: sourceURL, to: destURL)
-            rewriteMovedItemReferences(from: sourceURL, to: destURL)
-            DiagnosticLog.log("Moved: \(sourceURL.lastPathComponent) → \(folderURL.lastPathComponent)/")
-            return destURL
+            try FileManager.default.moveItem(at: url, to: newURL)
+            rewriteMovedItemReferences(from: url, to: newURL)
+            DiagnosticLog.log("\(kind): \(url.lastPathComponent) → \(newURL.lastPathComponent)")
+            return newURL
         } catch {
-            DiagnosticLog.log("Failed to move: \(error.localizedDescription)")
+            DiagnosticLog.log("Failed to \(kind.lowercased()): \(error.localizedDescription)")
             return nil
         }
     }

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -715,7 +715,7 @@ final class WorkspaceManager {
 
         guard let url = doc.fileURL, doc.isDirty else { return true }
         do {
-            try doc.text.write(to: url, atomically: true, encoding: .utf8)
+            try CoordinatedFileIO.write(Data(doc.text.utf8), to: url)
             openDocuments[index].lastSavedText = doc.text
 
             let finalURL: URL
@@ -761,7 +761,7 @@ final class WorkspaceManager {
 
         do {
             let text = openDocuments[index].text
-            try text.write(to: url, atomically: true, encoding: .utf8)
+            try CoordinatedFileIO.write(Data(text.utf8), to: url)
             openDocuments[index].fileURL = url
             openDocuments[index].lastSavedText = text
             openDocuments[index].untitledNumber = nil

--- a/ClearlyCLI/CLI/ClearlyCLI.swift
+++ b/ClearlyCLI/CLI/ClearlyCLI.swift
@@ -20,6 +20,7 @@ struct ClearlyCLI: AsyncParsableCommand {
             UpdateCommand.self,
             VaultsCommand.self,
             IndexCommand.self,
+            StatusCommand.self,
         ]
     )
 }

--- a/ClearlyCLI/CLI/ClearlyCLI.swift
+++ b/ClearlyCLI/CLI/ClearlyCLI.swift
@@ -18,6 +18,7 @@ struct ClearlyCLI: AsyncParsableCommand {
             TagsCommand.self,
             CreateCommand.self,
             UpdateCommand.self,
+            MoveCommand.self,
             VaultsCommand.self,
             IndexCommand.self,
             StatusCommand.self,

--- a/ClearlyCLI/CLI/Commands/ListCommand.swift
+++ b/ClearlyCLI/CLI/Commands/ListCommand.swift
@@ -14,8 +14,11 @@ struct ListCommand: AsyncParsableCommand {
         Use --under to scope to a subdirectory prefix and --in-vault to
         scope to a single vault when multiple are loaded.
 
-        Output shape documented in README.md, section "clearly CLI" →
-        "Tool reference" → list_notes.
+        Why NDJSON? One record per line — streams as the walker produces
+        results, ideal for pipelines. Wrap with `jq -s '.'` if you want a
+        single JSON array.
+
+        Full reference: https://clearly.md/cli#list
 
         EXAMPLES
           # Every note across every vault

--- a/ClearlyCLI/CLI/Commands/MCPCommand.swift
+++ b/ClearlyCLI/CLI/Commands/MCPCommand.swift
@@ -1,21 +1,27 @@
 import ArgumentParser
 import ClearlyCore
 import Foundation
+import MCP
 
 struct MCPCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mcp",
-        abstract: "Start the Model Context Protocol stdio server.",
+        abstract: "Start the Model Context Protocol stdio server (default), or inspect registered tools.",
         discussion: """
         Runs a JSON-RPC MCP server over stdio, exposing Clearly tools
         (semantic_search, search_notes, get_backlinks, get_tags, read_note,
-        list_notes, get_headings, get_frontmatter, create_note, update_note).
+        list_notes, get_headings, get_frontmatter, create_note,
+        update_note). Use `clearly mcp tools` for the live registered set.
 
         This is the mode invoked by Claude Desktop, Claude Code, Cursor, and
         other MCP clients. Do not run it interactively — stdout is reserved
         for JSON-RPC frames; the process ends when stdin closes.
 
-        Client config examples are in README.md, section "ClearlyMCP".
+        Subcommands
+          serve    Start the stdio server (default; same as `clearly mcp`).
+          tools    Print every registered tool's name, description, and
+                   input/output schema as JSON. Useful for debugging an
+                   MCP client config or generating tool reference docs.
 
         EXAMPLES
           # Typical Claude Desktop config entry (in claude_desktop_config.json):
@@ -23,6 +29,25 @@ struct MCPCommand: AsyncParsableCommand {
 
           # Manual smoke test (pipe a JSON-RPC initialize request):
           echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' | clearly mcp
+
+          # List every registered tool:
+          clearly mcp tools | jq -r '.[].name'
+
+          # Inspect read-only-only set:
+          clearly mcp tools --read-only
+        """,
+        subcommands: [MCPServeCommand.self, MCPToolsCommand.self],
+        defaultSubcommand: MCPServeCommand.self
+    )
+}
+
+struct MCPServeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Start the MCP stdio server (default; same as `clearly mcp`).",
+        discussion: """
+        Reads JSON-RPC frames from stdin, writes responses to stdout. Logs
+        go to stderr. The process exits when stdin closes.
         """
     )
 
@@ -52,5 +77,51 @@ struct MCPCommand: AsyncParsableCommand {
         }
 
         try await MCPServer.start(vaults: vaults, readOnly: readOnly)
+    }
+}
+
+struct MCPToolsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tools",
+        abstract: "Print registered MCP tools and their schemas as JSON.",
+        discussion: """
+        Emits a single JSON array. Each entry is an MCP `Tool` object with
+        name, description, input schema, output schema, and annotations.
+        Honors `--read-only` to show only the read-only tool set.
+
+        EXAMPLES
+          clearly mcp tools | jq -r '.[].name'
+          clearly mcp tools --read-only | jq '.[] | {name, description}'
+        """
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Flag(name: .customLong("read-only"), help: "Show only the read-only tool set.")
+    var readOnly: Bool = false
+
+    func run() async throws {
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID]
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        let tools = ToolRegistry.listTools(vaults: vaults, readOnly: readOnly)
+
+        switch globals.format {
+        case .json:
+            try Emitter.emit(tools, format: .json)
+        case .text:
+            for tool in tools {
+                Emitter.emitLine(tool.name)
+            }
+        }
     }
 }

--- a/ClearlyCLI/CLI/Commands/MCPCommand.swift
+++ b/ClearlyCLI/CLI/Commands/MCPCommand.swift
@@ -117,7 +117,17 @@ struct MCPToolsCommand: AsyncParsableCommand {
 
         switch globals.format {
         case .json:
-            try Emitter.emit(tools, format: .json)
+            // MCP's wire format uses camelCase keys (`inputSchema`,
+            // `outputSchema`, `readOnlyHint`, …) so the dump matches what
+            // a client sees over JSON-RPC. The shared Emitter helper
+            // converts to snake_case for our own structured output, which
+            // would silently rename these keys and confuse anyone
+            // comparing against the spec.
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(tools)
+            FileHandle.standardOutput.write(data)
+            FileHandle.standardOutput.write(Data("\n".utf8))
         case .text:
             for tool in tools {
                 Emitter.emitLine(tool.name)

--- a/ClearlyCLI/CLI/Commands/MoveCommand.swift
+++ b/ClearlyCLI/CLI/Commands/MoveCommand.swift
@@ -1,0 +1,63 @@
+import ArgumentParser
+import ClearlyCore
+import Foundation
+
+struct MoveCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "move",
+        abstract: "Move or rename a note within a vault, rewriting every inbound [[wiki-link]].",
+        discussion: """
+        Vault-aware move. Reads every note that links to the source,
+        rewrites those `[[wiki-links]]` to point at the new path
+        (preserving heading anchors and aliases), then moves the file
+        and updates the SQLite index without losing inbound link
+        relationships.
+
+        Fails with exit 5 / error note_exists if the destination already
+        exists, exit 3 / note_not_found if the source doesn't exist.
+
+        EXAMPLES
+          # Rename in place
+          clearly move Inbox/draft.md Notes/published.md
+
+          # Move into a subfolder, keeping the filename
+          clearly move Inbox/draft.md Archive/2026/draft.md
+        """
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Argument(help: "Source vault-relative path.")
+    var fromPath: String
+
+    @Argument(help: "Destination vault-relative path.")
+    var toPath: String
+
+    @Option(name: .customLong("in-vault"), help: "Vault name or path (required when multiple vaults are loaded).")
+    var inVault: String?
+
+    func run() async throws {
+        let vaults: [LoadedVault]
+        do {
+            vaults = try IndexSet.openIndexes(globals)
+        } catch {
+            Emitter.emitError(
+                "no_vaults",
+                message: "Unable to open any vault index: \(error.localizedDescription)",
+                extra: ["bundle_id": globals.bundleID]
+            )
+            throw ExitCode(Exit.general)
+        }
+
+        do {
+            let result = try await moveNote(
+                MoveNoteArgs(fromPath: fromPath, toPath: toPath, vault: inVault),
+                vaults: vaults
+            )
+            try Emitter.emit(result, format: globals.format)
+        } catch let error as ToolError {
+            let code = Emitter.emitToolError(error)
+            throw ExitCode(code)
+        }
+    }
+}

--- a/ClearlyCLI/CLI/Commands/SearchCommand.swift
+++ b/ClearlyCLI/CLI/Commands/SearchCommand.swift
@@ -12,8 +12,12 @@ struct SearchCommand: AsyncParsableCommand {
         context excerpts. Output is NDJSON — one hit per line — which
         composes well with jq / xargs.
 
-        Output shape documented in README.md, section "clearly CLI" →
-        "Tool reference" → search_notes.
+        Why NDJSON? Streaming results land on stdout as the index produces
+        them, so callers can pipeline with `head`, `xargs`, or jq without
+        waiting for the full set. If you need a single JSON array instead,
+        wrap the output: `clearly search foo | jq -s '.'`.
+
+        Full reference: https://clearly.md/cli#search
 
         EXAMPLES
           # Basic search

--- a/ClearlyCLI/CLI/Commands/SearchCommand.swift
+++ b/ClearlyCLI/CLI/Commands/SearchCommand.swift
@@ -19,6 +19,12 @@ struct SearchCommand: AsyncParsableCommand {
 
         Full reference: https://clearly.md/cli#search
 
+        Operators inside the query string narrow results without
+        changing the schema:
+
+          tag:foo            File must carry tag 'foo'. Repeat for AND.
+          path:notes/sub     File path must start with this prefix.
+
         EXAMPLES
           # Basic search
           clearly search pricing
@@ -29,7 +35,12 @@ struct SearchCommand: AsyncParsableCommand {
           # Pipeline: list paths of the top 20 matches
           clearly search rust --limit 20 | jq -r '.relative_path'
 
-          # Combine with --in-vault via read (search searches all vaults):
+          # Tag and path filters
+          clearly search "tag:work meeting"
+          clearly search "path:journal/2026/ tag:idea"
+          clearly search "tag:open"          # filter-only, no free text
+
+          # Combine with read (search searches all vaults):
           clearly search budget | jq -r '.relative_path' | xargs -I{} clearly read {}
         """
     )

--- a/ClearlyCLI/CLI/Commands/StatusCommand.swift
+++ b/ClearlyCLI/CLI/Commands/StatusCommand.swift
@@ -1,0 +1,90 @@
+import ArgumentParser
+import ClearlyCore
+import Foundation
+
+private struct VaultStatus: Encodable {
+    let name: String
+    let path: String
+    let fileCount: Int
+    let lastIndexedAt: String?
+}
+
+private struct StatusReport: Encodable {
+    let binaryVersion: String
+    let bundleId: String
+    let embeddingModelVersion: Int
+    let vaultCount: Int
+    let vaults: [VaultStatus]
+}
+
+struct StatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Print binary, vault, and index diagnostics as a single JSON document.",
+        discussion: """
+        One-shot diagnostic snapshot of the CLI process. Reports binary
+        version, configured bundle id, embedding model version, every
+        loaded vault with file count and last-indexed timestamp.
+
+        Unlike `clearly vaults list` (which streams NDJSON for piping),
+        `status` emits a single JSON object — intended for support tickets,
+        debug captures, and human eyeballing.
+
+        EXAMPLES
+          # JSON snapshot
+          clearly status
+
+          # Vault count only
+          clearly status | jq '.vault_count'
+
+          # Human-readable
+          clearly status --format text
+        """
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    func run() async throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var vaultStatuses: [VaultStatus] = []
+        if let loaded = try? IndexSet.openIndexes(globals) {
+            vaultStatuses = loaded.map { vault in
+                VaultStatus(
+                    name: vault.url.lastPathComponent,
+                    path: vault.url.path,
+                    fileCount: vault.index.fileCount(),
+                    lastIndexedAt: vault.index.lastIndexedAt().map { formatter.string(from: $0) }
+                )
+            }
+        }
+
+        let binaryVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+
+        let report = StatusReport(
+            binaryVersion: binaryVersion,
+            bundleId: globals.bundleID,
+            embeddingModelVersion: EmbeddingService.MODEL_VERSION,
+            vaultCount: vaultStatuses.count,
+            vaults: vaultStatuses
+        )
+
+        switch globals.format {
+        case .json:
+            try Emitter.emit(report, format: .json)
+        case .text:
+            Emitter.emitLine("clearly \(report.binaryVersion)")
+            Emitter.emitLine("bundle id:               \(report.bundleId)")
+            Emitter.emitLine("embedding model version: \(report.embeddingModelVersion)")
+            Emitter.emitLine("vaults loaded:           \(report.vaultCount)")
+            for vault in report.vaults {
+                Emitter.emitLine("")
+                Emitter.emitLine("  \(vault.name)")
+                Emitter.emitLine("    path:            \(vault.path)")
+                Emitter.emitLine("    file count:      \(vault.fileCount)")
+                Emitter.emitLine("    last indexed at: \(vault.lastIndexedAt ?? "—")")
+            }
+        }
+    }
+}

--- a/ClearlyCLI/CLI/Commands/TagsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/TagsCommand.swift
@@ -17,8 +17,10 @@ struct TagsCommand: AsyncParsableCommand {
         Tags come from both inline #hashtags and YAML frontmatter `tags:`
         entries. The argument must NOT include the leading "#".
 
-        Output shape documented in README.md, section "clearly CLI" →
-        "Tool reference" → get_tags.
+        Output is NDJSON in JSON mode — one record per line, streamed.
+        Wrap with `jq -s '.'` for a single JSON array.
+
+        Full reference: https://clearly.md/cli#tags
 
         EXAMPLES
           # Top 20 tags by count

--- a/ClearlyCLI/CLI/Commands/UpdateCommand.swift
+++ b/ClearlyCLI/CLI/Commands/UpdateCommand.swift
@@ -57,6 +57,9 @@ struct UpdateCommand: AsyncParsableCommand {
     @Option(name: .customLong("in-vault"), help: "Vault name or path.")
     var inVault: String?
 
+    @Option(name: .customLong("expected-content-hash"), help: "Optional optimistic-concurrency guard. Reject the update with exit 5 / error stale_content if the on-disk SHA-256 doesn't match.")
+    var expectedContentHash: String?
+
     func run() async throws {
         let body: String
         if let c = content {
@@ -86,7 +89,13 @@ struct UpdateCommand: AsyncParsableCommand {
 
         do {
             let result = try await updateNote(
-                UpdateNoteArgs(relativePath: relativePath, content: body, mode: mode, vault: inVault),
+                UpdateNoteArgs(
+                    relativePath: relativePath,
+                    content: body,
+                    mode: mode,
+                    vault: inVault,
+                    expectedContentHash: expectedContentHash
+                ),
                 vaults: vaults
             )
             try Emitter.emit(result, format: globals.format)

--- a/ClearlyCLI/CLI/Commands/VaultsCommand.swift
+++ b/ClearlyCLI/CLI/Commands/VaultsCommand.swift
@@ -40,9 +40,16 @@ struct VaultsListCommand: AsyncParsableCommand {
         vault. `last_indexed_at` is an ISO-8601 timestamp (fractional
         seconds) or null when the index is empty.
 
+        Output is NDJSON — one vault per line. Wrap with `jq -s '.'` for
+        a single JSON array. For a single-document diagnostic snapshot
+        (binary version, embedding model, all vaults), use
+        `clearly status` instead.
+
         EXAMPLES
           clearly vaults list
           clearly vaults list | jq -r '.name + "\\t" + (.file_count|tostring)'
+
+        Full reference: https://clearly.md/cli#vaults
         """
     )
 

--- a/ClearlyCLI/Core/ToolError.swift
+++ b/ClearlyCLI/Core/ToolError.swift
@@ -9,6 +9,9 @@ enum ToolError: Error, LocalizedError {
     case pathOutsideVault(String)
     case ambiguousVault(relativePath: String, matches: [String])
     case conflict(existingPath: String)
+    /// On-disk content hash didn't match the caller's `expected_content_hash`.
+    /// The agent should re-read the note and retry the write with a fresh hash.
+    case staleContent(relativePath: String, expected: String, actual: String)
 
     // Exact text the MCP adapter emits in the `.text` content block. Preserves
     // byte-for-byte parity with the pre-refactor handler output — notably,
@@ -29,6 +32,8 @@ enum ToolError: Error, LocalizedError {
             return "Ambiguous path '\(path)': matches \(matches.count) vaults (\(matches.joined(separator: ", "))). Specify --vault or the vault field."
         case .conflict(let path):
             return "Note already exists: \(path)\nUse update_note to modify existing notes."
+        case .staleContent(let path, let expected, let actual):
+            return "Note has changed on disk since you last read it: \(path) (expected hash \(expected), actual \(actual)). Re-read the note and retry."
         }
     }
 }
@@ -78,6 +83,13 @@ extension ToolError {
             payload["error"] = "note_exists"
             payload["message"] = errorDescription ?? ""
             payload["relative_path"] = path
+        case .staleContent(let path, let expected, let actual):
+            code = 5
+            payload["error"] = "stale_content"
+            payload["message"] = errorDescription ?? ""
+            payload["relative_path"] = path
+            payload["expected_content_hash"] = expected
+            payload["actual_content_hash"] = actual
         }
 
         let data = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data("{}".utf8)

--- a/ClearlyCLI/Core/Tools/CreateNote.swift
+++ b/ClearlyCLI/Core/Tools/CreateNote.swift
@@ -44,7 +44,7 @@ func createNote(_ args: CreateNoteArgs, vaults: [LoadedVault]) async throws -> C
     try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
 
     let data = Data(args.content.utf8)
-    try data.write(to: fileURL, options: .atomic)
+    try CoordinatedFileIO.write(data, to: fileURL)
 
     try loaded.index.updateFile(at: args.relativePath)
 

--- a/ClearlyCLI/Core/Tools/FindRelated.swift
+++ b/ClearlyCLI/Core/Tools/FindRelated.swift
@@ -56,7 +56,10 @@ func findRelated(_ args: FindRelatedArgs, vaults: [LoadedVault]) async throws ->
         throw ToolError.noteNotFound(args.relativePath)
     }
 
-    let sourceChunks = try sourceVault.index.chunkEmbeddings(forFileID: sourceFile.id)
+    let sourceChunks = try sourceVault.index.currentChunkEmbeddings(
+        forFileID: sourceFile.id,
+        modelVersion: EmbeddingService.MODEL_VERSION
+    )
     guard let queryVector = meanVector(of: sourceChunks.map(\.vector)) else {
         return FindRelatedResult(
             vault: sourceVault.url.lastPathComponent,

--- a/ClearlyCLI/Core/Tools/FindRelated.swift
+++ b/ClearlyCLI/Core/Tools/FindRelated.swift
@@ -1,0 +1,133 @@
+import Foundation
+import ClearlyCore
+
+struct FindRelatedArgs: Codable {
+    let relativePath: String
+    let limit: Int?
+    let vault: String?
+}
+
+struct FindRelatedResult: Codable {
+    struct Hit: Codable {
+        let vault: String
+        let vaultPath: String
+        let relativePath: String
+        let filename: String
+        let score: Float
+    }
+    let vault: String
+    let source: String
+    let totalCount: Int
+    let returnedCount: Int
+    let results: [Hit]
+}
+
+/// "Notes related to this one." Reuses the existing chunk embeddings —
+/// loads every chunk from the source file, takes their mean vector, and
+/// scores it against every other file's chunks via cosine. Best score
+/// per file, source excluded, descending by similarity.
+///
+/// English-only by virtue of the underlying embedding service. Files
+/// whose chunks are missing or stale (model version mismatch) are
+/// silently skipped on both sides — no separate error.
+func findRelated(_ args: FindRelatedArgs, vaults: [LoadedVault]) async throws -> FindRelatedResult {
+    guard !args.relativePath.isEmpty else {
+        throw ToolError.missingArgument("relative_path")
+    }
+    if let raw = args.limit, raw <= 0 {
+        throw ToolError.invalidArgument(name: "limit", reason: "must be greater than 0")
+    }
+    let limit = min(args.limit ?? 10, 50)
+
+    let sourceVault: LoadedVault
+    switch try VaultResolver.resolve(relativePath: args.relativePath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.relativePath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.relativePath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let v):
+        sourceVault = v
+    }
+
+    guard let sourceFile = sourceVault.index.file(forRelativePath: args.relativePath) else {
+        throw ToolError.noteNotFound(args.relativePath)
+    }
+
+    let sourceChunks = try sourceVault.index.chunkEmbeddings(forFileID: sourceFile.id)
+    guard let queryVector = meanVector(of: sourceChunks.map(\.vector)) else {
+        return FindRelatedResult(
+            vault: sourceVault.url.lastPathComponent,
+            source: args.relativePath,
+            totalCount: 0,
+            returnedCount: 0,
+            results: []
+        )
+    }
+
+    // Optional vault narrowing — same convention as semantic_search:
+    // substring match on path or basename.
+    let candidateVaults: [LoadedVault]
+    if let filter = args.vault, !filter.isEmpty {
+        let lower = filter.lowercased()
+        candidateVaults = vaults.filter {
+            $0.url.path.lowercased().contains(lower) || $0.url.lastPathComponent.lowercased().contains(lower)
+        }
+    } else {
+        candidateVaults = vaults
+    }
+
+    var bestPerFile: [String: (vault: LoadedVault, path: String, score: Float)] = [:]
+    for vault in candidateVaults {
+        let stored = try vault.index.allChunkEmbeddings(modelVersion: EmbeddingService.MODEL_VERSION)
+        for entry in stored {
+            // Skip the source itself. Match on (vault path, relative path)
+            // so two vaults with same-named files don't cross-contaminate.
+            if vault.url.path == sourceVault.url.path && entry.path == sourceFile.path {
+                continue
+            }
+            guard entry.vector.count == queryVector.count else { continue }
+            let score = EmbeddingService.cosine(queryVector, entry.vector)
+            let key = "\(vault.url.path)\u{0}\(entry.path)"
+            if let prev = bestPerFile[key], prev.score >= score { continue }
+            bestPerFile[key] = (vault, entry.path, score)
+        }
+    }
+
+    let scored = bestPerFile.values.sorted { $0.score > $1.score }
+    let capped = Array(scored.prefix(limit))
+    let hits = capped.map { item -> FindRelatedResult.Hit in
+        let filename = URL(fileURLWithPath: item.path).deletingPathExtension().lastPathComponent
+        return FindRelatedResult.Hit(
+            vault: item.vault.url.lastPathComponent,
+            vaultPath: item.vault.url.path,
+            relativePath: item.path,
+            filename: filename,
+            score: item.score
+        )
+    }
+
+    return FindRelatedResult(
+        vault: sourceVault.url.lastPathComponent,
+        source: args.relativePath,
+        totalCount: scored.count,
+        returnedCount: hits.count,
+        results: hits
+    )
+}
+
+private func meanVector(of vectors: [[Float]]) -> [Float]? {
+    guard let first = vectors.first, !first.isEmpty else { return nil }
+    let dims = first.count
+    var sum = [Float](repeating: 0, count: dims)
+    var count: Int = 0
+    for vec in vectors where vec.count == dims {
+        for i in 0..<dims { sum[i] += vec[i] }
+        count += 1
+    }
+    guard count > 0 else { return nil }
+    let inv = 1 / Float(count)
+    return sum.map { $0 * inv }
+}

--- a/ClearlyCLI/Core/Tools/MoveNote.swift
+++ b/ClearlyCLI/Core/Tools/MoveNote.swift
@@ -62,6 +62,8 @@ func moveNote(_ args: MoveNoteArgs, vaults: [LoadedVault]) async throws -> MoveN
         )
     } catch VaultMover.MoveError.sourceNotIndexed {
         throw ToolError.noteNotFound(args.fromPath)
+    } catch VaultMover.MoveError.destinationExists(_) {
+        throw ToolError.conflict(existingPath: args.toPath)
     }
 
     return MoveNoteResult(

--- a/ClearlyCLI/Core/Tools/MoveNote.swift
+++ b/ClearlyCLI/Core/Tools/MoveNote.swift
@@ -1,0 +1,75 @@
+import Foundation
+import ClearlyCore
+
+struct MoveNoteArgs: Codable {
+    let fromPath: String
+    let toPath: String
+    let vault: String?
+}
+
+struct MoveNoteResult: Codable {
+    struct Rewrite: Codable {
+        let relativePath: String
+        let count: Int
+    }
+    let vault: String
+    let from: String
+    let to: String
+    let linksRewritten: [Rewrite]
+}
+
+/// Move a note within a vault, rewriting every inbound `[[wiki-link]]`
+/// to point at the new path. See `VaultMover` for the orchestration —
+/// this tool is the MCP/CLI surface.
+func moveNote(_ args: MoveNoteArgs, vaults: [LoadedVault]) async throws -> MoveNoteResult {
+    guard !args.fromPath.isEmpty else {
+        throw ToolError.missingArgument("from_path")
+    }
+    guard !args.toPath.isEmpty else {
+        throw ToolError.missingArgument("to_path")
+    }
+    if args.fromPath == args.toPath {
+        throw ToolError.invalidArgument(name: "to_path", reason: "must differ from from_path")
+    }
+
+    let loaded: LoadedVault
+    switch try VaultResolver.resolve(relativePath: args.fromPath, hint: args.vault, in: vaults) {
+    case .notFound:
+        throw ToolError.noteNotFound(args.fromPath)
+    case .ambiguous(let matches):
+        throw ToolError.ambiguousVault(
+            relativePath: args.fromPath,
+            matches: matches.map { $0.url.lastPathComponent }
+        )
+    case .resolved(let v):
+        loaded = v
+    }
+
+    // Path-traversal validation. Both ends must resolve inside the vault.
+    _ = try PathGuard.resolve(relativePath: args.fromPath, in: loaded.url)
+    let destURL = try PathGuard.resolve(relativePath: args.toPath, in: loaded.url)
+    if FileManager.default.fileExists(atPath: destURL.path) {
+        throw ToolError.conflict(existingPath: args.toPath)
+    }
+
+    let outcome: VaultMover.Outcome
+    do {
+        outcome = try VaultMover.move(
+            index: loaded.index,
+            vaultRootURL: loaded.url,
+            oldRelativePath: args.fromPath,
+            newRelativePath: args.toPath
+        )
+    } catch VaultMover.MoveError.sourceNotIndexed {
+        throw ToolError.noteNotFound(args.fromPath)
+    }
+
+    return MoveNoteResult(
+        vault: loaded.url.lastPathComponent,
+        from: args.fromPath,
+        to: args.toPath,
+        linksRewritten: outcome.linksRewritten.map {
+            MoveNoteResult.Rewrite(relativePath: $0.relativePath, count: $0.count)
+        }
+    )
+}

--- a/ClearlyCLI/Core/Tools/UpdateNote.swift
+++ b/ClearlyCLI/Core/Tools/UpdateNote.swift
@@ -13,6 +13,12 @@ struct UpdateNoteArgs: Codable {
     let content: String
     let mode: UpdateMode
     let vault: String?
+    /// Optional optimistic-concurrency guard. When provided, the tool
+    /// hashes the on-disk file before writing and rejects the call if the
+    /// hash doesn't match — protecting against the user (or another
+    /// agent) editing the file between the agent's last read and this
+    /// write. Omit to skip the check.
+    let expectedContentHash: String?
 }
 
 struct UpdateNoteResult: Codable {
@@ -44,7 +50,15 @@ func updateNote(_ args: UpdateNoteArgs, vaults: [LoadedVault]) async throws -> U
 
     let fileURL = try PathGuard.resolve(relativePath: args.relativePath, in: loaded.url)
 
-    let rawData = try Data(contentsOf: fileURL)
+    let rawData = try CoordinatedFileIO.read(at: fileURL)
+    let actualHash = sha256Hex(rawData)
+    if let expected = args.expectedContentHash, expected != actualHash {
+        throw ToolError.staleContent(
+            relativePath: args.relativePath,
+            expected: expected,
+            actual: actualHash
+        )
+    }
     guard let existing = String(data: rawData, encoding: .utf8) else {
         throw ToolError.invalidEncoding(args.relativePath)
     }
@@ -65,12 +79,11 @@ func updateNote(_ args: UpdateNoteArgs, vaults: [LoadedVault]) async throws -> U
     }
 
     let newData = Data(composed.utf8)
-    try newData.write(to: fileURL, options: .atomic)
+    try CoordinatedFileIO.write(newData, to: fileURL)
 
     try loaded.index.updateFile(at: args.relativePath)
 
-    let hash = SHA256.hash(data: newData)
-    let contentHash = hash.map { String(format: "%02x", $0) }.joined()
+    let contentHash = sha256Hex(newData)
 
     let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
     let modifiedAt = (attrs?[.modificationDate] as? Date) ?? Date()
@@ -85,4 +98,8 @@ func updateNote(_ args: UpdateNoteArgs, vaults: [LoadedVault]) async throws -> U
         sizeBytes: newData.count,
         modifiedAt: iso.string(from: modifiedAt)
     )
+}
+
+private func sha256Hex(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
 }

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -28,6 +28,16 @@ enum Handlers {
                 return try await searchNotes(args, vaults: vaults)
             }
 
+        case "find_related":
+            return await structuredCall {
+                let args = FindRelatedArgs(
+                    relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
+                    limit: params.arguments?["limit"]?.intValue,
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return try await findRelated(args, vaults: vaults)
+            }
+
         case "get_backlinks":
             return await structuredCall {
                 let args = GetBacklinksArgs(

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -111,7 +111,8 @@ enum Handlers {
                     relativePath: params.arguments?["relative_path"]?.stringValue ?? "",
                     content: params.arguments?["content"]?.stringValue ?? "",
                     mode: mode,
-                    vault: params.arguments?["vault"]?.stringValue
+                    vault: params.arguments?["vault"]?.stringValue,
+                    expectedContentHash: params.arguments?["expected_content_hash"]?.stringValue
                 )
                 return try await updateNote(args, vaults: vaults)
             }

--- a/ClearlyCLI/MCP/Handlers.swift
+++ b/ClearlyCLI/MCP/Handlers.swift
@@ -101,6 +101,16 @@ enum Handlers {
                 return try await createNote(args, vaults: vaults)
             }
 
+        case "move_note":
+            return await structuredCall {
+                let args = MoveNoteArgs(
+                    fromPath: params.arguments?["from_path"]?.stringValue ?? "",
+                    toPath: params.arguments?["to_path"]?.stringValue ?? "",
+                    vault: params.arguments?["vault"]?.stringValue
+                )
+                return try await moveNote(args, vaults: vaults)
+            }
+
         case "update_note":
             return await structuredCall {
                 guard let modeStr = params.arguments?["mode"]?.stringValue,

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -60,6 +60,42 @@ enum ToolRegistry {
                 ])
             ),
             Tool(
+                name: "find_related",
+                description: "Find notes semantically related to a given note. Reuses on-device embeddings to score every other note's chunks against the source's mean vector, returns the top matches with cosine similarity. Use when you have one note and want \"more like this\" — e.g. surface adjacent thinking, related projects, or earlier passes at the same idea. English-only via Apple's NLContextualEmbedding.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "relative_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path of the source note, e.g. 'Notes/local-first.md'.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "minimum": .int(1),
+                            "description": .string("Max results to return. Default 10, capped at 50.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name or path substring. When set, only matching vaults are searched. The source note must still resolve unambiguously among loaded vaults.")
+                        ])
+                    ]),
+                    "required": .array([.string("relative_path")])
+                ]),
+                annotations: readAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":           .object(["type": .string("string"), "description": .string("Vault that owns the source note.")]),
+                        "source":          .object(["type": .string("string"), "description": .string("Vault-relative path of the source note.")]),
+                        "total_count":     .object(["type": .string("integer"), "description": .string("Number of distinct files scored across the selected vaults.")]),
+                        "returned_count":  .object(["type": .string("integer"), "description": .string("Number of hits in the results array after applying limit.")]),
+                        "results":         .object(["type": .string("array"), "items": .object(["type": .string("object")]), "description": .string("Ranked top-N. Each item has 'vault', 'vault_path', 'relative_path', 'filename', 'score' (cosine similarity, -1…1, higher is closer).")])
+                    ]),
+                    "required": .array([.string("vault"), .string("source"), .string("total_count"), .string("returned_count"), .string("results")])
+                ])
+            ),
+            Tool(
                 name: "search_notes",
                 description: "Full-text search across all notes in Clearly. Searches \(vaults.count) vault(s): \(vaultDescription). Returns relevance-ranked results with context snippets. Uses BM25 ranking and stemming. Supports `tag:foo` (AND-combined, case-insensitive) and `path:notes/sub` operators inside the query string to narrow by tag or vault-relative path prefix. Results include the vault path and relative file path — use standard file access to read full content.",
                 inputSchema: .object([

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -352,7 +352,7 @@ enum ToolRegistry {
             ),
             Tool(
                 name: "update_note",
-                description: "Update an existing note. Mode 'replace' overwrites the entire file. Mode 'append' adds content to the end (with a leading newline if the file does not end in one). Mode 'prepend' inserts content after YAML frontmatter if present, or at the beginning of the file.",
+                description: "Update an existing note. Mode 'replace' overwrites the entire file. Mode 'append' adds content to the end (with a leading newline if the file does not end in one). Mode 'prepend' inserts content after YAML frontmatter if present, or at the beginning of the file. Pass `expected_content_hash` (the value `read_note` returned) to opt into optimistic concurrency: the call is rejected with `stale_content` if the file changed since you last read it.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "additionalProperties": .bool(false),
@@ -373,6 +373,10 @@ enum ToolRegistry {
                         "vault": .object([
                             "type": .string("string"),
                             "description": .string("Optional vault name; required only when 'relative_path' is ambiguous across multiple loaded vaults.")
+                        ]),
+                        "expected_content_hash": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional. SHA-256 hex digest of the on-disk content the agent last observed (typically from `read_note`). If provided and the on-disk hash differs at write time, the call is rejected with error `stale_content` so the agent can re-read and retry without clobbering a concurrent edit.")
                         ])
                     ]),
                     "required": .array([.string("relative_path"), .string("content"), .string("mode")])

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -61,14 +61,14 @@ enum ToolRegistry {
             ),
             Tool(
                 name: "search_notes",
-                description: "Full-text search across all notes in Clearly. Searches \(vaults.count) vault(s): \(vaultDescription). Returns relevance-ranked results with context snippets. Uses BM25 ranking and stemming. Results include the vault path and relative file path — use standard file access to read full content.",
+                description: "Full-text search across all notes in Clearly. Searches \(vaults.count) vault(s): \(vaultDescription). Returns relevance-ranked results with context snippets. Uses BM25 ranking and stemming. Supports `tag:foo` (AND-combined, case-insensitive) and `path:notes/sub` operators inside the query string to narrow by tag or vault-relative path prefix. Results include the vault path and relative file path — use standard file access to read full content.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "additionalProperties": .bool(false),
                     "properties": .object([
                         "query": .object([
                             "type": .string("string"),
-                            "description": .string("Search query. Supports quoted phrases for exact match.")
+                            "description": .string("Search query. Supports quoted phrases for exact match. Operators: `tag:work` filters to files carrying that tag (repeat for AND); `path:journal/2026/` filters by vault-relative path prefix. Filter-only queries (e.g. `tag:idea`) are valid and return every matching file.")
                         ]),
                         "limit": .object([
                             "type": .string("integer"),

--- a/ClearlyCLI/MCP/ToolRegistry.swift
+++ b/ClearlyCLI/MCP/ToolRegistry.swift
@@ -3,7 +3,7 @@ import ClearlyCore
 import MCP
 
 enum ToolRegistry {
-    static let writeToolNames: Set<String> = ["create_note", "update_note"]
+    static let writeToolNames: Set<String> = ["create_note", "update_note", "move_note"]
 
     static func listTools(vaults: [LoadedVault], readOnly: Bool = false) -> [Tool] {
         let vaultPaths = vaults.map { $0.url.path }
@@ -348,6 +348,44 @@ enum ToolRegistry {
                         "created_at":    .object(["type": .string("string"), "format": .string("date-time")])
                     ]),
                     "required": .array([.string("vault"), .string("relative_path"), .string("content_hash"), .string("size_bytes"), .string("created_at")])
+                ])
+            ),
+            Tool(
+                name: "move_note",
+                description: "Rename or move a note within a vault, rewriting every inbound [[wiki-link]] in other notes to point at the new path. Preserves heading anchors and aliases on rewritten links. Index `id` is preserved across the move, so backlink relationships survive without re-resolution. Fails with note_exists if the destination already exists.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "from_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative path of the source note, e.g. 'Inbox/draft.md'.")
+                        ]),
+                        "to_path": .object([
+                            "type": .string("string"),
+                            "description": .string("Vault-relative destination path, e.g. 'Notes/published.md'. Parent folders are created automatically.")
+                        ]),
+                        "vault": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional vault name; required only when 'from_path' is ambiguous across multiple loaded vaults.")
+                        ])
+                    ]),
+                    "required": .array([.string("from_path"), .string("to_path")])
+                ]),
+                annotations: writeAnnotations,
+                outputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "vault":           .object(["type": .string("string")]),
+                        "from":            .object(["type": .string("string")]),
+                        "to":              .object(["type": .string("string")]),
+                        "links_rewritten": .object([
+                            "type": .string("array"),
+                            "items": .object(["type": .string("object")]),
+                            "description": .string("Per-file count of [[wiki-link]] rewrites. Each entry has 'relative_path' and 'count'.")
+                        ])
+                    ]),
+                    "required": .array([.string("vault"), .string("from"), .string("to"), .string("links_rewritten")])
                 ])
             ),
             Tool(

--- a/ClearlyCLIIntegrationTests/ConcurrentEditTests.swift
+++ b/ClearlyCLIIntegrationTests/ConcurrentEditTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import ClearlyCore
+import MCP
+import CryptoKit
+import XCTest
+
+/// Coverage of the new write-coordination + optimistic-concurrency
+/// behavior on `update_note`. Both surfaces (the editor save path and
+/// MCP write tools) now route writes through `CoordinatedFileIO`, and
+/// `update_note` accepts an optional `expected_content_hash` that
+/// rejects stale-base writes.
+final class ConcurrentEditTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    private struct UpdateResult: Decodable {
+        let contentHash: String
+    }
+
+    private func sha256(_ url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    func testExpectedHashMismatchReturnsStaleContent() async throws {
+        let url = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        // Mutate the file out from under us so the agent's "expected"
+        // hash is now stale.
+        try "wrong base".data(using: .utf8)!.write(to: url, options: .atomic)
+        let staleHash = String(repeating: "0", count: 64)
+
+        let payload = try await harness.callToolExpectingError(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Notes/Linker.md"),
+                "content": .string("# replaced\n"),
+                "mode": .string("replace"),
+                "expected_content_hash": .string(staleHash),
+            ]
+        )
+        XCTAssertEqual(payload.error, "stale_content")
+    }
+
+    func testExpectedHashMatchAllowsUpdate() async throws {
+        let url = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        let currentHash = try sha256(url)
+
+        let result = try await harness.callTool(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Notes/Linker.md"),
+                "content": .string("# replaced\n"),
+                "mode": .string("replace"),
+                "expected_content_hash": .string(currentHash),
+            ],
+            as: UpdateResult.self
+        )
+        let actual = try sha256(url)
+        XCTAssertEqual(actual, result.contentHash, "tool's reported hash must equal on-disk hash")
+        XCTAssertNotEqual(actual, currentHash, "file should have changed")
+    }
+
+    func testMissingExpectedHashStillSucceedsForBackwardCompatibility() async throws {
+        // Legacy callers don't send expected_content_hash. The tool must
+        // still accept the call and write through.
+        let result = try await harness.callTool(
+            "update_note",
+            arguments: [
+                "relative_path": .string("Notes/Linker.md"),
+                "content": .string("legacy update\n"),
+                "mode": .string("replace"),
+            ],
+            as: UpdateResult.self
+        )
+        let onDisk = try sha256(harness.vaultURL.appendingPathComponent("Notes/Linker.md"))
+        XCTAssertEqual(onDisk, result.contentHash)
+    }
+
+    /// Two writers racing the same file via `CoordinatedFileIO` must
+    /// produce a final state matching exactly one of the two payloads —
+    /// not a torn mix. (This is the OS file-coordinator's contract; we
+    /// just verify our paths actually go through it.)
+    func testConcurrentCoordinatedWritesProduceOneOrTheOtherNotTorn() async throws {
+        let url = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        let payloadA = String(repeating: "A", count: 4096) + "\n"
+        let payloadB = String(repeating: "B", count: 4096) + "\n"
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try? CoordinatedFileIO.write(Data(payloadA.utf8), to: url)
+            }
+            group.addTask {
+                try? CoordinatedFileIO.write(Data(payloadB.utf8), to: url)
+            }
+        }
+
+        let final = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(
+            final == payloadA || final == payloadB,
+            "Coordinated writes must serialize; final must equal one full payload, not a mix"
+        )
+    }
+}

--- a/ClearlyCLIIntegrationTests/FindRelatedTests.swift
+++ b/ClearlyCLIIntegrationTests/FindRelatedTests.swift
@@ -151,6 +151,28 @@ final class FindRelatedTests: XCTestCase {
         XCTAssertTrue(result.results.isEmpty)
     }
 
+    func testReturnsEmptyResultsWhenSourceEmbeddingsAreStale() async throws {
+        let index = harness.loadedVaults[0].index
+        guard let source = index.file(forRelativePath: "Notes/Linker.md") else {
+            return XCTFail("source missing from fixture")
+        }
+
+        try seedChunk(index, file: source, vector: [1, 0])
+
+        let url = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        try Data("# changed\n".utf8).write(to: url, options: .atomic)
+        _ = try index.updateFile(at: "Notes/Linker.md")
+
+        let result = try await harness.callTool(
+            "find_related",
+            arguments: ["relative_path": .string("Notes/Linker.md")],
+            as: Result.self
+        )
+        XCTAssertEqual(result.totalCount, 0)
+        XCTAssertEqual(result.returnedCount, 0)
+        XCTAssertTrue(result.results.isEmpty)
+    }
+
     func testMissingSourceErrors() async throws {
         let payload = try await harness.callToolExpectingError(
             "find_related",

--- a/ClearlyCLIIntegrationTests/FindRelatedTests.swift
+++ b/ClearlyCLIIntegrationTests/FindRelatedTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import ClearlyCore
+import MCP
+import NaturalLanguage
+import XCTest
+
+/// End-to-end coverage of the `find_related` MCP tool.
+///
+/// Instead of relying on the live `NLContextualEmbedding` model (which
+/// requires English assets that aren't always available on test
+/// runners), these tests seed deterministic unit vectors directly via
+/// `VaultIndex.upsertChunkEmbeddings` so cosine ranking is exact and
+/// self-validating.
+final class FindRelatedTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    // MARK: - Helpers (mirrored from MCPIntegrationTests)
+
+    private func skipIfEmbeddingAssetsMissing() throws {
+        guard let probe = NLContextualEmbedding(language: .english), probe.hasAvailableAssets else {
+            throw XCTSkip("NLContextualEmbedding English assets not available on this runner")
+        }
+    }
+
+    private func unitVector(at index: Int, dim: Int) -> [Float] {
+        var v = [Float](repeating: 0, count: dim)
+        if dim > 0 { v[index % dim] = 1.0 }
+        return v
+    }
+
+    private func seedChunk(
+        _ index: VaultIndex,
+        file: IndexedFile,
+        vector: [Float],
+        modelVersion: Int = EmbeddingService.MODEL_VERSION
+    ) throws {
+        let body = "fixture seed for \(file.path)"
+        try index.upsertChunkEmbeddings(
+            fileID: file.id,
+            contentHash: file.contentHash,
+            chunks: [
+                VaultIndex.ChunkEmbeddingInput(
+                    chunkIndex: 0,
+                    textOffset: 0,
+                    textLength: body.utf8.count,
+                    headingPath: [],
+                    body: body,
+                    vector: vector
+                )
+            ],
+            modelVersion: modelVersion
+        )
+    }
+
+    // MARK: - Result decoding
+
+    private struct Hit: Decodable {
+        let relativePath: String
+        let score: Float
+    }
+    private struct Result: Decodable {
+        let vault: String
+        let source: String
+        let totalCount: Int
+        let returnedCount: Int
+        let results: [Hit]
+    }
+
+    // MARK: - Tests
+
+    func testRanksClosestVectorFirst() async throws {
+        try skipIfEmbeddingAssetsMissing()
+        let index = harness.loadedVaults[0].index
+        let dim = try EmbeddingService().dimension
+
+        // Use real fixture files. The source's mean vector lives at
+        // index 0; the "near" file shares index 0; "far" sits at index 2.
+        guard
+            let source = index.file(forRelativePath: "Notes/Linker.md"),
+            let near = index.file(forRelativePath: "README.md"),
+            let far = index.file(forRelativePath: "Notes/Link Target.md")
+        else {
+            return XCTFail("fixture files missing")
+        }
+
+        try seedChunk(index, file: source, vector: unitVector(at: 0, dim: dim))
+        try seedChunk(index, file: near, vector: unitVector(at: 0, dim: dim))
+        try seedChunk(index, file: far, vector: unitVector(at: 2, dim: dim))
+
+        let result = try await harness.callTool(
+            "find_related",
+            arguments: ["relative_path": .string("Notes/Linker.md")],
+            as: Result.self
+        )
+
+        XCTAssertEqual(result.source, "Notes/Linker.md")
+        XCTAssertEqual(result.totalCount, 2, "source itself must be excluded")
+        XCTAssertEqual(result.returnedCount, 2)
+        XCTAssertEqual(result.results.first?.relativePath, "README.md", "closest vector should rank first")
+        // Scores monotonically non-increasing.
+        for i in 1..<result.results.count {
+            XCTAssertGreaterThanOrEqual(result.results[i - 1].score, result.results[i].score)
+        }
+        // Source must never appear.
+        XCTAssertFalse(result.results.contains { $0.relativePath == "Notes/Linker.md" })
+    }
+
+    func testRespectsLimit() async throws {
+        try skipIfEmbeddingAssetsMissing()
+        let index = harness.loadedVaults[0].index
+        let dim = try EmbeddingService().dimension
+
+        guard let source = index.file(forRelativePath: "Notes/Linker.md") else {
+            return XCTFail("source missing from fixture")
+        }
+        try seedChunk(index, file: source, vector: unitVector(at: 0, dim: dim))
+        for file in index.allFiles() where file.id != source.id {
+            try seedChunk(index, file: file, vector: unitVector(at: 0, dim: dim))
+        }
+
+        let result = try await harness.callTool(
+            "find_related",
+            arguments: [
+                "relative_path": .string("Notes/Linker.md"),
+                "limit": .int(2),
+            ],
+            as: Result.self
+        )
+        XCTAssertEqual(result.returnedCount, 2)
+        XCTAssertGreaterThan(result.totalCount, 2, "totalCount reports the unclamped scored set")
+    }
+
+    func testReturnsEmptyResultsWhenSourceHasNoEmbeddings() async throws {
+        // No skip — this path doesn't touch the model.
+        let result = try await harness.callTool(
+            "find_related",
+            arguments: ["relative_path": .string("Notes/Linker.md")],
+            as: Result.self
+        )
+        XCTAssertEqual(result.totalCount, 0)
+        XCTAssertEqual(result.returnedCount, 0)
+        XCTAssertTrue(result.results.isEmpty)
+    }
+
+    func testMissingSourceErrors() async throws {
+        let payload = try await harness.callToolExpectingError(
+            "find_related",
+            arguments: ["relative_path": .string("does/not/exist.md")]
+        )
+        XCTAssertEqual(payload.error, "note_not_found")
+    }
+
+    func testInvalidLimitRejected() async throws {
+        let payload = try await harness.callToolExpectingError(
+            "find_related",
+            arguments: [
+                "relative_path": .string("Notes/Linker.md"),
+                "limit": .int(0),
+            ]
+        )
+        XCTAssertEqual(payload.error, "invalid_argument")
+    }
+}

--- a/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
+++ b/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
@@ -23,13 +23,13 @@ final class MCPIntegrationTests: XCTestCase {
 
     func testListToolsReturnsAllRegisteredTools() async throws {
         let (tools, _) = try await harness.client.listTools()
-        XCTAssertEqual(tools.count, 11)
+        XCTAssertEqual(tools.count, 12)
         let names = Set(tools.map(\.name))
         XCTAssertEqual(names, Set([
             "semantic_search", "find_related",
             "search_notes", "get_backlinks", "get_tags",
             "read_note", "list_notes", "get_headings",
-            "get_frontmatter", "create_note", "update_note"
+            "get_frontmatter", "create_note", "update_note", "move_note"
         ]))
         // Every tool advertises an outputSchema.
         for t in tools {
@@ -44,6 +44,7 @@ final class MCPIntegrationTests: XCTestCase {
         XCTAssertEqual(tools.count, 9)
         XCTAssertFalse(names.contains("create_note"))
         XCTAssertFalse(names.contains("update_note"))
+        XCTAssertFalse(names.contains("move_note"))
         XCTAssertTrue(names.contains("semantic_search"))
         XCTAssertTrue(names.contains("find_related"))
         XCTAssertTrue(names.contains("search_notes"))

--- a/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
+++ b/ClearlyCLIIntegrationTests/MCPIntegrationTests.swift
@@ -23,10 +23,10 @@ final class MCPIntegrationTests: XCTestCase {
 
     func testListToolsReturnsAllRegisteredTools() async throws {
         let (tools, _) = try await harness.client.listTools()
-        XCTAssertEqual(tools.count, 10)
+        XCTAssertEqual(tools.count, 11)
         let names = Set(tools.map(\.name))
         XCTAssertEqual(names, Set([
-            "semantic_search",
+            "semantic_search", "find_related",
             "search_notes", "get_backlinks", "get_tags",
             "read_note", "list_notes", "get_headings",
             "get_frontmatter", "create_note", "update_note"
@@ -41,10 +41,11 @@ final class MCPIntegrationTests: XCTestCase {
     func testReadOnlyToolRegistryHidesWriteTools() throws {
         let tools = ToolRegistry.listTools(vaults: harness.loadedVaults, readOnly: true)
         let names = Set(tools.map(\.name))
-        XCTAssertEqual(tools.count, 8)
+        XCTAssertEqual(tools.count, 9)
         XCTAssertFalse(names.contains("create_note"))
         XCTAssertFalse(names.contains("update_note"))
         XCTAssertTrue(names.contains("semantic_search"))
+        XCTAssertTrue(names.contains("find_related"))
         XCTAssertTrue(names.contains("search_notes"))
     }
 

--- a/ClearlyCLIIntegrationTests/MoveNoteTests.swift
+++ b/ClearlyCLIIntegrationTests/MoveNoteTests.swift
@@ -123,6 +123,63 @@ final class MoveNoteTests: XCTestCase {
         )
     }
 
+    func testDestinationConflictDoesNotRewriteInboundLinks() async throws {
+        let index = harness.loadedVaults[0].index
+        let linkerURL = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        let before = try String(contentsOf: linkerURL, encoding: .utf8)
+
+        do {
+            _ = try VaultMover.move(
+                index: index,
+                vaultRootURL: harness.vaultURL,
+                oldRelativePath: "Notes/Link Target.md",
+                newRelativePath: "Notes/Linker.md"
+            )
+            XCTFail("expected destination conflict")
+        } catch VaultMover.MoveError.destinationExists(let path) {
+            XCTAssertEqual(path, "Notes/Linker.md")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        let after = try String(contentsOf: linkerURL, encoding: .utf8)
+        XCTAssertEqual(after, before)
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: harness.vaultURL.appendingPathComponent("Notes/Link Target.md").path
+        ))
+    }
+
+    func testSelfLinkIsReindexedAtDestination() async throws {
+        let index = harness.loadedVaults[0].index
+        let sourcePath = "Notes/Self Link.md"
+        let destPath = "Archived/Self Link.md"
+        let sourceURL = harness.vaultURL.appendingPathComponent(sourcePath)
+        try Data("See [[Self Link]] here.\n".utf8).write(to: sourceURL, options: .atomic)
+        _ = try index.updateFile(at: sourcePath)
+
+        let result = try await harness.callTool(
+            "move_note",
+            arguments: [
+                "from_path": .string(sourcePath),
+                "to_path": .string(destPath),
+            ],
+            as: Result.self
+        )
+
+        XCTAssertEqual(result.linksRewritten.first?.relativePath, destPath)
+
+        let destURL = harness.vaultURL.appendingPathComponent(destPath)
+        let content = try String(contentsOf: destURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("[[Archived/Self Link]]"))
+
+        guard let moved = index.file(forRelativePath: destPath) else {
+            return XCTFail("moved file missing from index")
+        }
+        let outgoing = index.linksFrom(fileId: moved.id)
+        XCTAssertEqual(outgoing.map(\.targetName), ["Archived/Self Link"])
+        XCTAssertEqual(outgoing.first?.targetFileId, moved.id)
+    }
+
     func testMissingSourceErrors() async throws {
         let payload = try await harness.callToolExpectingError(
             "move_note",

--- a/ClearlyCLIIntegrationTests/MoveNoteTests.swift
+++ b/ClearlyCLIIntegrationTests/MoveNoteTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import ClearlyCore
+import MCP
+import XCTest
+
+/// End-to-end coverage of `move_note`. Verifies the source file moves,
+/// inbound `[[wiki-links]]` are rewritten in every linking source file,
+/// the SQLite index keeps the same `file_id` (so backlink rows survive),
+/// and existing GUI-side state remap continues to work.
+final class MoveNoteTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    private struct Rewrite: Decodable {
+        let relativePath: String
+        let count: Int
+    }
+    private struct Result: Decodable {
+        let vault: String
+        let from: String
+        let to: String
+        let linksRewritten: [Rewrite]
+    }
+
+    /// Fixture vault has `Notes/Linker.md` linking to `Link Target` via
+    /// `[[Link Target]]` and `[[Link Target|custom display]]`. After
+    /// moving `Notes/Link Target.md` → `Archived/Link Target.md`, the
+    /// linker file's wiki-links must point at the new path while
+    /// preserving the alias.
+    func testMovesFileAndRewritesInboundWikiLinks() async throws {
+        let result = try await harness.callTool(
+            "move_note",
+            arguments: [
+                "from_path": .string("Notes/Link Target.md"),
+                "to_path": .string("Archived/Link Target.md"),
+            ],
+            as: Result.self
+        )
+
+        XCTAssertEqual(result.from, "Notes/Link Target.md")
+        XCTAssertEqual(result.to, "Archived/Link Target.md")
+
+        // Source moved on disk.
+        let oldURL = harness.vaultURL.appendingPathComponent("Notes/Link Target.md")
+        let newURL = harness.vaultURL.appendingPathComponent("Archived/Link Target.md")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newURL.path))
+
+        // Linker file's content was rewritten; its rewrite count is in the response.
+        let linkerURL = harness.vaultURL.appendingPathComponent("Notes/Linker.md")
+        let linkerContent = try String(contentsOf: linkerURL, encoding: .utf8)
+        XCTAssertTrue(
+            linkerContent.contains("[[Archived/Link Target]]"),
+            "expected wiki-link to be rewritten; got: \(linkerContent)"
+        )
+        XCTAssertTrue(
+            linkerContent.contains("[[Archived/Link Target|custom display]]"),
+            "expected aliased wiki-link to be rewritten preserving the alias"
+        )
+        XCTAssertFalse(linkerContent.contains("[[Link Target]]"))
+
+        let linkerRewrite = result.linksRewritten.first { $0.relativePath == "Notes/Linker.md" }
+        XCTAssertNotNil(linkerRewrite)
+        XCTAssertEqual(linkerRewrite?.count, 2)
+    }
+
+    func testIndexPreservesFileIdAcrossMove() async throws {
+        let index = harness.loadedVaults[0].index
+        let originalFile = index.file(forRelativePath: "Notes/Link Target.md")
+        XCTAssertNotNil(originalFile)
+        let originalId = originalFile?.id
+
+        _ = try await harness.callTool(
+            "move_note",
+            arguments: [
+                "from_path": .string("Notes/Link Target.md"),
+                "to_path": .string("Archived/Link Target.md"),
+            ],
+            as: Result.self
+        )
+
+        // After the move, the file row exists at the new path with the
+        // same id — so existing inbound `links.target_file_id` rows
+        // continue to point at the right file without re-resolution.
+        let movedFile = index.file(forRelativePath: "Archived/Link Target.md")
+        XCTAssertNotNil(movedFile)
+        XCTAssertEqual(movedFile?.id, originalId)
+        XCTAssertNil(index.file(forRelativePath: "Notes/Link Target.md"))
+    }
+
+    func testBacklinksContinueToResolveAfterMove() async throws {
+        struct Linked: Decodable { let relativePath: String }
+        struct BacklinksResult: Decodable {
+            let linked: [Linked]
+        }
+
+        _ = try await harness.callTool(
+            "move_note",
+            arguments: [
+                "from_path": .string("Notes/Link Target.md"),
+                "to_path": .string("Archived/Link Target.md"),
+            ],
+            as: Result.self
+        )
+
+        let backlinks = try await harness.callTool(
+            "get_backlinks",
+            arguments: ["relative_path": .string("Archived/Link Target.md")],
+            as: BacklinksResult.self
+        )
+        let linkedPaths = Set(backlinks.linked.map(\.relativePath))
+        XCTAssertTrue(
+            linkedPaths.contains("Notes/Linker.md"),
+            "Linker should still appear as an inbound backlink after the rewrite"
+        )
+    }
+
+    func testMissingSourceErrors() async throws {
+        let payload = try await harness.callToolExpectingError(
+            "move_note",
+            arguments: [
+                "from_path": .string("does/not/exist.md"),
+                "to_path": .string("anywhere.md"),
+            ]
+        )
+        XCTAssertEqual(payload.error, "note_not_found")
+    }
+
+    func testDestinationConflictRejected() async throws {
+        // Both fixture files exist, so moving Linker → Link Target.md
+        // must conflict.
+        let payload = try await harness.callToolExpectingError(
+            "move_note",
+            arguments: [
+                "from_path": .string("Notes/Linker.md"),
+                "to_path": .string("Notes/Link Target.md"),
+            ]
+        )
+        XCTAssertEqual(payload.error, "note_exists")
+    }
+
+    func testSamePathRejected() async throws {
+        let payload = try await harness.callToolExpectingError(
+            "move_note",
+            arguments: [
+                "from_path": .string("Notes/Linker.md"),
+                "to_path": .string("Notes/Linker.md"),
+            ]
+        )
+        XCTAssertEqual(payload.error, "invalid_argument")
+    }
+}

--- a/ClearlyCLIIntegrationTests/SearchOperatorTests.swift
+++ b/ClearlyCLIIntegrationTests/SearchOperatorTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import ClearlyCore
+import MCP
+import XCTest
+
+/// End-to-end coverage of the `tag:` and `path:` operators introduced by
+/// `SearchQueryParser` and the JOIN-based filtering in
+/// `VaultIndex.searchFilesGrouped(parsed:)`. Drives the same MCP
+/// `search_notes` tool the live server exposes — operators are pulled
+/// from the query string, no schema change.
+final class SearchOperatorTests: XCTestCase {
+    var harness: TestVaultHarness!
+
+    override func setUp() async throws {
+        harness = try await TestVaultHarness()
+    }
+
+    override func tearDown() async throws {
+        await harness?.tearDown()
+        harness = nil
+    }
+
+    private struct SearchHit: Decodable {
+        let relativePath: String
+    }
+    private struct SearchResult: Decodable {
+        let totalCount: Int
+        let returnedCount: Int
+        let results: [SearchHit]
+    }
+
+    // FixtureVault tags (frontmatter + inline #hashtags):
+    //   README.md            tags: fixture, meta
+    //   Daily/2026-04-17.md  tags: daily, fixture
+    //   Projects/Plan.md     tags: architecture, planning
+    //   Notes/Link Target.md inline #architecture
+    //   Notes/Linker.md      inline #fixture
+    //   Resume-é.md          inline #resume
+
+    func testTagFilterAloneReturnsEveryFileCarryingTheTag() async throws {
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("tag:fixture")],
+            as: SearchResult.self
+        )
+        let paths = Set(result.results.map(\.relativePath))
+        XCTAssertEqual(paths, Set([
+            "README.md",
+            "Daily/2026-04-17.md",
+            "Notes/Linker.md",
+        ]))
+    }
+
+    func testTagFiltersAreAndCombined() async throws {
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("tag:fixture tag:meta")],
+            as: SearchResult.self
+        )
+        XCTAssertEqual(result.results.map(\.relativePath), ["README.md"])
+    }
+
+    func testTagFilterIsCaseInsensitive() async throws {
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("tag:FIXTURE")],
+            as: SearchResult.self
+        )
+        let paths = Set(result.results.map(\.relativePath))
+        XCTAssertTrue(paths.contains("README.md"))
+        XCTAssertTrue(paths.contains("Daily/2026-04-17.md"))
+        XCTAssertTrue(paths.contains("Notes/Linker.md"))
+    }
+
+    func testPathPrefixNarrowsToSubfolder() async throws {
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("path:Daily/")],
+            as: SearchResult.self
+        )
+        XCTAssertEqual(result.results.map(\.relativePath), ["Daily/2026-04-17.md"])
+    }
+
+    func testTagAndPathCombineToIntersection() async throws {
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("path:Notes/ tag:fixture")],
+            as: SearchResult.self
+        )
+        XCTAssertEqual(result.results.map(\.relativePath), ["Notes/Linker.md"])
+    }
+
+    func testFilterPlusFreeTextLimitsToBothConstraints() async throws {
+        // "Linker" is in Notes/Linker.md's content; only one fixture-tagged
+        // file mentions it.
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("tag:fixture Linker")],
+            as: SearchResult.self
+        )
+        XCTAssertEqual(result.results.map(\.relativePath), ["Notes/Linker.md"])
+    }
+
+    func testUnknownOperatorDoesNotFilter() async throws {
+        // `foo:bar` is not a recognized operator; it's a literal FTS term
+        // that doesn't appear anywhere in the fixture vault.
+        let result = try await harness.callTool(
+            "search_notes",
+            arguments: ["query": .string("foo:bar Linker")],
+            as: SearchResult.self
+        )
+        // Should return Notes/Linker.md from the "Linker" term — not
+        // filtered out by foo:bar.
+        XCTAssertTrue(result.results.contains { $0.relativePath == "Notes/Linker.md" })
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/FileParser.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/FileParser.swift
@@ -7,12 +7,18 @@ public struct ParsedLink: Equatable {
     public let heading: String?
     public let alias: String?
     public let lineNumber: Int
+    /// Full `[[...]]` span in the source string, expressed as an NSRange
+    /// over UTF-16 code units (the same coordinate space `NSRegularExpression`
+    /// produces). `WikiLinkRewriter` uses this to splice replacements
+    /// in place.
+    public let range: NSRange
 
-    public init(target: String, heading: String?, alias: String?, lineNumber: Int) {
+    public init(target: String, heading: String?, alias: String?, lineNumber: Int, range: NSRange = NSRange(location: NSNotFound, length: 0)) {
         self.target = target
         self.heading = heading
         self.alias = alias
         self.lineNumber = lineNumber
+        self.range = range
     }
 }
 
@@ -142,7 +148,7 @@ public enum FileParser {
             }
 
             let line = lineNumber(at: match.range.location, in: nsContent)
-            links.append(ParsedLink(target: target, heading: heading, alias: alias, lineNumber: line))
+            links.append(ParsedLink(target: target, heading: heading, alias: alias, lineNumber: line, range: match.range))
         }
 
         return links

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/SearchQueryParser.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/SearchQueryParser.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// A parsed search query: free-text terms plus optional structured filters.
+///
+/// The CLI/MCP search surface accepts query strings like
+/// `"tag:work tag:urgent path:journal/ retro"`. Operators are split out
+/// here so the SQL layer can JOIN against the `tags` table and filter
+/// `files.path` without changing the FTS5 schema.
+public struct ParsedSearchQuery: Equatable, Sendable {
+    /// Free-text portion of the query, ready for FTS5 MATCH. May be empty
+    /// when the user specified only filters (e.g. `tag:work`); callers
+    /// should treat that as "match every file that satisfies the
+    /// filters".
+    public let ftsQuery: String
+
+    /// Tags the file must carry (case-insensitive, AND-combined). Empty
+    /// when no `tag:` operator was used.
+    public let tagFilters: [String]
+
+    /// Vault-relative path prefix (case-insensitive) the file must start
+    /// with. Nil when no `path:` operator was used. Only the first
+    /// `path:` operator wins — additional ones are ignored.
+    public let pathPrefix: String?
+
+    public init(ftsQuery: String, tagFilters: [String], pathPrefix: String?) {
+        self.ftsQuery = ftsQuery
+        self.tagFilters = tagFilters
+        self.pathPrefix = pathPrefix
+    }
+
+    public var hasFilters: Bool {
+        !tagFilters.isEmpty || pathPrefix != nil
+    }
+}
+
+public enum SearchQueryParser {
+    /// Pulls `tag:<value>` and `path:<value>` operators out of a query
+    /// string, leaving everything else for FTS5. Quoted phrases pass
+    /// through to FTS unchanged.
+    ///
+    /// Recognized operators:
+    /// - `tag:foo` — file must carry the tag (case-insensitive). Repeat
+    ///   to AND multiple tags. The value cannot contain spaces; use
+    ///   underscores or hyphens, matching how tags are stored.
+    /// - `path:notes/sub` — file's vault-relative path must start with
+    ///   this prefix (case-insensitive). Only the first `path:` wins.
+    ///
+    /// Unknown operators (e.g. `foo:bar`) pass through to FTS verbatim
+    /// so we don't surprise users searching for literal `key:value`
+    /// substrings.
+    public static func parse(_ raw: String) -> ParsedSearchQuery {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return ParsedSearchQuery(ftsQuery: "", tagFilters: [], pathPrefix: nil)
+        }
+
+        var ftsTokens: [String] = []
+        var tagFilters: [String] = []
+        var pathPrefix: String?
+
+        for token in tokenize(trimmed) {
+            if token.hasPrefix("\"") {
+                // Quoted phrase — pass through verbatim.
+                ftsTokens.append(token)
+                continue
+            }
+            if let (op, value) = splitOperator(token), !value.isEmpty {
+                switch op {
+                case "tag":
+                    tagFilters.append(value.lowercased())
+                    continue
+                case "path":
+                    if pathPrefix == nil {
+                        pathPrefix = value
+                    }
+                    continue
+                default:
+                    // Unknown operator — fall through as a literal term.
+                    break
+                }
+            }
+            ftsTokens.append(token)
+        }
+
+        return ParsedSearchQuery(
+            ftsQuery: ftsTokens.joined(separator: " "),
+            tagFilters: tagFilters,
+            pathPrefix: pathPrefix
+        )
+    }
+
+    /// Split a string into whitespace-separated tokens, preserving
+    /// quoted phrases as single tokens (with their quotes intact).
+    private static func tokenize(_ input: String) -> [String] {
+        var tokens: [String] = []
+        var buffer = ""
+        var inQuotes = false
+        for ch in input {
+            if ch == "\"" {
+                buffer.append(ch)
+                inQuotes.toggle()
+                continue
+            }
+            if ch.isWhitespace, !inQuotes {
+                if !buffer.isEmpty {
+                    tokens.append(buffer)
+                    buffer = ""
+                }
+                continue
+            }
+            buffer.append(ch)
+        }
+        if !buffer.isEmpty {
+            tokens.append(buffer)
+        }
+        return tokens
+    }
+
+    private static func splitOperator(_ token: String) -> (op: String, value: String)? {
+        guard let colonIdx = token.firstIndex(of: ":") else { return nil }
+        let op = String(token[token.startIndex..<colonIdx]).lowercased()
+        let value = String(token[token.index(after: colonIdx)...])
+        guard !op.isEmpty else { return nil }
+        return (op, value)
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -669,51 +669,85 @@ public final class VaultIndex: @unchecked Sendable {
     }
 
     public func searchFilesGrouped(query: String) -> [SearchFileGroup] {
-        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
+        searchFilesGrouped(parsed: SearchQueryParser.parse(query))
+    }
 
-        // Parse quoted phrases and bare terms
-        let trimmed = query.trimmingCharacters(in: .whitespaces)
+    public func searchFilesGrouped(parsed: ParsedSearchQuery) -> [SearchFileGroup] {
+        let trimmed = parsed.ftsQuery.trimmingCharacters(in: .whitespaces)
         var ftsTerms: [String] = []
         var searchTerms: [String] = [] // plain terms for line matching
 
-        let quoteRegex = try! NSRegularExpression(pattern: #""([^"]+)""#)
-        let matches = quoteRegex.matches(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed))
-        var coveredRanges = Set<Range<String.Index>>()
+        if !trimmed.isEmpty {
+            let quoteRegex = try! NSRegularExpression(pattern: #""([^"]+)""#)
+            let matches = quoteRegex.matches(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed))
+            var coveredRanges = Set<Range<String.Index>>()
 
-        for match in matches {
-            if let range = Range(match.range(at: 1), in: trimmed) {
-                let phrase = String(trimmed[range])
-                ftsTerms.append("\"\(phrase.replacingOccurrences(of: "\"", with: "\"\""))\"")
-                searchTerms.append(phrase.lowercased())
-                coveredRanges.insert(Range(match.range, in: trimmed)!)
+            for match in matches {
+                if let range = Range(match.range(at: 1), in: trimmed) {
+                    let phrase = String(trimmed[range])
+                    ftsTerms.append("\"\(phrase.replacingOccurrences(of: "\"", with: "\"\""))\"")
+                    searchTerms.append(phrase.lowercased())
+                    coveredRanges.insert(Range(match.range, in: trimmed)!)
+                }
+            }
+
+            // Bare (unquoted) terms
+            var remaining = trimmed
+            for range in coveredRanges.sorted(by: { $0.lowerBound > $1.lowerBound }) {
+                remaining.removeSubrange(range)
+            }
+            for word in remaining.components(separatedBy: .whitespaces) where !word.isEmpty {
+                let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
+                ftsTerms.append("\"\(escaped)\"*")
+                searchTerms.append(word.lowercased())
             }
         }
 
-        // Bare (unquoted) terms
-        var remaining = trimmed
-        for range in coveredRanges.sorted(by: { $0.lowerBound > $1.lowerBound }) {
-            remaining.removeSubrange(range)
-        }
-        for word in remaining.components(separatedBy: .whitespaces) where !word.isEmpty {
-            let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
-            ftsTerms.append("\"\(escaped)\"*")
-            searchTerms.append(word.lowercased())
-        }
-
-        guard !ftsTerms.isEmpty else { return [] }
+        // Either FTS terms or structured filters must be present.
+        guard !ftsTerms.isEmpty || parsed.hasFilters else { return [] }
         let ftsQuery = ftsTerms.joined(separator: " ")
+        let pathLike = parsed.pathPrefix.map { Self.escapedPathPrefix($0) }
 
         do {
             return try dbPool.read { db in
-                // FTS5 content search
-                let contentRows = try Row.fetchAll(db, sql: """
-                    SELECT f.*, highlight(files_fts, 1, '<<', '>>') AS highlighted_content, bm25(files_fts) AS rank
-                    FROM files_fts
-                    JOIN files f ON f.id = files_fts.rowid
-                    WHERE files_fts MATCH ?
-                    ORDER BY bm25(files_fts)
-                    LIMIT 50
-                    """, arguments: [ftsQuery])
+                let contentRows: [Row]
+                if !ftsTerms.isEmpty {
+                    var sql = """
+                        SELECT f.*, highlight(files_fts, 1, '<<', '>>') AS highlighted_content, bm25(files_fts) AS rank
+                        FROM files_fts
+                        JOIN files f ON f.id = files_fts.rowid
+                        WHERE files_fts MATCH ?
+                        """
+                    var args: [DatabaseValueConvertible] = [ftsQuery]
+                    if !parsed.tagFilters.isEmpty {
+                        sql += " AND f.id IN (SELECT file_id FROM tags WHERE LOWER(tag) IN (\(Self.placeholders(parsed.tagFilters.count))) GROUP BY file_id HAVING COUNT(DISTINCT LOWER(tag)) = ?)"
+                        args.append(contentsOf: parsed.tagFilters as [DatabaseValueConvertible])
+                        args.append(parsed.tagFilters.count)
+                    }
+                    if let pathLike {
+                        sql += " AND LOWER(f.path) LIKE LOWER(?) ESCAPE '\\'"
+                        args.append(pathLike)
+                    }
+                    sql += " ORDER BY bm25(files_fts) LIMIT 50"
+                    contentRows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                } else {
+                    // Filter-only query: enumerate every file that matches the
+                    // structured filters, no FTS pre-filter. Cap to 50 to
+                    // match the FTS branch.
+                    var sql = "SELECT f.* FROM files f WHERE 1=1"
+                    var args: [DatabaseValueConvertible] = []
+                    if !parsed.tagFilters.isEmpty {
+                        sql += " AND f.id IN (SELECT file_id FROM tags WHERE LOWER(tag) IN (\(Self.placeholders(parsed.tagFilters.count))) GROUP BY file_id HAVING COUNT(DISTINCT LOWER(tag)) = ?)"
+                        args.append(contentsOf: parsed.tagFilters as [DatabaseValueConvertible])
+                        args.append(parsed.tagFilters.count)
+                    }
+                    if let pathLike {
+                        sql += " AND LOWER(f.path) LIKE LOWER(?) ESCAPE '\\'"
+                        args.append(pathLike)
+                    }
+                    sql += " ORDER BY f.path LIMIT 50"
+                    contentRows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                }
 
                 var resultsByFileId: [Int64: SearchFileGroup] = [:]
                 var orderedIds: [Int64] = []
@@ -752,15 +786,27 @@ public final class VaultIndex: @unchecked Sendable {
                     orderedIds.append(file.id)
                 }
 
-                // Filename-only matches (not already in content results)
+                // Filename-only matches (not already in content results).
+                // Honors structured filters so a tag:foo + raw query
+                // doesn't surface tag-less files via filename-LIKE.
                 let existingIds = Set(orderedIds)
                 for term in searchTerms {
-                    let likePattern = "%\(term)%"
-                    let nameRows = try Row.fetchAll(db, sql: """
-                        SELECT * FROM files
-                        WHERE LOWER(filename) LIKE LOWER(?)
-                        LIMIT 20
-                        """, arguments: [likePattern])
+                    var sql = """
+                        SELECT f.* FROM files f
+                        WHERE LOWER(f.filename) LIKE LOWER(?)
+                        """
+                    var args: [DatabaseValueConvertible] = ["%\(term)%"]
+                    if !parsed.tagFilters.isEmpty {
+                        sql += " AND f.id IN (SELECT file_id FROM tags WHERE LOWER(tag) IN (\(Self.placeholders(parsed.tagFilters.count))) GROUP BY file_id HAVING COUNT(DISTINCT LOWER(tag)) = ?)"
+                        args.append(contentsOf: parsed.tagFilters as [DatabaseValueConvertible])
+                        args.append(parsed.tagFilters.count)
+                    }
+                    if let pathLike {
+                        sql += " AND LOWER(f.path) LIKE LOWER(?) ESCAPE '\\'"
+                        args.append(pathLike)
+                    }
+                    sql += " LIMIT 20"
+                    let nameRows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
                     for row in nameRows {
                         let file = Self.indexedFile(from: row)
                         guard !existingIds.contains(file.id) else { continue }
@@ -1413,6 +1459,21 @@ public final class VaultIndex: @unchecked Sendable {
 
     private static func fileModDate(_ url: URL) -> Date {
         (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date) ?? Date()
+    }
+
+    private static func placeholders(_ count: Int) -> String {
+        Array(repeating: "?", count: count).joined(separator: ",")
+    }
+
+    /// Escape SQL LIKE wildcards in a user-supplied path prefix, then
+    /// append `%` so the prefix matches anything beneath it. Use with
+    /// `LIKE ... ESCAPE '\\'`.
+    private static func escapedPathPrefix(_ prefix: String) -> String {
+        let escaped = prefix
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        return escaped + "%"
     }
 
     private static func truncatedHighlightedLine(_ line: String, visibleLimit: Int) -> String {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -293,6 +293,31 @@ public final class VaultIndex: @unchecked Sendable {
         }
     }
 
+    /// Move a file row from one vault-relative path to another, preserving
+    /// `id` (and therefore every inbound `links.target_file_id` row that
+    /// already pointed at it). Updates `path`, `filename`, the FTS row's
+    /// filename column, and re-resolves any unresolved link rows whose
+    /// `target_name` matches the new filename. Caller is responsible for
+    /// the actual filesystem move and for re-indexing source files whose
+    /// content was rewritten as part of the move.
+    public func moveFile(fromPath oldPath: String, toPath newPath: String) throws {
+        try dbPool.write { db in
+            guard let row = try Row.fetchOne(db, sql: "SELECT id FROM files WHERE path = ?", arguments: [oldPath]) else {
+                return
+            }
+            let id: Int64 = row["id"]
+            let newFilename = URL(fileURLWithPath: newPath).deletingPathExtension().lastPathComponent
+            try db.execute(sql: """
+                UPDATE files SET path = ?, filename = ? WHERE id = ?
+                """, arguments: [newPath, newFilename, id])
+            // files_fts mirrors filename; keep it in sync without re-tokenizing content.
+            try db.execute(sql: """
+                UPDATE files_fts SET filename = ? WHERE rowid = ?
+                """, arguments: [newFilename, id])
+            try self.resolveWikiLinkTargets(db: db)
+        }
+    }
+
     // MARK: Write — Full Index
 
     public func indexAllFiles(showHiddenFiles: Bool = false) {
@@ -521,10 +546,18 @@ public final class VaultIndex: @unchecked Sendable {
     }
 
     private func resolveWikiLinkTargets(db: Database) throws {
+        // Resolve `[[wiki-link]]` text in the source to a concrete file
+        // row. Tries, in order: bare filename match (the dominant short
+        // form), exact path match (`[[notes/foo.md]]`), and stripped
+        // path with an `.md` / `.markdown` extension appended (the form
+        // produced by `WikiLinkRewriter` after a vault-aware move).
         try db.execute(sql: """
             UPDATE links SET target_file_id = (
                 SELECT f.id FROM files f
                 WHERE LOWER(f.filename) = LOWER(links.target_name)
+                   OR LOWER(f.path) = LOWER(links.target_name)
+                   OR LOWER(f.path) = LOWER(links.target_name) || '.md'
+                   OR LOWER(f.path) = LOWER(links.target_name) || '.markdown'
                 LIMIT 1
             )
             """)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -1318,6 +1318,37 @@ public final class VaultIndex: @unchecked Sendable {
         }
     }
 
+    /// Lookup current chunks for a file at `modelVersion`. Skips stale rows
+    /// whose stored content hash no longer matches the file row.
+    public func currentChunkEmbeddings(forFileID fileID: Int64, modelVersion: Int) throws -> [StoredChunkEmbedding] {
+        try dbPool.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT e.file_id, e.chunk_index, f.path, e.heading_path,
+                       e.chunk_text_offset, e.chunk_text_length, e.vector
+                FROM embeddings e
+                JOIN files f ON f.id = e.file_id
+                WHERE e.file_id = ?
+                  AND e.model_version = ?
+                  AND e.content_hash = f.content_hash
+                ORDER BY e.chunk_index
+                """, arguments: [fileID, modelVersion])
+            return rows.compactMap { row -> StoredChunkEmbedding? in
+                let blob: Data = row["vector"]
+                guard let vec = [Float].fromBlobData(blob) else { return nil }
+                let headingJSON: String = row["heading_path"]
+                return StoredChunkEmbedding(
+                    fileID: row["file_id"],
+                    chunkIndex: row["chunk_index"],
+                    path: row["path"],
+                    headingPath: Self.decodeHeadingPath(headingJSON),
+                    textOffset: row["chunk_text_offset"],
+                    textLength: row["chunk_text_length"],
+                    vector: vec
+                )
+            }
+        }
+    }
+
     /// Explicit invalidation — clears every chunk row + chunks_fts. Used when the embedder
     /// itself changes (e.g. dimension flip on a future swap) and you'd rather take the hit
     /// up-front than rely on `embeddingsMissingOrStale` to drip-detect.

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultMover.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultMover.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Vault-aware file move. Handles the bookkeeping that a plain
+/// `FileManager.moveItem` doesn't:
+///
+/// 1. Rewrites every `[[wiki-link]]` in inbound source files to point at
+///    the new path (preserving heading anchors and aliases).
+/// 2. Moves the source file via the file coordinator.
+/// 3. Updates the SQLite index, preserving the file's `id` so existing
+///    inbound `links.target_file_id` rows survive the move.
+/// 4. Reindexes every rewritten source so the `links` table reflects
+///    the new wiki-link text.
+///
+/// Used by both the MCP `move_note` tool and the Mac GUI sidebar rename
+/// path so the two surfaces stay consistent.
+public enum VaultMover {
+    public struct Outcome: Equatable {
+        public struct Rewrite: Equatable {
+            public let relativePath: String
+            public let count: Int
+            public init(relativePath: String, count: Int) {
+                self.relativePath = relativePath
+                self.count = count
+            }
+        }
+        public let linksRewritten: [Rewrite]
+        public init(linksRewritten: [Rewrite]) {
+            self.linksRewritten = linksRewritten
+        }
+    }
+
+    public enum MoveError: Error {
+        case sourceNotIndexed(String)
+    }
+
+    /// Apply the move. Caller is responsible for path validation —
+    /// `oldRelativePath` and `newRelativePath` must already be confirmed
+    /// vault-relative and safe (no traversal, no absolute paths).
+    /// Filesystem move + index update happen unconditionally; if the
+    /// caller has already moved the file (e.g. legacy `FileManager`
+    /// callers being migrated incrementally), pass `skipFilesystemMove`
+    /// and only the index/link bookkeeping runs.
+    @discardableResult
+    public static func move(
+        index: VaultIndex,
+        vaultRootURL: URL,
+        oldRelativePath: String,
+        newRelativePath: String,
+        skipFilesystemMove: Bool = false
+    ) throws -> Outcome {
+        guard let sourceFile = index.file(forRelativePath: oldRelativePath) else {
+            throw MoveError.sourceNotIndexed(oldRelativePath)
+        }
+
+        // 1. Rewrite inbound wiki-links in every source file.
+        let inbound = index.linksTo(fileId: sourceFile.id)
+        let inboundSourcePaths = Set(inbound.compactMap { $0.sourcePath })
+        var rewrites: [Outcome.Rewrite] = []
+        for sourcePath in inboundSourcePaths {
+            let url = vaultRootURL.appendingPathComponent(sourcePath)
+            let data: Data
+            do { data = try CoordinatedFileIO.read(at: url) } catch { continue }
+            guard let content = String(data: data, encoding: .utf8) else { continue }
+            let result = WikiLinkRewriter.rewrite(content: content, oldTarget: oldRelativePath, newTarget: newRelativePath)
+            guard result.count > 0 else { continue }
+            try CoordinatedFileIO.write(Data(result.newContent.utf8), to: url)
+            rewrites.append(Outcome.Rewrite(relativePath: sourcePath, count: result.count))
+        }
+
+        // 2. Move the file itself (unless caller already did it).
+        if !skipFilesystemMove {
+            let sourceURL = vaultRootURL.appendingPathComponent(oldRelativePath)
+            let destURL = vaultRootURL.appendingPathComponent(newRelativePath)
+            let destParent = destURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
+            try CoordinatedFileIO.move(from: sourceURL, to: destURL)
+        }
+
+        // 3. Update the index — preserves file_id.
+        try index.moveFile(fromPath: oldRelativePath, toPath: newRelativePath)
+
+        // 4. Reindex every rewritten source.
+        for rewrite in rewrites {
+            try index.updateFile(at: rewrite.relativePath)
+        }
+
+        return Outcome(linksRewritten: rewrites)
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultMover.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultMover.swift
@@ -3,13 +3,11 @@ import Foundation
 /// Vault-aware file move. Handles the bookkeeping that a plain
 /// `FileManager.moveItem` doesn't:
 ///
-/// 1. Rewrites every `[[wiki-link]]` in inbound source files to point at
-///    the new path (preserving heading anchors and aliases).
+/// 1. Precomputes every inbound `[[wiki-link]]` rewrite in memory.
 /// 2. Moves the source file via the file coordinator.
 /// 3. Updates the SQLite index, preserving the file's `id` so existing
 ///    inbound `links.target_file_id` rows survive the move.
-/// 4. Reindexes every rewritten source so the `links` table reflects
-///    the new wiki-link text.
+/// 4. Writes rewritten sources and reindexes them.
 ///
 /// Used by both the MCP `move_note` tool and the Mac GUI sidebar rename
 /// path so the two surfaces stay consistent.
@@ -31,6 +29,13 @@ public enum VaultMover {
 
     public enum MoveError: Error {
         case sourceNotIndexed(String)
+        case destinationExists(String)
+    }
+
+    private struct PreparedRewrite {
+        let relativePath: String
+        let newContent: String
+        let count: Int
     }
 
     /// Apply the move. Caller is responsible for path validation —
@@ -52,36 +57,61 @@ public enum VaultMover {
             throw MoveError.sourceNotIndexed(oldRelativePath)
         }
 
-        // 1. Rewrite inbound wiki-links in every source file.
+        let sourceURL = vaultRootURL.appendingPathComponent(oldRelativePath)
+        let destURL = vaultRootURL.appendingPathComponent(newRelativePath)
+        if !skipFilesystemMove {
+            if FileManager.default.fileExists(atPath: destURL.path) {
+                throw MoveError.destinationExists(newRelativePath)
+            }
+            try FileManager.default.createDirectory(
+                at: destURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        }
+
+        // 1. Precompute inbound wiki-link rewrites without touching disk.
         let inbound = index.linksTo(fileId: sourceFile.id)
         let inboundSourcePaths = Set(inbound.compactMap { $0.sourcePath })
-        var rewrites: [Outcome.Rewrite] = []
+        var prepared: [PreparedRewrite] = []
         for sourcePath in inboundSourcePaths {
-            let url = vaultRootURL.appendingPathComponent(sourcePath)
+            let readPath = (skipFilesystemMove && sourcePath == oldRelativePath) ? newRelativePath : sourcePath
+            let url = vaultRootURL.appendingPathComponent(readPath)
             let data: Data
             do { data = try CoordinatedFileIO.read(at: url) } catch { continue }
             guard let content = String(data: data, encoding: .utf8) else { continue }
             let result = WikiLinkRewriter.rewrite(content: content, oldTarget: oldRelativePath, newTarget: newRelativePath)
             guard result.count > 0 else { continue }
-            try CoordinatedFileIO.write(Data(result.newContent.utf8), to: url)
-            rewrites.append(Outcome.Rewrite(relativePath: sourcePath, count: result.count))
+            let writePath = sourcePath == oldRelativePath ? newRelativePath : sourcePath
+            prepared.append(PreparedRewrite(
+                relativePath: writePath,
+                newContent: result.newContent,
+                count: result.count
+            ))
         }
 
         // 2. Move the file itself (unless caller already did it).
         if !skipFilesystemMove {
-            let sourceURL = vaultRootURL.appendingPathComponent(oldRelativePath)
-            let destURL = vaultRootURL.appendingPathComponent(newRelativePath)
-            let destParent = destURL.deletingLastPathComponent()
-            try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
             try CoordinatedFileIO.move(from: sourceURL, to: destURL)
         }
 
         // 3. Update the index — preserves file_id.
-        try index.moveFile(fromPath: oldRelativePath, toPath: newRelativePath)
+        do {
+            try index.moveFile(fromPath: oldRelativePath, toPath: newRelativePath)
+        } catch {
+            if !skipFilesystemMove {
+                try? CoordinatedFileIO.move(from: destURL, to: sourceURL)
+            }
+            throw error
+        }
 
-        // 4. Reindex every rewritten source.
-        for rewrite in rewrites {
+        // 4. Write and reindex every rewritten source. Self-links in the
+        // moved file are now written/reindexed at the destination path.
+        var rewrites: [Outcome.Rewrite] = []
+        for rewrite in prepared {
+            let url = vaultRootURL.appendingPathComponent(rewrite.relativePath)
+            try CoordinatedFileIO.write(Data(rewrite.newContent.utf8), to: url)
             try index.updateFile(at: rewrite.relativePath)
+            rewrites.append(Outcome.Rewrite(relativePath: rewrite.relativePath, count: rewrite.count))
         }
 
         return Outcome(linksRewritten: rewrites)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/WikiLinkRewriter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/WikiLinkRewriter.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// In-place rewrite of `[[wiki-links]]` after a file is moved.
+///
+/// Given the source text of a note, the old target's vault-relative
+/// path (with or without `.md` extension), and the new target's
+/// vault-relative path, finds every link whose resolved target matches
+/// the old path and rewrites it to the new path while preserving any
+/// `#heading` anchor and `|alias` display text.
+///
+/// Matching is case-insensitive, mirroring `VaultIndex.resolveWikiLinkTargets`
+/// — a link `[[Foo]]` resolves to `Foo.md`, `foo.md`, or `FOO.MD`. Both
+/// path-style references (`[[notes/foo]]`) and bare-filename references
+/// (`[[foo]]`) are recognized.
+///
+/// The rewritten target is the new vault-relative path with the markdown
+/// extension stripped — `bar/baz` for a destination of `bar/baz.md`.
+/// This is unambiguous across name collisions, at the cost of replacing
+/// short-form references with longer path-form ones.
+public enum WikiLinkRewriter {
+    public struct Output: Equatable {
+        public let newContent: String
+        public let count: Int
+    }
+
+    public static func rewrite(content: String, oldTarget: String, newTarget: String) -> Output {
+        let oldKey = canonicalKey(oldTarget)
+        let oldBasename = stripMarkdownExtension(URL(fileURLWithPath: oldTarget).lastPathComponent).lowercased()
+        let newRefTarget = stripMarkdownExtension(newTarget)
+
+        let parse = FileParser.parse(content: content)
+        let nsContent = content as NSString
+
+        // Filter to matching links and sort descending by start so we
+        // can splice without invalidating later ranges.
+        var matches = parse.links.filter { link in
+            let linkKey = canonicalKey(link.target)
+            if linkKey == oldKey { return true }
+            // Bare-filename references: `[[foo]]` matches old path
+            // `notes/foo.md` because both have the same basename.
+            let linkBasename = stripMarkdownExtension(URL(fileURLWithPath: link.target).lastPathComponent).lowercased()
+            // Only match the basename when the link itself is bare —
+            // otherwise `[[a/foo]]` could collide with a different
+            // `b/foo.md` after a rename.
+            return !link.target.contains("/") && linkBasename == oldBasename
+        }
+        matches.sort { $0.range.location > $1.range.location }
+
+        var output = nsContent
+        for match in matches {
+            let replacement = renderLink(target: newRefTarget, heading: match.heading, alias: match.alias)
+            output = output.replacingCharacters(in: match.range, with: replacement) as NSString
+        }
+        return Output(newContent: output as String, count: matches.count)
+    }
+
+    private static func canonicalKey(_ raw: String) -> String {
+        stripMarkdownExtension(raw)
+            .replacingOccurrences(of: "\\", with: "/")
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func stripMarkdownExtension(_ raw: String) -> String {
+        let url = URL(fileURLWithPath: raw)
+        let ext = url.pathExtension.lowercased()
+        if FileNode.markdownExtensions.contains(ext) {
+            return url.deletingPathExtension().relativePath
+        }
+        return raw
+    }
+
+    private static func renderLink(target: String, heading: String?, alias: String?) -> String {
+        var s = "[[\(target)"
+        if let heading, !heading.isEmpty { s += "#\(heading)" }
+        if let alias, !alias.isEmpty { s += "|\(alias)" }
+        s += "]]"
+        return s
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/SearchQueryParserTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/SearchQueryParserTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import ClearlyCore
+
+final class SearchQueryParserTests: XCTestCase {
+
+    func testEmptyQueryProducesEmptyParse() {
+        let parsed = SearchQueryParser.parse("")
+        XCTAssertEqual(parsed.ftsQuery, "")
+        XCTAssertEqual(parsed.tagFilters, [])
+        XCTAssertNil(parsed.pathPrefix)
+        XCTAssertFalse(parsed.hasFilters)
+    }
+
+    func testWhitespaceOnlyProducesEmptyParse() {
+        let parsed = SearchQueryParser.parse("   \t  ")
+        XCTAssertEqual(parsed.ftsQuery, "")
+        XCTAssertFalse(parsed.hasFilters)
+    }
+
+    func testBareTermsPassThroughUnchanged() {
+        let parsed = SearchQueryParser.parse("foo bar baz")
+        XCTAssertEqual(parsed.ftsQuery, "foo bar baz")
+        XCTAssertEqual(parsed.tagFilters, [])
+        XCTAssertNil(parsed.pathPrefix)
+    }
+
+    func testQuotedPhrasePreserved() {
+        let parsed = SearchQueryParser.parse("\"flow state\" focus")
+        XCTAssertEqual(parsed.ftsQuery, "\"flow state\" focus")
+    }
+
+    func testSingleTagOperator() {
+        let parsed = SearchQueryParser.parse("tag:work")
+        XCTAssertEqual(parsed.ftsQuery, "")
+        XCTAssertEqual(parsed.tagFilters, ["work"])
+        XCTAssertNil(parsed.pathPrefix)
+        XCTAssertTrue(parsed.hasFilters)
+    }
+
+    func testMultipleTagOperatorsAreLowercasedAndAccumulated() {
+        let parsed = SearchQueryParser.parse("tag:Work tag:URGENT")
+        XCTAssertEqual(parsed.ftsQuery, "")
+        XCTAssertEqual(parsed.tagFilters, ["work", "urgent"])
+    }
+
+    func testPathOperator() {
+        let parsed = SearchQueryParser.parse("path:journal/2026/")
+        XCTAssertEqual(parsed.ftsQuery, "")
+        XCTAssertEqual(parsed.pathPrefix, "journal/2026/")
+    }
+
+    func testFirstPathOperatorWinsSubsequentIgnored() {
+        let parsed = SearchQueryParser.parse("path:notes/ path:archive/")
+        XCTAssertEqual(parsed.pathPrefix, "notes/")
+    }
+
+    func testMixedOperatorsAndFreeText() {
+        let parsed = SearchQueryParser.parse("tag:work path:meetings/ retro")
+        XCTAssertEqual(parsed.ftsQuery, "retro")
+        XCTAssertEqual(parsed.tagFilters, ["work"])
+        XCTAssertEqual(parsed.pathPrefix, "meetings/")
+    }
+
+    func testQuotedPhrasePlusTag() {
+        let parsed = SearchQueryParser.parse("tag:idea \"local-first software\"")
+        XCTAssertEqual(parsed.ftsQuery, "\"local-first software\"")
+        XCTAssertEqual(parsed.tagFilters, ["idea"])
+    }
+
+    func testEmptyOperatorValueFallsThroughAsLiteralTerm() {
+        let parsed = SearchQueryParser.parse("tag: foo")
+        // `tag:` has no value, so it stays as a literal token.
+        XCTAssertEqual(parsed.ftsQuery, "tag: foo")
+        XCTAssertEqual(parsed.tagFilters, [])
+    }
+
+    func testUnknownOperatorPassesThroughVerbatim() {
+        let parsed = SearchQueryParser.parse("foo:bar baseline")
+        XCTAssertEqual(parsed.ftsQuery, "foo:bar baseline")
+        XCTAssertEqual(parsed.tagFilters, [])
+        XCTAssertNil(parsed.pathPrefix)
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiLinkRewriterTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/WikiLinkRewriterTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import ClearlyCore
+
+final class WikiLinkRewriterTests: XCTestCase {
+
+    func testRewritesBasicLink() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "See [[foo]] for context.",
+            oldTarget: "foo.md",
+            newTarget: "bar/baz.md"
+        )
+        XCTAssertEqual(result.newContent, "See [[bar/baz]] for context.")
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testPreservesHeadingAnchor() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "Jump to [[foo#Section A]] there.",
+            oldTarget: "foo",
+            newTarget: "renamed"
+        )
+        XCTAssertEqual(result.newContent, "Jump to [[renamed#Section A]] there.")
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testPreservesAlias() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "Inline [[foo|the foo note]] here.",
+            oldTarget: "foo.md",
+            newTarget: "bar.md"
+        )
+        XCTAssertEqual(result.newContent, "Inline [[bar|the foo note]] here.")
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testPreservesBothHeadingAndAlias() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "[[foo#Goals|see goals]]",
+            oldTarget: "foo",
+            newTarget: "renamed"
+        )
+        XCTAssertEqual(result.newContent, "[[renamed#Goals|see goals]]")
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testRewritesMultipleOccurrencesOnSameLine() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "[[foo]] then [[foo]] then [[foo|alias]]",
+            oldTarget: "foo",
+            newTarget: "bar"
+        )
+        XCTAssertEqual(result.newContent, "[[bar]] then [[bar]] then [[bar|alias]]")
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testRewritesAcrossMultipleLines() {
+        let content = """
+        # Heading
+        See [[foo]] up top.
+        Some other text.
+        And [[foo#bar]] later.
+        """
+        let result = WikiLinkRewriter.rewrite(content: content, oldTarget: "foo", newTarget: "renamed/foo")
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.newContent.contains("[[renamed/foo]]"))
+        XCTAssertTrue(result.newContent.contains("[[renamed/foo#bar]]"))
+    }
+
+    func testNoOpWhenTargetAbsent() {
+        let content = "Has no links to foo."
+        let result = WikiLinkRewriter.rewrite(content: content, oldTarget: "foo", newTarget: "bar")
+        XCTAssertEqual(result.count, 0)
+        XCTAssertEqual(result.newContent, content)
+    }
+
+    func testIsCaseInsensitiveOnTargetMatch() {
+        let result = WikiLinkRewriter.rewrite(
+            content: "[[Foo]] and [[FOO]] and [[foo]]",
+            oldTarget: "foo",
+            newTarget: "renamed"
+        )
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result.newContent, "[[renamed]] and [[renamed]] and [[renamed]]")
+    }
+
+    func testBareLinkMatchesPathBasename() {
+        // Old target lives under a folder; bare-filename wiki-links to it
+        // (e.g. `[[notes]]` referring to `journal/notes.md`) should rewrite.
+        let result = WikiLinkRewriter.rewrite(
+            content: "Reference [[notes]] here.",
+            oldTarget: "journal/notes.md",
+            newTarget: "archive/notes.md"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.newContent, "Reference [[archive/notes]] here.")
+    }
+
+    func testPathLinkOnlyMatchesIdenticalPath() {
+        // `[[a/foo]]` must NOT rewrite when oldTarget is `b/foo.md` —
+        // path-form links carry intent that bare-filename links don't.
+        let result = WikiLinkRewriter.rewrite(
+            content: "[[a/foo]] and [[b/foo]]",
+            oldTarget: "b/foo.md",
+            newTarget: "z/foo.md"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.newContent, "[[a/foo]] and [[z/foo]]")
+    }
+
+    func testReverseSplicePreservesEarlierRanges() {
+        // Two adjacent links — splicing in reverse order must not corrupt
+        // the earlier link's range coordinates.
+        let result = WikiLinkRewriter.rewrite(
+            content: "[[a]] [[a]] tail",
+            oldTarget: "a",
+            newTarget: "longer-replacement"
+        )
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.newContent, "[[longer-replacement]] [[longer-replacement]] tail")
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,5 @@
+# Clearly CLI
+
+The user-facing reference lives at **<https://clearly.md/cli>**. That page is the canonical source — it covers install, every subcommand, examples, exit codes, and stays in sync with each release.
+
+This file is a stub for contributors browsing the repo on GitHub. If you're hacking on the CLI itself, the source is in `ClearlyCLI/CLI/Commands/` and tests in `ClearlyCLIIntegrationTests/`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,5 @@
+# Clearly MCP server
+
+The user-facing reference lives at **<https://clearly.md/mcp>**. That page covers setup (Claude Desktop, Claude Code, Cursor, Codex CLI), every registered tool, input/output schemas, and the local-first design.
+
+This file is a stub for contributors browsing the repo on GitHub. The server lives in `ClearlyCLI/MCP/`, tool implementations in `ClearlyCLI/Core/Tools/`, and the registry in `ClearlyCLI/MCP/ToolRegistry.swift`. Run `clearly mcp tools` against a built binary to dump every tool's JSON Schema.

--- a/project.yml
+++ b/project.yml
@@ -217,6 +217,11 @@ targets:
         SWIFT_STRICT_CONCURRENCY: minimal
         ENABLE_HARDENED_RUNTIME: YES
         SKIP_INSTALL: YES
+        # Embed an Info.plist via -sectcreate so `Bundle.main` exposes
+        # CFBundleShortVersionString — `clearly status` reads it for the
+        # binary_version diagnostic.
+        GENERATE_INFOPLIST_FILE: YES
+        CREATE_INFOPLIST_SECTION_IN_BINARY: YES
       configs:
         Release:
           CODE_SIGN_STYLE: Manual

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -27,12 +27,16 @@ if [ ! -d "$FIXTURE" ]; then
 fi
 
 # ─── Build ─────────────────────────────────────────────────────────────────
+# Pin DerivedData to a workspace-local path so parallel Conductor worktrees
+# don't cross-contaminate. CLAUDE.md mandates this for any direct xcodebuild
+# invocation.
+DERIVED="$REPO_ROOT/.build/DerivedData"
 echo "→ xcodebuild -scheme ClearlyCLI -configuration Debug build"
-xcodebuild -scheme ClearlyCLI -configuration Debug build -quiet >/dev/null
+xcodebuild -scheme ClearlyCLI -configuration Debug build -quiet -derivedDataPath "$DERIVED" >/dev/null
 
-CLI="$(find ~/Library/Developer/Xcode/DerivedData/Clearly-*/Build/Products/Debug -maxdepth 2 -name ClearlyCLI -type f 2>/dev/null | head -1 || true)"
-if [ -z "$CLI" ] || [ ! -x "$CLI" ]; then
-    echo "ClearlyCLI binary not found in DerivedData" >&2
+CLI="$DERIVED/Build/Products/Debug/ClearlyCLI"
+if [ ! -x "$CLI" ]; then
+    echo "ClearlyCLI binary not found at $CLI" >&2
     exit 11
 fi
 echo "  using $CLI"
@@ -142,10 +146,19 @@ RESPONSES=$({ printf '%s\n%s\n%s\n' \
 
 # tools/list comes back as id: 2
 TOOL_COUNT=$(printf '%s\n' "$RESPONSES" | jq -s '.[] | select(.id == 2) | .result.tools | length' | head -1)
-if [ "$TOOL_COUNT" != "10" ]; then
-    echo "mcp tools/list: expected 10 tools, got $TOOL_COUNT" >&2
+if [ "$TOOL_COUNT" != "12" ]; then
+    echo "mcp tools/list: expected 12 tools, got $TOOL_COUNT" >&2
     exit 40
 fi
+
+# Spot-check that the new tools show up alongside the originals.
+TOOL_NAMES=$(printf '%s\n' "$RESPONSES" | jq -rs '.[] | select(.id == 2) | .result.tools[].name' | sort | tr '\n' ' ')
+for required in semantic_search find_related search_notes get_backlinks get_tags read_note list_notes get_headings get_frontmatter create_note update_note move_note; do
+    if ! printf '%s' "$TOOL_NAMES" | grep -q -w "$required"; then
+        echo "mcp tools/list: missing tool '$required' in: $TOOL_NAMES" >&2
+        exit 40
+    fi
+done
 
 echo "→ mcp: tools/call read_note (success + error)"
 CALL_RESPONSES=$({ printf '%s\n%s\n%s\n%s\n' \

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -49,6 +49,7 @@
             </a>
             <div class="flex items-center gap-5 text-zinc-400">
                 <a href="/changelog" class="text-white" aria-current="page">Changelog</a>
+                <a href="/cli" class="hover:text-white transition-colors">Docs</a>
                 <a href="https://github.com/Shpigford/clearly" class="hover:text-white transition-colors">GitHub</a>
             </div>
         </div>

--- a/website/cli.html
+++ b/website/cli.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en" style="color-scheme: dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <meta name="apple-mobile-web-app-title" content="Clearly">
+    <link rel="manifest" href="/site.webmanifest">
+
+    <title>Command line — Clearly</title>
+    <meta name="description" content="Reference for the clearly CLI — search, read, list, tag, edit, and serve MCP from your vault, all on disk, no cloud.">
+    <meta property="og:title" content="Command line — Clearly">
+    <meta property="og:description" content="Reference for the clearly CLI — search, read, list, tag, edit, and serve MCP from your vault.">
+    <meta property="og:image" content="https://clearly.md/icon.png">
+    <meta property="og:url" content="https://clearly.md/cli">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Command line — Clearly">
+    <meta name="twitter:description" content="Reference for the clearly CLI.">
+    <meta name="twitter:image" content="https://clearly.md/icon.png">
+
+    <link rel="preconnect" href="https://rsms.me" crossorigin>
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-mono/style.css" rel="stylesheet">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['InterVariable', 'Inter', 'system-ui', 'sans-serif'],
+                        mono: ['"Geist Mono"', 'ui-monospace', 'monospace'],
+                    },
+                },
+            },
+        }
+    </script>
+    <style>
+        html { scroll-behavior: smooth; }
+        :root { font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11'; }
+        pre { font-feature-settings: normal; }
+    </style>
+</head>
+<body class="bg-[#0a0a0a] text-zinc-300 antialiased overflow-x-hidden">
+
+    <nav class="relative z-20">
+        <div class="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between text-sm">
+            <a href="/" class="flex items-center gap-2 text-white font-medium hover:opacity-80 transition-opacity">
+                <img src="icon.png" alt="" class="size-6 rounded-md">
+                Clearly
+            </a>
+            <div class="flex items-center gap-5 text-zinc-400">
+                <a href="/changelog" class="hover:text-white transition-colors">Changelog</a>
+                <a href="/cli" class="text-white" aria-current="page">Docs</a>
+                <a href="https://github.com/Shpigford/clearly" class="hover:text-white transition-colors">GitHub</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="relative z-10">
+        <section class="pt-10 pb-6 md:pt-16 md:pb-8">
+            <div class="max-w-3xl mx-auto px-6">
+                <h1 class="text-3xl sm:text-4xl font-medium tracking-tight text-white text-balance">
+                    Command line
+                </h1>
+                <p class="mt-3 text-zinc-400 text-pretty max-w-[60ch]">
+                    Search, read, list, tag, and edit your vault from the terminal. Pipe results into anything. Same SQLite index the app uses, no daemon, no auth, no cloud.
+                </p>
+                <div class="mt-6 flex items-center gap-2 text-sm">
+                    <a href="/cli" class="px-3 py-1.5 rounded-md bg-white/10 text-white" aria-current="page">CLI</a>
+                    <a href="/mcp" class="px-3 py-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/5 transition-colors">MCP server</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Install</h2>
+                    <p class="text-sm text-zinc-400 mb-4">Open Clearly &rarr; Settings &rarr; Command Line &rarr; Install. A symlink lands at <code class="font-mono text-zinc-200">~/.local/bin/clearly</code> &mdash; no sudo, no Homebrew, no second update channel. Add <code class="font-mono text-zinc-200">~/.local/bin</code> to your <code class="font-mono text-zinc-200">PATH</code> if it isn't there:</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>export PATH="$HOME/.local/bin:$PATH"</code></pre>
+                    <p class="mt-4 text-sm text-zinc-400">Verify:</p>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly status</code></pre>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Global flags</h2>
+                    <dl class="space-y-3 text-sm">
+                        <div class="sm:flex sm:gap-3">
+                            <dt class="font-mono text-zinc-200 sm:shrink-0 sm:w-44">--vault &lt;path&gt;</dt>
+                            <dd class="text-zinc-400">Load a specific vault. Repeat to load multiple. Omit to auto-discover every vault Clearly has opened.</dd>
+                        </div>
+                        <div class="sm:flex sm:gap-3">
+                            <dt class="font-mono text-zinc-200 sm:shrink-0 sm:w-44">--format json|text</dt>
+                            <dd class="text-zinc-400">JSON (default) is structured snake_case for machines. Text is loose and tab-separated for humans. Pipelines should stay on JSON.</dd>
+                        </div>
+                        <div class="sm:flex sm:gap-3">
+                            <dt class="font-mono text-zinc-200 sm:shrink-0 sm:w-44">--bundle-id &lt;id&gt;</dt>
+                            <dd class="text-zinc-400">Override the app bundle identifier when running against a Debug build (<code class="font-mono">com.sabotage.clearly.dev</code>).</dd>
+                        </div>
+                    </dl>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Commands</h2>
+                    <ul class="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 text-sm font-mono">
+                        <li><a class="text-zinc-300 hover:text-white" href="#mcp">mcp</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#search">search</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#read">read</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#list">list</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#headings">headings</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#frontmatter">frontmatter</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#backlinks">backlinks</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#tags">tags</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#create">create</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#update">update</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#vaults">vaults</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#index">index</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#status">status</a></li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6 space-y-4">
+
+                <article id="mcp" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">mcp</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-emerald-500/10 text-emerald-300 ring-1 ring-inset ring-emerald-500/20">read &amp; write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Start the Model Context Protocol stdio server, or inspect registered tools.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly mcp [serve | tools] [--read-only]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Subcommands</h3>
+                    <ul class="mt-2 space-y-1 text-sm text-zinc-400">
+                        <li><code class="font-mono text-zinc-200">serve</code> &mdash; start the stdio server. Default. Same as <code class="font-mono text-zinc-200">clearly mcp</code>.</li>
+                        <li><code class="font-mono text-zinc-200">tools</code> &mdash; print every registered tool's name, description, input schema, and output schema as JSON.</li>
+                    </ul>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code># Typical Claude Desktop config (claude_desktop_config.json)
+"clearly": { "command": "/usr/local/bin/clearly", "args": ["mcp"] }
+
+# List every registered tool
+clearly mcp tools | jq -r '.[].name'
+
+# Inspect the read-only-only set
+clearly mcp tools --read-only</code></pre>
+                </article>
+
+                <article id="search" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">search</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Full-text search across loaded vaults. Streams NDJSON hits &mdash; one per line &mdash; ranked by BM25.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly search &lt;query&gt; [--limit N]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <p class="mt-2 text-sm text-zinc-400">One JSON object per line: <code class="font-mono text-zinc-200">{vault, vault_path, relative_path, filename, matches_filename, excerpts:[{line_number, context_line}]}</code>.</p>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly search pricing
+clearly search "API design" --limit 5 | head -1 | jq .
+clearly search rust --limit 20 | jq -r '.relative_path'
+
+# Wrap NDJSON into a single array
+clearly search foo | jq -s '.'</code></pre>
+                </article>
+
+                <article id="read" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">read</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Read a note by vault-relative path, with optional line range. Returns content plus content hash, size, modified timestamp, parsed frontmatter, headings, and tags.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly read &lt;path&gt; [--start-line N] [--end-line N] [--in-vault NAME]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly read Daily/2026-04-17.md
+clearly read Strategy/pricing.md --start-line 10 --end-line 40
+clearly read Inbox/idea.md --in-vault Work | jq -r '.content'</code></pre>
+                </article>
+
+                <article id="list" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">list</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">List notes in loaded vault(s). Walks the filesystem fresh every call &mdash; results always reflect current on-disk state. Streams NDJSON.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly list [--under PREFIX] [--in-vault NAME]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly list
+clearly list --under Daily/
+clearly list | jq -r '.vault' | sort | uniq -c
+clearly list --under Projects/ | jq -r '.relative_path' | xargs -I{} clearly headings {}</code></pre>
+                </article>
+
+                <article id="headings" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">headings</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Heading outline (H1&ndash;H6) for a note: level, text, and 1-based line number.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly headings &lt;path&gt; [--in-vault NAME]</code></pre>
+                </article>
+
+                <article id="frontmatter" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">frontmatter</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Parsed YAML frontmatter as a flat key-value map. Empty map when the note has no frontmatter block.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly frontmatter &lt;path&gt; [--in-vault NAME]</code></pre>
+                </article>
+
+                <article id="backlinks" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">backlinks</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Notes that link to a target note via <code class="font-mono text-zinc-200">[[wiki-links]]</code>, plus &ldquo;unlinked mentions&rdquo; &mdash; places the target's filename appears as plain text without being wrapped.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly backlinks &lt;path&gt; [--in-vault NAME]</code></pre>
+                </article>
+
+                <article id="tags" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">tags</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">No argument: stream <code class="font-mono text-zinc-200">{tag, count}</code> records across every vault. With a tag argument: stream every note carrying that tag. Tags come from inline <code class="font-mono">#hashtags</code> and YAML frontmatter <code class="font-mono">tags:</code>.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly tags                       # all tags with counts
+clearly tags architecture          # all notes tagged #architecture
+clearly tags | jq -s 'sort_by(-.count) | .[:20]'</code></pre>
+                </article>
+
+                <article id="create" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">create</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Create a new note. Parent directories created automatically. Fails with exit 5 / <code class="font-mono">note_exists</code> if the path is already taken &mdash; use <a href="#update" class="text-zinc-200 hover:text-white">update</a> to modify.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly create &lt;path&gt; (--content STR | --from-stdin) [--in-vault NAME]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly create Daily/2026-04-17.md --content "# Today\n\nNotes..."
+cat draft.md | clearly create Inbox/draft.md --from-stdin
+clearly create Notes/idea.md --content "..." --in-vault Work</code></pre>
+                </article>
+
+                <article id="update" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">update</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Update an existing note in one of three modes. <code class="font-mono">replace</code> overwrites the whole file. <code class="font-mono">append</code> adds to the end. <code class="font-mono">prepend</code> inserts after the YAML frontmatter block (or at the top if there is none).</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly update &lt;path&gt; --mode replace|append|prepend (--content STR | --from-stdin) [--in-vault NAME]</code></pre>
+                </article>
+
+                <article id="vaults" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">vaults</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">List loaded vaults as NDJSON: <code class="font-mono text-zinc-200">{name, path, file_count, last_indexed_at, bundle_id}</code>. Use <a href="#status" class="text-zinc-200 hover:text-white">status</a> for a single-document diagnostic snapshot. Vault add/remove lives in the app &mdash; the CLI subcommands are placeholders that exit 2 and point you to Settings.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly vaults                         # same as `clearly vaults list`
+clearly vaults list --format text      # name<tab>path<tab>file_count</code></pre>
+                </article>
+
+                <article id="index" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">index</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Vault index maintenance. <code class="font-mono">rebuild</code> performs a full filesystem walk and re-hashes every markdown file &mdash; use it after out-of-band file ops or to recover from a corrupted index.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly index                        # same as `clearly index rebuild`
+clearly index rebuild --in-vault Work</code></pre>
+                </article>
+
+                <article id="status" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">status</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">One-shot diagnostic snapshot: binary version, configured bundle id, embedding model version, every loaded vault with file count and last-indexed timestamp. Single JSON document &mdash; intended for support tickets and human eyeballing.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly status
+clearly status | jq '.vault_count'
+clearly status --format text</code></pre>
+                </article>
+
+            </div>
+        </section>
+
+        <section class="pb-24">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Exit codes</h2>
+                    <dl class="space-y-2 text-sm">
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">0</dt><dd class="text-zinc-400">Success.</dd></div>
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">1</dt><dd class="text-zinc-400">General error (vault not loadable, internal failure).</dd></div>
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">2</dt><dd class="text-zinc-400">Usage error (bad flags, missing required argument).</dd></div>
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">3</dt><dd class="text-zinc-400">Not found (note doesn't exist, vault filter matches nothing).</dd></div>
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">4</dt><dd class="text-zinc-400">Permission / sandboxing error (path outside vault, traversal attempt).</dd></div>
+                        <div class="flex gap-3"><dt class="font-mono text-zinc-200 w-8">5</dt><dd class="text-zinc-400">Conflict (creating a note that already exists).</dd></div>
+                    </dl>
+                    <p class="mt-4 text-sm text-zinc-400">Errors are written to stderr as JSON: <code class="font-mono text-zinc-200">{error: "&lt;code&gt;", message: "&lt;human&gt;", ...}</code>.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="relative z-10 border-t border-white/5">
+        <div class="max-w-3xl mx-auto px-6 py-8 flex flex-wrap items-center gap-4 text-xs text-zinc-600">
+            <a href="/" class="hover:text-zinc-300 transition-colors">Home</a>
+            <a href="/changelog" class="hover:text-zinc-300 transition-colors">Changelog</a>
+            <a href="/cli" class="hover:text-zinc-300 transition-colors">CLI</a>
+            <a href="/mcp" class="hover:text-zinc-300 transition-colors">MCP server</a>
+            <a href="/privacy" class="hover:text-zinc-300 transition-colors">Privacy</a>
+            <a href="https://github.com/Shpigford/clearly" class="hover:text-zinc-300 transition-colors">GitHub</a>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/website/cli.html
+++ b/website/cli.html
@@ -165,12 +165,23 @@ clearly mcp tools --read-only</code></pre>
                     </header>
                     <p class="text-sm text-zinc-400 mb-3">Full-text search across loaded vaults. Streams NDJSON hits &mdash; one per line &mdash; ranked by BM25.</p>
                     <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly search &lt;query&gt; [--limit N]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Operators</h3>
+                    <p class="mt-2 text-sm text-zinc-400">Inside the query string, narrow results without changing the schema:</p>
+                    <ul class="mt-2 space-y-1 text-sm text-zinc-400">
+                        <li><code class="font-mono text-zinc-200">tag:foo</code> &mdash; file must carry tag <code class="font-mono">foo</code> (case-insensitive). Repeat for AND.</li>
+                        <li><code class="font-mono text-zinc-200">path:notes/sub</code> &mdash; file's vault-relative path must start with this prefix (case-insensitive).</li>
+                    </ul>
                     <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
                     <p class="mt-2 text-sm text-zinc-400">One JSON object per line: <code class="font-mono text-zinc-200">{vault, vault_path, relative_path, filename, matches_filename, excerpts:[{line_number, context_line}]}</code>.</p>
                     <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
                     <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly search pricing
 clearly search "API design" --limit 5 | head -1 | jq .
 clearly search rust --limit 20 | jq -r '.relative_path'
+
+# Operators
+clearly search "tag:work meeting"
+clearly search "path:journal/2026/ tag:idea"
+clearly search "tag:open"           # filter-only, no free text
 
 # Wrap NDJSON into a single array
 clearly search foo | jq -s '.'</code></pre>

--- a/website/cli.html
+++ b/website/cli.html
@@ -271,7 +271,9 @@ clearly create Notes/idea.md --content "..." --in-vault Work</code></pre>
                         <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
                     </header>
                     <p class="text-sm text-zinc-400 mb-3">Update an existing note in one of three modes. <code class="font-mono">replace</code> overwrites the whole file. <code class="font-mono">append</code> adds to the end. <code class="font-mono">prepend</code> inserts after the YAML frontmatter block (or at the top if there is none).</p>
-                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly update &lt;path&gt; --mode replace|append|prepend (--content STR | --from-stdin) [--in-vault NAME]</code></pre>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly update &lt;path&gt; --mode replace|append|prepend (--content STR | --from-stdin) \
+                [--in-vault NAME] [--expected-content-hash &lt;sha256&gt;]</code></pre>
+                    <p class="mt-3 text-sm text-zinc-400"><code class="font-mono text-zinc-200">--expected-content-hash</code> opts into optimistic concurrency &mdash; the call returns exit 5 / <code class="font-mono">stale_content</code> if the on-disk file has changed since the supplied hash, so a script can re-read and retry without clobbering a concurrent edit.</p>
                 </article>
 
                 <article id="vaults" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">

--- a/website/cli.html
+++ b/website/cli.html
@@ -124,6 +124,7 @@
                         <li><a class="text-zinc-300 hover:text-white" href="#tags">tags</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#create">create</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#update">update</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#move">move</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#vaults">vaults</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#index">index</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#status">status</a></li>
@@ -274,6 +275,18 @@ clearly create Notes/idea.md --content "..." --in-vault Work</code></pre>
                     <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly update &lt;path&gt; --mode replace|append|prepend (--content STR | --from-stdin) \
                 [--in-vault NAME] [--expected-content-hash &lt;sha256&gt;]</code></pre>
                     <p class="mt-3 text-sm text-zinc-400"><code class="font-mono text-zinc-200">--expected-content-hash</code> opts into optimistic concurrency &mdash; the call returns exit 5 / <code class="font-mono">stale_content</code> if the on-disk file has changed since the supplied hash, so a script can re-read and retry without clobbering a concurrent edit.</p>
+                </article>
+
+                <article id="move" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">move</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Move or rename a note within a vault. Vault-aware: reads every note that links to the source, rewrites those <code class="font-mono">[[wiki-links]]</code> to the new path (preserving heading anchors and aliases), then moves the file and updates the index without losing inbound link relationships.</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly move &lt;from-path&gt; &lt;to-path&gt; [--in-vault NAME]</code></pre>
+                    <h3 class="mt-5 text-xs font-mono tracking-wide uppercase text-zinc-500">Examples</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>clearly move Inbox/draft.md Notes/published.md
+clearly move Inbox/draft.md Archive/2026/draft.md</code></pre>
                 </article>
 
                 <article id="vaults" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">

--- a/website/index.html
+++ b/website/index.html
@@ -82,6 +82,7 @@
             </a>
             <div class="flex items-center gap-5 text-zinc-400">
                 <a href="/changelog" class="hover:text-white transition-colors">Changelog</a>
+                <a href="/cli" class="hover:text-white transition-colors">Docs</a>
                 <a href="https://github.com/Shpigford/clearly" class="hover:text-white transition-colors">GitHub</a>
             </div>
         </div>

--- a/website/mcp.html
+++ b/website/mcp.html
@@ -114,6 +114,7 @@
                     <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Tools</h2>
                     <ul class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm font-mono">
                         <li><a class="text-zinc-300 hover:text-white" href="#semantic_search">semantic_search</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#find_related">find_related</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#search_notes">search_notes</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#get_backlinks">get_backlinks</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#get_tags">get_tags</a></li>
@@ -143,6 +144,19 @@
                     <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query, total_count, returned_count,
   results: [{ vault, vault_path, relative_path, filename, score, snippet }] }</code></pre>
                     <p class="mt-3 text-sm text-zinc-400"><code class="font-mono">score</code> is cosine similarity (-1 to 1, higher is closer).</p>
+                </article>
+
+                <article id="find_related" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">find_related</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">&ldquo;More like this.&rdquo; Reuses on-device embeddings to score every other note's chunks against the source's mean vector. Use when you have one note and want to surface adjacent thinking, related projects, or earlier passes at the same idea.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, limit?: integer (default 10, max 50), vault?: string }</code></pre>
+                    <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ vault, source, total_count, returned_count,
+  results: [{ vault, vault_path, relative_path, filename, score }] }</code></pre>
                 </article>
 
                 <article id="search_notes" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">

--- a/website/mcp.html
+++ b/website/mcp.html
@@ -124,6 +124,7 @@
                         <li><a class="text-zinc-300 hover:text-white" href="#get_frontmatter">get_frontmatter</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#create_note">create_note</a></li>
                         <li><a class="text-zinc-300 hover:text-white" href="#update_note">update_note</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#move_note">move_note</a></li>
                     </ul>
                 </article>
             </div>
@@ -244,6 +245,19 @@
                     <p class="text-sm text-zinc-400 mb-3">Create a new note. Parent folders are created automatically. Returns a <code class="font-mono">note_exists</code> error if the path is already taken.</p>
                     <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
                     <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, content: string, vault?: string }</code></pre>
+                </article>
+
+                <article id="move_note" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">move_note</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Rename or move a note within a vault, rewriting every inbound <code class="font-mono">[[wiki-link]]</code> to point at the new path. Preserves heading anchors and aliases. Index <code class="font-mono">id</code> is preserved across the move &mdash; existing backlink relationships survive without re-resolution.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ from_path: string, to_path: string, vault?: string }</code></pre>
+                    <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ vault, from, to,
+  links_rewritten: [{ relative_path, count }] }</code></pre>
                 </article>
 
                 <article id="update_note" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">

--- a/website/mcp.html
+++ b/website/mcp.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en" style="color-scheme: dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <meta name="apple-mobile-web-app-title" content="Clearly">
+    <link rel="manifest" href="/site.webmanifest">
+
+    <title>MCP server — Clearly</title>
+    <meta name="description" content="The Model Context Protocol server bundled with Clearly. Local stdio, no auth, no cloud — every MCP client (Claude Desktop, Claude Code, Cursor, Codex CLI) just works.">
+    <meta property="og:title" content="MCP server — Clearly">
+    <meta property="og:description" content="Local-first MCP server for your markdown vault. No auth, no cloud, your files stay on your disk.">
+    <meta property="og:image" content="https://clearly.md/icon.png">
+    <meta property="og:url" content="https://clearly.md/mcp">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="MCP server — Clearly">
+    <meta name="twitter:description" content="Local-first MCP server for your markdown vault.">
+    <meta name="twitter:image" content="https://clearly.md/icon.png">
+
+    <link rel="preconnect" href="https://rsms.me" crossorigin>
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-mono/style.css" rel="stylesheet">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['InterVariable', 'Inter', 'system-ui', 'sans-serif'],
+                        mono: ['"Geist Mono"', 'ui-monospace', 'monospace'],
+                    },
+                },
+            },
+        }
+    </script>
+    <style>
+        html { scroll-behavior: smooth; }
+        :root { font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11'; }
+        pre { font-feature-settings: normal; }
+    </style>
+</head>
+<body class="bg-[#0a0a0a] text-zinc-300 antialiased overflow-x-hidden">
+
+    <nav class="relative z-20">
+        <div class="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between text-sm">
+            <a href="/" class="flex items-center gap-2 text-white font-medium hover:opacity-80 transition-opacity">
+                <img src="icon.png" alt="" class="size-6 rounded-md">
+                Clearly
+            </a>
+            <div class="flex items-center gap-5 text-zinc-400">
+                <a href="/changelog" class="hover:text-white transition-colors">Changelog</a>
+                <a href="/cli" class="text-white" aria-current="page">Docs</a>
+                <a href="https://github.com/Shpigford/clearly" class="hover:text-white transition-colors">GitHub</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="relative z-10">
+        <section class="pt-10 pb-6 md:pt-16 md:pb-8">
+            <div class="max-w-3xl mx-auto px-6">
+                <h1 class="text-3xl sm:text-4xl font-medium tracking-tight text-white text-balance">
+                    MCP server
+                </h1>
+                <p class="mt-3 text-zinc-400 text-pretty max-w-[60ch]">
+                    The Model Context Protocol server bundled with Clearly. Run it as <code class="font-mono text-zinc-200">clearly mcp</code> from any MCP client &mdash; Claude Desktop, Claude Code, Cursor, Codex CLI &mdash; and your AI gets vault-aware search, link graph traversal, and file edit tools. Your notes never leave the device.
+                </p>
+                <div class="mt-6 flex items-center gap-2 text-sm">
+                    <a href="/cli" class="px-3 py-1.5 rounded-md text-zinc-400 hover:text-white hover:bg-white/5 transition-colors">CLI</a>
+                    <a href="/mcp" class="px-3 py-1.5 rounded-md bg-white/10 text-white" aria-current="page">MCP server</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Setup</h2>
+                    <p class="text-sm text-zinc-400 mb-4">Install the CLI from Clearly &rarr; Settings &rarr; Command Line. Then add the server to your MCP client. For Claude Desktop, edit <code class="font-mono text-zinc-200">claude_desktop_config.json</code>:</p>
+                    <pre class="rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{
+  "mcpServers": {
+    "clearly": {
+      "command": "/usr/local/bin/clearly",
+      "args": ["mcp"]
+    }
+  }
+}</code></pre>
+                    <p class="mt-4 text-sm text-zinc-400">For an opt-in read-only profile, append <code class="font-mono text-zinc-200">"--read-only"</code> to the args. The server discovers vaults the same way the CLI does &mdash; auto-detected, or pass <code class="font-mono text-zinc-200">"--vault", "&lt;path&gt;"</code>.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Design</h2>
+                    <ul class="space-y-2 text-sm text-zinc-400 list-none pl-0">
+                        <li class="relative pl-5 before:content-[''] before:absolute before:left-1 before:top-[0.55rem] before:size-1 before:rounded-full before:bg-zinc-600">Local stdio only. No HTTP, no relay, no OAuth. Notes never leave the device.</li>
+                        <li class="relative pl-5 before:content-[''] before:absolute before:left-1 before:top-[0.55rem] before:size-1 before:rounded-full before:bg-zinc-600">Reads from the same SQLite index the app uses, in WAL mode &mdash; safe to query while the app is open.</li>
+                        <li class="relative pl-5 before:content-[''] before:absolute before:left-1 before:top-[0.55rem] before:size-1 before:rounded-full before:bg-zinc-600">Reads use the link graph, BM25 ranking, on-device embeddings &mdash; not just substring matching.</li>
+                        <li class="relative pl-5 before:content-[''] before:absolute before:left-1 before:top-[0.55rem] before:size-1 before:rounded-full before:bg-zinc-600"><code class="font-mono text-zinc-200">--read-only</code> hides every write tool at registration time. The client genuinely cannot call them.</li>
+                        <li class="relative pl-5 before:content-[''] before:absolute before:left-1 before:top-[0.55rem] before:size-1 before:rounded-full before:bg-zinc-600">Use <code class="font-mono text-zinc-200">clearly mcp tools</code> to dump every registered tool and its JSON Schema for debugging or generating client manifests.</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Tools</h2>
+                    <ul class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm font-mono">
+                        <li><a class="text-zinc-300 hover:text-white" href="#semantic_search">semantic_search</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#search_notes">search_notes</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#get_backlinks">get_backlinks</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#get_tags">get_tags</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#read_note">read_note</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#list_notes">list_notes</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#get_headings">get_headings</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#get_frontmatter">get_frontmatter</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#create_note">create_note</a></li>
+                        <li><a class="text-zinc-300 hover:text-white" href="#update_note">update_note</a></li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="pb-10">
+            <div class="max-w-3xl mx-auto px-6 space-y-4">
+
+                <article id="semantic_search" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">semantic_search</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Conceptual search via on-device embeddings (Apple's <code class="font-mono">NLContextualEmbedding</code>). Use when the user's question doesn't share keywords with the relevant notes &mdash; e.g. asking about &ldquo;productivity&rdquo; when the note actually says &ldquo;flow state&rdquo;.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query: string, limit?: integer (default 10, max 50), vault?: string }</code></pre>
+                    <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query, total_count, returned_count,
+  results: [{ vault, vault_path, relative_path, filename, score, snippet }] }</code></pre>
+                    <p class="mt-3 text-sm text-zinc-400"><code class="font-mono">score</code> is cosine similarity (-1 to 1, higher is closer).</p>
+                </article>
+
+                <article id="search_notes" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">search_notes</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Full-text search with BM25 ranking and stemming. Supports quoted phrases for exact match. Use this for keyword targets and proper nouns; use <a href="#semantic_search" class="text-zinc-200 hover:text-white">semantic_search</a> when the question is conceptual.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query: string, limit?: integer (default 20, max 100) }</code></pre>
+                    <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query, total_count, returned_count, results: [...] }</code></pre>
+                </article>
+
+                <article id="get_backlinks" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">get_backlinks</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Notes that link to a target via <code class="font-mono">[[wiki-links]]</code>, plus &ldquo;unlinked mentions&rdquo; &mdash; places the target's filename appears as plain text without being wrapped.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, vault?: string }</code></pre>
+                    <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ vault, relative_path,
+  linked:   [{ vault, relative_path, line_number, display_text, context }],
+  unlinked: [{ vault, relative_path, line_number, context_line }] }</code></pre>
+                </article>
+
+                <article id="get_tags" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">get_tags</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Without <code class="font-mono">tag</code>: list every tag with file count (mode <code class="font-mono">all</code>). With <code class="font-mono">tag</code>: list every note carrying it (mode <code class="font-mono">by_tag</code>). Tags come from inline <code class="font-mono">#hashtags</code> and YAML frontmatter <code class="font-mono">tags:</code>.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ tag?: string }</code></pre>
+                </article>
+
+                <article id="read_note" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">read_note</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Full content of a note plus metadata: content hash, byte size, modified timestamp, parsed frontmatter, headings, and tags. Optional 1-based line range.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, start_line?: integer, end_line?: integer, vault?: string }</code></pre>
+                </article>
+
+                <article id="list_notes" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">list_notes</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Walks the filesystem fresh every call &mdash; results always reflect current on-disk state. Optional subpath prefix.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ under?: string, vault?: string }</code></pre>
+                </article>
+
+                <article id="get_headings" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">get_headings</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Heading outline (H1&ndash;H6) with level, text, and 1-based line number.</p>
+                </article>
+
+                <article id="get_frontmatter" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">get_frontmatter</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Parsed YAML frontmatter as a flat key-value map, plus a <code class="font-mono">has_frontmatter</code> boolean.</p>
+                </article>
+
+                <article id="create_note" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">create_note</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Create a new note. Parent folders are created automatically. Returns a <code class="font-mono">note_exists</code> error if the path is already taken.</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, content: string, vault?: string }</code></pre>
+                </article>
+
+                <article id="update_note" class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8 scroll-mt-20">
+                    <header class="mb-4 flex items-center gap-3">
+                        <h2 class="text-lg font-medium text-white font-mono">update_note</h2>
+                        <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
+                    </header>
+                    <p class="text-sm text-zinc-400 mb-3">Update an existing note. <code class="font-mono">replace</code> overwrites the whole file. <code class="font-mono">append</code> adds to the end. <code class="font-mono">prepend</code> inserts after the YAML frontmatter block (or at the top if there is none).</p>
+                    <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, content: string, mode: "replace"|"append"|"prepend", vault?: string }</code></pre>
+                </article>
+
+            </div>
+        </section>
+
+        <section class="pb-24">
+            <div class="max-w-3xl mx-auto px-6">
+                <article class="rounded-xl outline-1 -outline-offset-1 outline-white/10 bg-white/[0.02] p-6 md:p-8">
+                    <h2 class="text-xs font-mono tracking-wide uppercase text-zinc-500 mb-3">Errors</h2>
+                    <p class="text-sm text-zinc-400">Tool calls that fail return MCP error responses with a stable <code class="font-mono text-zinc-200">error</code> code: <code class="font-mono">note_not_found</code>, <code class="font-mono">note_exists</code>, <code class="font-mono">path_outside_vault</code>, <code class="font-mono">ambiguous_vault</code>, <code class="font-mono">no_vault_match</code>, <code class="font-mono">invalid_argument</code>. Inspect the full schema with <code class="font-mono text-zinc-200">clearly mcp tools</code>.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="relative z-10 border-t border-white/5">
+        <div class="max-w-3xl mx-auto px-6 py-8 flex flex-wrap items-center gap-4 text-xs text-zinc-600">
+            <a href="/" class="hover:text-zinc-300 transition-colors">Home</a>
+            <a href="/changelog" class="hover:text-zinc-300 transition-colors">Changelog</a>
+            <a href="/cli" class="hover:text-zinc-300 transition-colors">CLI</a>
+            <a href="/mcp" class="hover:text-zinc-300 transition-colors">MCP server</a>
+            <a href="/privacy" class="hover:text-zinc-300 transition-colors">Privacy</a>
+            <a href="https://github.com/Shpigford/clearly" class="hover:text-zinc-300 transition-colors">GitHub</a>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/website/mcp.html
+++ b/website/mcp.html
@@ -151,6 +151,11 @@
                         <span class="px-2 py-0.5 rounded-full text-xs bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">read</span>
                     </header>
                     <p class="text-sm text-zinc-400 mb-3">Full-text search with BM25 ranking and stemming. Supports quoted phrases for exact match. Use this for keyword targets and proper nouns; use <a href="#semantic_search" class="text-zinc-200 hover:text-white">semantic_search</a> when the question is conceptual.</p>
+                    <p class="text-sm text-zinc-400 mb-3">Operators inside the query string narrow without a schema change:</p>
+                    <ul class="space-y-1 text-sm text-zinc-400 mb-3">
+                        <li><code class="font-mono text-zinc-200">tag:foo</code> &mdash; file must carry tag <code class="font-mono">foo</code> (case-insensitive). Repeat for AND.</li>
+                        <li><code class="font-mono text-zinc-200">path:notes/sub</code> &mdash; file's vault-relative path must start with this prefix.</li>
+                    </ul>
                     <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
                     <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ query: string, limit?: integer (default 20, max 100) }</code></pre>
                     <h3 class="mt-4 text-xs font-mono tracking-wide uppercase text-zinc-500">Output</h3>

--- a/website/mcp.html
+++ b/website/mcp.html
@@ -252,8 +252,10 @@
                         <span class="px-2 py-0.5 rounded-full text-xs bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">write</span>
                     </header>
                     <p class="text-sm text-zinc-400 mb-3">Update an existing note. <code class="font-mono">replace</code> overwrites the whole file. <code class="font-mono">append</code> adds to the end. <code class="font-mono">prepend</code> inserts after the YAML frontmatter block (or at the top if there is none).</p>
+                    <p class="text-sm text-zinc-400 mb-3">Pass <code class="font-mono text-zinc-200">expected_content_hash</code> (the value <code class="font-mono">read_note</code> returned) to opt into optimistic concurrency &mdash; the call is rejected with <code class="font-mono">stale_content</code> if the file changed since you last read it. The editor's save path goes through the same coordinated I/O, so a user typing in the editor and an MCP write to the same note can no longer drop each other's edits.</p>
                     <h3 class="mt-3 text-xs font-mono tracking-wide uppercase text-zinc-500">Input</h3>
-                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, content: string, mode: "replace"|"append"|"prepend", vault?: string }</code></pre>
+                    <pre class="mt-2 rounded-md bg-black/40 p-4 text-xs font-mono text-zinc-300 overflow-x-auto"><code>{ relative_path: string, content: string, mode: "replace"|"append"|"prepend",
+  vault?: string, expected_content_hash?: string }</code></pre>
                 </article>
 
             </div>


### PR DESCRIPTION
## Summary
- New CLI/MCP surface area: `clearly status`, `clearly mcp tools` introspection, `clearly move`, plus MCP tools `find_related` and `move_note`. Search query gains `tag:` and `path:` operators (used by CLI, MCP, and Cmd+P).
- Editor saves and MCP write tools now route through `CoordinatedFileIO`; `update_note` accepts an optional `expected_content_hash` and rejects stale-base writes with a new `stale_content` error.
- Renaming a file in the sidebar now rewrites every inbound `[[wiki-link]]` across the vault and preserves the SQLite `id` so backlink relationships survive — fixes a pre-existing GUI bug. Same orchestration powers `move_note`. Inbound rewrites are precomputed in memory and the FS move rolls back if the index update fails.
- Public reference docs at `clearly.md/cli` and `clearly.md/mcp` (HTML pages mirror the changelog visual language); thin `docs/cli.md` / `docs/mcp.md` pointers in the repo for GitHub readers.

## Test plan
- [ ] `xcodebuild -scheme ClearlyCoreTests test` (195 tests) and `-scheme ClearlyCLIIntegrationTests test` (57 tests) green
- [ ] `xcodebuild -scheme Clearly` and `-scheme Clearly-iOS` build clean
- [ ] `clearly status` reports the correct binary version and vault inventory
- [ ] `clearly mcp tools | jq '.[].inputSchema'` returns camelCase MCP wire-format keys
- [ ] `clearly search "tag:work path:journal/"` narrows correctly across the fixture vault
- [ ] Renaming a wiki-linked file from the sidebar updates inbound `[[links]]` in every other note; cross-vault drag-drop still falls through to `FileManager.moveItem`
- [ ] `update_note` with a stale `expected_content_hash` returns `stale_content` and leaves the file untouched