### PR TITLE
Add Docs/CLI/MCP nav links to website changelog page

### DIFF
--- a/website/changelog.html
+++ b/website/changelog.html
@@ -49,6 +49,7 @@
             </a>
             <div class="flex items-center gap-5 text-zinc-400">
                 <a href="/changelog" class="text-white" aria-current="page">Changelog</a>
+                <a href="/cli" class="hover:text-white transition-colors">Docs</a>
                 <a href="https://github.com/Shpigford/clearly" class="hover:text-white transition-colors">GitHub</a>
             </div>
         </div>
@@ -663,12 +664,15 @@
     </main>
 
     <footer class="pb-12 pt-8 border-t border-zinc-900">
-        <div class="max-w-4xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-zinc-600">
+        <div class="max-w-3xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-zinc-600">
             <span>&copy; 2026</span>
-            <div class="flex items-center gap-6">
-                <a href="https://github.com/Shpigford/clearly" class="hover:text-zinc-400 transition-colors">GitHub</a>
+            <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+                <a href="/" class="hover:text-zinc-400 transition-colors">Home</a>
                 <a href="/changelog" class="hover:text-zinc-400 transition-colors">Changelog</a>
+                <a href="/cli" class="hover:text-zinc-400 transition-colors">CLI</a>
+                <a href="/mcp" class="hover:text-zinc-400 transition-colors">MCP server</a>
                 <a href="/privacy" class="hover:text-zinc-400 transition-colors">Privacy</a>
+                <a href="https://github.com/Shpigford/clearly" class="hover:text-zinc-400 transition-colors">GitHub</a>
                 <a href="https://x.com/Shpigford" class="hover:text-zinc-400 transition-colors">@Shpigford</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Header on `website/changelog.html` now includes a `Docs` link (→ `/cli`), matching `index.html`, `cli.html`, and `mcp.html`.
- Footer adds Home, CLI, and MCP server links, narrows to `max-w-3xl` to match the page column, and wraps cleanly on small widths.

## Test plan
- [ ] Open `website/changelog.html` locally — header shows `Changelog · Docs · GitHub`; footer shows `Home · Changelog · CLI · MCP server · Privacy · GitHub · @Shpigford`.
- [ ] Click `Docs`, `CLI`, and `MCP server` from the changelog and confirm they land on the correct pages.
- [ ] Resize to mobile width — footer wraps without overflow.