### PR TITLE
[mac] Fix editable-preview ⌘N copying previous note's content

### DIFF
--- a/Clearly/WYSIWYGView.swift
+++ b/Clearly/WYSIWYGView.swift
@@ -142,17 +142,23 @@ struct WYSIWYGView: NSViewRepresentable {
         let webView = WYSIWYGWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.underPageBackgroundColor = Theme.backgroundColor
-        WYSIWYGSession.update(documentID: documentID, epoch: documentEpoch)
         context.coordinator.attach(webView: webView, findState: findState, outlineState: outlineState)
         loadEditorPage(in: webView)
         return webView
     }
 
+    // `WYSIWYGSession` is updated authoritatively by `WorkspaceManager` on
+    // every document switch (createUntitledDocument, switchToDocument,
+    // restoreActiveDocument, etc.). Mirroring it here would let SwiftUI's
+    // teardown call `updateNSView` once more with this view's stale
+    // `documentID`/`documentEpoch` after the user has already activated a
+    // new document — clobbering the session and letting in-flight async
+    // `getDocument` callbacks pass their epoch guard and write the previous
+    // note's content into the new doc's binding (#313).
     func updateNSView(_ webView: WYSIWYGWebView, context: Context) {
         DiagnosticLog.log("WYSIWYGView.updateNSView: \(text.count) chars")
         context.coordinator.parent = self
         webView.underPageBackgroundColor = Theme.backgroundColor
-        WYSIWYGSession.update(documentID: documentID, epoch: documentEpoch)
         context.coordinator.attach(webView: webView, findState: findState, outlineState: outlineState)
         context.coordinator.syncFromSwiftIfNeeded()
     }

--- a/ClearlyWYSIWYGWeb/src/index.ts
+++ b/ClearlyWYSIWYGWeb/src/index.ts
@@ -1,4 +1,5 @@
 import { Editor } from "@tiptap/core";
+import { history } from "@tiptap/pm/history";
 import { joinFrontmatter, splitFrontmatter } from "./frontmatter";
 import { SourcePreservation } from "./preservation";
 import { clearlyExtensions } from "./extensions";
@@ -190,6 +191,32 @@ function attachClickDelegate(root: HTMLElement): void {
   );
 }
 
+// `setContent("", { contentType: "markdown" })` is a silent no-op: the
+// markdown extension parses "" to `{ type: "doc", content: [] }`, which
+// violates ProseMirror's `block+` schema, and the resulting `replaceWith`
+// leaves the editor unchanged. `clearContent()` uses `tr.delete()` instead,
+// which auto-fills with an empty paragraph. Use it for the empty case so a
+// new untitled document doesn't display the previous note's content (#313).
+function replaceEditorBody(body: string): void {
+  if (!editor) return;
+  if (body.length === 0) {
+    editor.commands.clearContent();
+  } else {
+    editor.commands.setContent(body, { contentType: "markdown" });
+  }
+}
+
+// Tiptap 3 / ProseMirror have no command to clear undo history, so reset
+// the plugin instance instead. `unregisterPlugin("history")` filters by key
+// prefix `history$` (the key PM's `history()` plugin always uses); the
+// fresh `history()` registers under the same key, keeping UndoRedo's
+// `Mod-Z` shortcut wired without extra plumbing.
+function resetUndoHistory(): void {
+  if (!editor) return;
+  editor.unregisterPlugin("history");
+  editor.registerPlugin(history());
+}
+
 function ensureMounted(initialMarkdown: string, epoch: number, appearance: "light" | "dark", fontSize: number): void {
   const root = document.getElementById("editor");
   if (!root) throw new Error("missing #editor root");
@@ -199,7 +226,7 @@ function ensureMounted(initialMarkdown: string, epoch: number, appearance: "ligh
   if (editor) {
     withSuppressedUpdates(() => {
       preservation?.beginExternalReplace(split.body);
-      editor!.commands.setContent(split.body, { contentType: "markdown" });
+      replaceEditorBody(split.body);
       // Tiptap's setContent leaves the selection covering the whole inserted
       // range (Selection.atStart-of-replaced-range to atEnd). Collapse to the
       // start so switching INTO WYSIWYG mode doesn't show the whole doc as
@@ -207,6 +234,7 @@ function ensureMounted(initialMarkdown: string, epoch: number, appearance: "ligh
       editor!.commands.setTextSelection(0);
       if (preservation) preservation.attach(editor!);
     });
+    resetUndoHistory();
     pendingEpoch = epoch;
     return;
   }
@@ -275,10 +303,11 @@ window.clearlyWYSIWYG = {
     storedFrontmatter = split.frontmatter;
     withSuppressedUpdates(() => {
       preservation?.beginExternalReplace(split.body);
-      editor!.commands.setContent(split.body, { contentType: "markdown" });
+      replaceEditorBody(split.body);
       editor!.commands.setTextSelection(0);
       if (preservation) preservation.attach(editor!);
     });
+    resetUndoHistory();
   },
   setTheme({ appearance, fontSize }) {
     applyAppearance(appearance, fontSize);

--- a/ClearlyWYSIWYGWeb/src/preservation.ts
+++ b/ClearlyWYSIWYGWeb/src/preservation.ts
@@ -37,6 +37,8 @@ interface BlockSnapshot {
   json: string; // canonicalized JSON of the PM child at mount time
 }
 
+type UpdateHandler = (event: { transaction: any }) => void;
+
 export class SourcePreservation {
   private originalBody: string;
   private tokens: MarkedToken[] = [];
@@ -48,6 +50,10 @@ export class SourcePreservation {
   // Used only when not aligned (global dirty bit).
   private globalDirty = false;
   private ignoreNextUpdate = false;
+  // Held so we can detach on re-attach. `editor.on("update", fn)` registers
+  // a fresh listener each call without removing prior ones — without this,
+  // every doc switch would leak a listener that fires on every keystroke.
+  private updateHandler: UpdateHandler | null = null;
 
   constructor(body: string) {
     this.originalBody = body;
@@ -57,6 +63,10 @@ export class SourcePreservation {
   // PM child with a preserveId, then snapshot JSON. Must be called after
   // the editor finishes mounting.
   attach(editor: Editor): void {
+    if (this.updateHandler) {
+      editor.off("update", this.updateHandler);
+      this.updateHandler = null;
+    }
     const manager = (editor as any).markdown;
     const marked = manager?.instance;
     if (manager && marked && typeof marked.lexer === "function") {
@@ -105,14 +115,15 @@ export class SourcePreservation {
       });
     }
 
-    editor.on("update", ({ transaction }) => {
+    this.updateHandler = ({ transaction }) => {
       if (this.ignoreNextUpdate) {
         this.ignoreNextUpdate = false;
         return;
       }
       if (transaction.getMeta("preservation:internal")) return;
       this.globalDirty = true;
-    });
+    };
+    editor.on("update", this.updateHandler);
   }
 
   // Re-initialize state for a new source body. Must be followed by attach().

--- a/Shared/Resources/wysiwyg/wysiwyg.js
+++ b/Shared/Resources/wysiwyg/wysiwyg.js
@@ -19667,6 +19667,542 @@ ${indentedChild}`;
     });
   }
 
+  // node_modules/rope-sequence/dist/index.js
+  var GOOD_LEAF_SIZE = 200;
+  var RopeSequence = function RopeSequence2() {
+  };
+  RopeSequence.prototype.append = function append(other) {
+    if (!other.length) {
+      return this;
+    }
+    other = RopeSequence.from(other);
+    return !this.length && other || other.length < GOOD_LEAF_SIZE && this.leafAppend(other) || this.length < GOOD_LEAF_SIZE && other.leafPrepend(this) || this.appendInner(other);
+  };
+  RopeSequence.prototype.prepend = function prepend(other) {
+    if (!other.length) {
+      return this;
+    }
+    return RopeSequence.from(other).append(this);
+  };
+  RopeSequence.prototype.appendInner = function appendInner(other) {
+    return new Append(this, other);
+  };
+  RopeSequence.prototype.slice = function slice(from2, to) {
+    if (from2 === void 0) from2 = 0;
+    if (to === void 0) to = this.length;
+    if (from2 >= to) {
+      return RopeSequence.empty;
+    }
+    return this.sliceInner(Math.max(0, from2), Math.min(this.length, to));
+  };
+  RopeSequence.prototype.get = function get(i) {
+    if (i < 0 || i >= this.length) {
+      return void 0;
+    }
+    return this.getInner(i);
+  };
+  RopeSequence.prototype.forEach = function forEach2(f, from2, to) {
+    if (from2 === void 0) from2 = 0;
+    if (to === void 0) to = this.length;
+    if (from2 <= to) {
+      this.forEachInner(f, from2, to, 0);
+    } else {
+      this.forEachInvertedInner(f, from2, to, 0);
+    }
+  };
+  RopeSequence.prototype.map = function map(f, from2, to) {
+    if (from2 === void 0) from2 = 0;
+    if (to === void 0) to = this.length;
+    var result = [];
+    this.forEach(function(elt, i) {
+      return result.push(f(elt, i));
+    }, from2, to);
+    return result;
+  };
+  RopeSequence.from = function from(values) {
+    if (values instanceof RopeSequence) {
+      return values;
+    }
+    return values && values.length ? new Leaf(values) : RopeSequence.empty;
+  };
+  var Leaf = /* @__PURE__ */ (function(RopeSequence3) {
+    function Leaf2(values) {
+      RopeSequence3.call(this);
+      this.values = values;
+    }
+    if (RopeSequence3) Leaf2.__proto__ = RopeSequence3;
+    Leaf2.prototype = Object.create(RopeSequence3 && RopeSequence3.prototype);
+    Leaf2.prototype.constructor = Leaf2;
+    var prototypeAccessors = { length: { configurable: true }, depth: { configurable: true } };
+    Leaf2.prototype.flatten = function flatten() {
+      return this.values;
+    };
+    Leaf2.prototype.sliceInner = function sliceInner(from2, to) {
+      if (from2 == 0 && to == this.length) {
+        return this;
+      }
+      return new Leaf2(this.values.slice(from2, to));
+    };
+    Leaf2.prototype.getInner = function getInner(i) {
+      return this.values[i];
+    };
+    Leaf2.prototype.forEachInner = function forEachInner(f, from2, to, start) {
+      for (var i = from2; i < to; i++) {
+        if (f(this.values[i], start + i) === false) {
+          return false;
+        }
+      }
+    };
+    Leaf2.prototype.forEachInvertedInner = function forEachInvertedInner(f, from2, to, start) {
+      for (var i = from2 - 1; i >= to; i--) {
+        if (f(this.values[i], start + i) === false) {
+          return false;
+        }
+      }
+    };
+    Leaf2.prototype.leafAppend = function leafAppend(other) {
+      if (this.length + other.length <= GOOD_LEAF_SIZE) {
+        return new Leaf2(this.values.concat(other.flatten()));
+      }
+    };
+    Leaf2.prototype.leafPrepend = function leafPrepend(other) {
+      if (this.length + other.length <= GOOD_LEAF_SIZE) {
+        return new Leaf2(other.flatten().concat(this.values));
+      }
+    };
+    prototypeAccessors.length.get = function() {
+      return this.values.length;
+    };
+    prototypeAccessors.depth.get = function() {
+      return 0;
+    };
+    Object.defineProperties(Leaf2.prototype, prototypeAccessors);
+    return Leaf2;
+  })(RopeSequence);
+  RopeSequence.empty = new Leaf([]);
+  var Append = /* @__PURE__ */ (function(RopeSequence3) {
+    function Append2(left, right) {
+      RopeSequence3.call(this);
+      this.left = left;
+      this.right = right;
+      this.length = left.length + right.length;
+      this.depth = Math.max(left.depth, right.depth) + 1;
+    }
+    if (RopeSequence3) Append2.__proto__ = RopeSequence3;
+    Append2.prototype = Object.create(RopeSequence3 && RopeSequence3.prototype);
+    Append2.prototype.constructor = Append2;
+    Append2.prototype.flatten = function flatten() {
+      return this.left.flatten().concat(this.right.flatten());
+    };
+    Append2.prototype.getInner = function getInner(i) {
+      return i < this.left.length ? this.left.get(i) : this.right.get(i - this.left.length);
+    };
+    Append2.prototype.forEachInner = function forEachInner(f, from2, to, start) {
+      var leftLen = this.left.length;
+      if (from2 < leftLen && this.left.forEachInner(f, from2, Math.min(to, leftLen), start) === false) {
+        return false;
+      }
+      if (to > leftLen && this.right.forEachInner(f, Math.max(from2 - leftLen, 0), Math.min(this.length, to) - leftLen, start + leftLen) === false) {
+        return false;
+      }
+    };
+    Append2.prototype.forEachInvertedInner = function forEachInvertedInner(f, from2, to, start) {
+      var leftLen = this.left.length;
+      if (from2 > leftLen && this.right.forEachInvertedInner(f, from2 - leftLen, Math.max(to, leftLen) - leftLen, start + leftLen) === false) {
+        return false;
+      }
+      if (to < leftLen && this.left.forEachInvertedInner(f, Math.min(from2, leftLen), to, start) === false) {
+        return false;
+      }
+    };
+    Append2.prototype.sliceInner = function sliceInner(from2, to) {
+      if (from2 == 0 && to == this.length) {
+        return this;
+      }
+      var leftLen = this.left.length;
+      if (to <= leftLen) {
+        return this.left.slice(from2, to);
+      }
+      if (from2 >= leftLen) {
+        return this.right.slice(from2 - leftLen, to - leftLen);
+      }
+      return this.left.slice(from2, leftLen).append(this.right.slice(0, to - leftLen));
+    };
+    Append2.prototype.leafAppend = function leafAppend(other) {
+      var inner = this.right.leafAppend(other);
+      if (inner) {
+        return new Append2(this.left, inner);
+      }
+    };
+    Append2.prototype.leafPrepend = function leafPrepend(other) {
+      var inner = this.left.leafPrepend(other);
+      if (inner) {
+        return new Append2(inner, this.right);
+      }
+    };
+    Append2.prototype.appendInner = function appendInner2(other) {
+      if (this.left.depth >= Math.max(this.right.depth, other.depth) + 1) {
+        return new Append2(this.left, new Append2(this.right, other));
+      }
+      return new Append2(this, other);
+    };
+    return Append2;
+  })(RopeSequence);
+  var dist_default2 = RopeSequence;
+
+  // node_modules/prosemirror-history/dist/index.js
+  var max_empty_items = 500;
+  var Branch = class _Branch {
+    constructor(items, eventCount) {
+      this.items = items;
+      this.eventCount = eventCount;
+    }
+    // Pop the latest event off the branch's history and apply it
+    // to a document transform.
+    popEvent(state, preserveItems) {
+      if (this.eventCount == 0)
+        return null;
+      let end = this.items.length;
+      for (; ; end--) {
+        let next = this.items.get(end - 1);
+        if (next.selection) {
+          --end;
+          break;
+        }
+      }
+      let remap, mapFrom;
+      if (preserveItems) {
+        remap = this.remapping(end, this.items.length);
+        mapFrom = remap.maps.length;
+      }
+      let transform = state.tr;
+      let selection, remaining;
+      let addAfter = [], addBefore = [];
+      this.items.forEach((item, i) => {
+        if (!item.step) {
+          if (!remap) {
+            remap = this.remapping(end, i + 1);
+            mapFrom = remap.maps.length;
+          }
+          mapFrom--;
+          addBefore.push(item);
+          return;
+        }
+        if (remap) {
+          addBefore.push(new Item(item.map));
+          let step = item.step.map(remap.slice(mapFrom)), map2;
+          if (step && transform.maybeStep(step).doc) {
+            map2 = transform.mapping.maps[transform.mapping.maps.length - 1];
+            addAfter.push(new Item(map2, void 0, void 0, addAfter.length + addBefore.length));
+          }
+          mapFrom--;
+          if (map2)
+            remap.appendMap(map2, mapFrom);
+        } else {
+          transform.maybeStep(item.step);
+        }
+        if (item.selection) {
+          selection = remap ? item.selection.map(remap.slice(mapFrom)) : item.selection;
+          remaining = new _Branch(this.items.slice(0, end).append(addBefore.reverse().concat(addAfter)), this.eventCount - 1);
+          return false;
+        }
+      }, this.items.length, 0);
+      return { remaining, transform, selection };
+    }
+    // Create a new branch with the given transform added.
+    addTransform(transform, selection, histOptions, preserveItems) {
+      let newItems = [], eventCount = this.eventCount;
+      let oldItems = this.items, lastItem = !preserveItems && oldItems.length ? oldItems.get(oldItems.length - 1) : null;
+      for (let i = 0; i < transform.steps.length; i++) {
+        let step = transform.steps[i].invert(transform.docs[i]);
+        let item = new Item(transform.mapping.maps[i], step, selection), merged;
+        if (merged = lastItem && lastItem.merge(item)) {
+          item = merged;
+          if (i)
+            newItems.pop();
+          else
+            oldItems = oldItems.slice(0, oldItems.length - 1);
+        }
+        newItems.push(item);
+        if (selection) {
+          eventCount++;
+          selection = void 0;
+        }
+        if (!preserveItems)
+          lastItem = item;
+      }
+      let overflow = eventCount - histOptions.depth;
+      if (overflow > DEPTH_OVERFLOW) {
+        oldItems = cutOffEvents(oldItems, overflow);
+        eventCount -= overflow;
+      }
+      return new _Branch(oldItems.append(newItems), eventCount);
+    }
+    remapping(from2, to) {
+      let maps = new Mapping();
+      this.items.forEach((item, i) => {
+        let mirrorPos = item.mirrorOffset != null && i - item.mirrorOffset >= from2 ? maps.maps.length - item.mirrorOffset : void 0;
+        maps.appendMap(item.map, mirrorPos);
+      }, from2, to);
+      return maps;
+    }
+    addMaps(array) {
+      if (this.eventCount == 0)
+        return this;
+      return new _Branch(this.items.append(array.map((map2) => new Item(map2))), this.eventCount);
+    }
+    // When the collab module receives remote changes, the history has
+    // to know about those, so that it can adjust the steps that were
+    // rebased on top of the remote changes, and include the position
+    // maps for the remote changes in its array of items.
+    rebased(rebasedTransform, rebasedCount) {
+      if (!this.eventCount)
+        return this;
+      let rebasedItems = [], start = Math.max(0, this.items.length - rebasedCount);
+      let mapping = rebasedTransform.mapping;
+      let newUntil = rebasedTransform.steps.length;
+      let eventCount = this.eventCount;
+      this.items.forEach((item) => {
+        if (item.selection)
+          eventCount--;
+      }, start);
+      let iRebased = rebasedCount;
+      this.items.forEach((item) => {
+        let pos = mapping.getMirror(--iRebased);
+        if (pos == null)
+          return;
+        newUntil = Math.min(newUntil, pos);
+        let map2 = mapping.maps[pos];
+        if (item.step) {
+          let step = rebasedTransform.steps[pos].invert(rebasedTransform.docs[pos]);
+          let selection = item.selection && item.selection.map(mapping.slice(iRebased + 1, pos));
+          if (selection)
+            eventCount++;
+          rebasedItems.push(new Item(map2, step, selection));
+        } else {
+          rebasedItems.push(new Item(map2));
+        }
+      }, start);
+      let newMaps = [];
+      for (let i = rebasedCount; i < newUntil; i++)
+        newMaps.push(new Item(mapping.maps[i]));
+      let items = this.items.slice(0, start).append(newMaps).append(rebasedItems);
+      let branch = new _Branch(items, eventCount);
+      if (branch.emptyItemCount() > max_empty_items)
+        branch = branch.compress(this.items.length - rebasedItems.length);
+      return branch;
+    }
+    emptyItemCount() {
+      let count = 0;
+      this.items.forEach((item) => {
+        if (!item.step)
+          count++;
+      });
+      return count;
+    }
+    // Compressing a branch means rewriting it to push the air (map-only
+    // items) out. During collaboration, these naturally accumulate
+    // because each remote change adds one. The `upto` argument is used
+    // to ensure that only the items below a given level are compressed,
+    // because `rebased` relies on a clean, untouched set of items in
+    // order to associate old items with rebased steps.
+    compress(upto = this.items.length) {
+      let remap = this.remapping(0, upto), mapFrom = remap.maps.length;
+      let items = [], events = 0;
+      this.items.forEach((item, i) => {
+        if (i >= upto) {
+          items.push(item);
+          if (item.selection)
+            events++;
+        } else if (item.step) {
+          let step = item.step.map(remap.slice(mapFrom)), map2 = step && step.getMap();
+          mapFrom--;
+          if (map2)
+            remap.appendMap(map2, mapFrom);
+          if (step) {
+            let selection = item.selection && item.selection.map(remap.slice(mapFrom));
+            if (selection)
+              events++;
+            let newItem = new Item(map2.invert(), step, selection), merged, last = items.length - 1;
+            if (merged = items.length && items[last].merge(newItem))
+              items[last] = merged;
+            else
+              items.push(newItem);
+          }
+        } else if (item.map) {
+          mapFrom--;
+        }
+      }, this.items.length, 0);
+      return new _Branch(dist_default2.from(items.reverse()), events);
+    }
+  };
+  Branch.empty = new Branch(dist_default2.empty, 0);
+  function cutOffEvents(items, n) {
+    let cutPoint;
+    items.forEach((item, i) => {
+      if (item.selection && n-- == 0) {
+        cutPoint = i;
+        return false;
+      }
+    });
+    return items.slice(cutPoint);
+  }
+  var Item = class _Item {
+    constructor(map2, step, selection, mirrorOffset) {
+      this.map = map2;
+      this.step = step;
+      this.selection = selection;
+      this.mirrorOffset = mirrorOffset;
+    }
+    merge(other) {
+      if (this.step && other.step && !other.selection) {
+        let step = other.step.merge(this.step);
+        if (step)
+          return new _Item(step.getMap().invert(), step, this.selection);
+      }
+    }
+  };
+  var HistoryState = class {
+    constructor(done, undone, prevRanges, prevTime, prevComposition) {
+      this.done = done;
+      this.undone = undone;
+      this.prevRanges = prevRanges;
+      this.prevTime = prevTime;
+      this.prevComposition = prevComposition;
+    }
+  };
+  var DEPTH_OVERFLOW = 20;
+  function applyTransaction(history2, state, tr2, options) {
+    let historyTr = tr2.getMeta(historyKey), rebased;
+    if (historyTr)
+      return historyTr.historyState;
+    if (tr2.getMeta(closeHistoryKey))
+      history2 = new HistoryState(history2.done, history2.undone, null, 0, -1);
+    let appended = tr2.getMeta("appendedTransaction");
+    if (tr2.steps.length == 0) {
+      return history2;
+    } else if (appended && appended.getMeta(historyKey)) {
+      if (appended.getMeta(historyKey).redo)
+        return new HistoryState(history2.done.addTransform(tr2, void 0, options, mustPreserveItems(state)), history2.undone, rangesFor(tr2.mapping.maps), history2.prevTime, history2.prevComposition);
+      else
+        return new HistoryState(history2.done, history2.undone.addTransform(tr2, void 0, options, mustPreserveItems(state)), null, history2.prevTime, history2.prevComposition);
+    } else if (tr2.getMeta("addToHistory") !== false && !(appended && appended.getMeta("addToHistory") === false)) {
+      let composition = tr2.getMeta("composition");
+      let newGroup = history2.prevTime == 0 || !appended && history2.prevComposition != composition && (history2.prevTime < (tr2.time || 0) - options.newGroupDelay || !isAdjacentTo(tr2, history2.prevRanges));
+      let prevRanges = appended ? mapRanges(history2.prevRanges, tr2.mapping) : rangesFor(tr2.mapping.maps);
+      return new HistoryState(history2.done.addTransform(tr2, newGroup ? state.selection.getBookmark() : void 0, options, mustPreserveItems(state)), Branch.empty, prevRanges, tr2.time, composition == null ? history2.prevComposition : composition);
+    } else if (rebased = tr2.getMeta("rebased")) {
+      return new HistoryState(history2.done.rebased(tr2, rebased), history2.undone.rebased(tr2, rebased), mapRanges(history2.prevRanges, tr2.mapping), history2.prevTime, history2.prevComposition);
+    } else {
+      return new HistoryState(history2.done.addMaps(tr2.mapping.maps), history2.undone.addMaps(tr2.mapping.maps), mapRanges(history2.prevRanges, tr2.mapping), history2.prevTime, history2.prevComposition);
+    }
+  }
+  function isAdjacentTo(transform, prevRanges) {
+    if (!prevRanges)
+      return false;
+    if (!transform.docChanged)
+      return true;
+    let adjacent = false;
+    transform.mapping.maps[0].forEach((start, end) => {
+      for (let i = 0; i < prevRanges.length; i += 2)
+        if (start <= prevRanges[i + 1] && end >= prevRanges[i])
+          adjacent = true;
+    });
+    return adjacent;
+  }
+  function rangesFor(maps) {
+    let result = [];
+    for (let i = maps.length - 1; i >= 0 && result.length == 0; i--)
+      maps[i].forEach((_from, _to, from2, to) => result.push(from2, to));
+    return result;
+  }
+  function mapRanges(ranges, mapping) {
+    if (!ranges)
+      return null;
+    let result = [];
+    for (let i = 0; i < ranges.length; i += 2) {
+      let from2 = mapping.map(ranges[i], 1), to = mapping.map(ranges[i + 1], -1);
+      if (from2 <= to)
+        result.push(from2, to);
+    }
+    return result;
+  }
+  function histTransaction(history2, state, redo2) {
+    let preserveItems = mustPreserveItems(state);
+    let histOptions = historyKey.get(state).spec.config;
+    let pop = (redo2 ? history2.undone : history2.done).popEvent(state, preserveItems);
+    if (!pop)
+      return null;
+    let selection = pop.selection.resolve(pop.transform.doc);
+    let added = (redo2 ? history2.done : history2.undone).addTransform(pop.transform, state.selection.getBookmark(), histOptions, preserveItems);
+    let newHist = new HistoryState(redo2 ? added : pop.remaining, redo2 ? pop.remaining : added, null, 0, -1);
+    return pop.transform.setSelection(selection).setMeta(historyKey, { redo: redo2, historyState: newHist });
+  }
+  var cachedPreserveItems = false;
+  var cachedPreserveItemsPlugins = null;
+  function mustPreserveItems(state) {
+    let plugins = state.plugins;
+    if (cachedPreserveItemsPlugins != plugins) {
+      cachedPreserveItems = false;
+      cachedPreserveItemsPlugins = plugins;
+      for (let i = 0; i < plugins.length; i++)
+        if (plugins[i].spec.historyPreserveItems) {
+          cachedPreserveItems = true;
+          break;
+        }
+    }
+    return cachedPreserveItems;
+  }
+  var historyKey = new PluginKey("history");
+  var closeHistoryKey = new PluginKey("closeHistory");
+  function history(config = {}) {
+    config = {
+      depth: config.depth || 100,
+      newGroupDelay: config.newGroupDelay || 500
+    };
+    return new Plugin({
+      key: historyKey,
+      state: {
+        init() {
+          return new HistoryState(Branch.empty, Branch.empty, null, 0, -1);
+        },
+        apply(tr2, hist, state) {
+          return applyTransaction(hist, state, tr2, config);
+        }
+      },
+      config,
+      props: {
+        handleDOMEvents: {
+          beforeinput(view, e) {
+            let inputType = e.inputType;
+            let command2 = inputType == "historyUndo" ? undo : inputType == "historyRedo" ? redo : null;
+            if (!command2 || !view.editable)
+              return false;
+            e.preventDefault();
+            return command2(view.state, view.dispatch);
+          }
+        }
+      }
+    });
+  }
+  function buildCommand(redo2, scroll) {
+    return (state, dispatch) => {
+      let hist = historyKey.getState(state);
+      if (!hist || (redo2 ? hist.undone : hist.done).eventCount == 0)
+        return false;
+      if (dispatch) {
+        let tr2 = histTransaction(hist, state, redo2);
+        if (tr2)
+          dispatch(scroll ? tr2.scrollIntoView() : tr2);
+      }
+      return true;
+    };
+  }
+  var undo = buildCommand(false, true);
+  var redo = buildCommand(true, true);
+  var undoNoScroll = buildCommand(false, false);
+  var redoNoScroll = buildCommand(true, false);
+
   // src/frontmatter.ts
   var FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n(?:[ \t]*\r?\n)*|$)/;
   function splitFrontmatter(md) {
@@ -19698,6 +20234,10 @@ ${indentedChild}`;
     // Used only when not aligned (global dirty bit).
     globalDirty = false;
     ignoreNextUpdate = false;
+    // Held so we can detach on re-attach. `editor.on("update", fn)` registers
+    // a fresh listener each call without removing prior ones — without this,
+    // every doc switch would leak a listener that fires on every keystroke.
+    updateHandler = null;
     constructor(body) {
       this.originalBody = body;
     }
@@ -19705,6 +20245,10 @@ ${indentedChild}`;
     // PM child with a preserveId, then snapshot JSON. Must be called after
     // the editor finishes mounting.
     attach(editor2) {
+      if (this.updateHandler) {
+        editor2.off("update", this.updateHandler);
+        this.updateHandler = null;
+      }
       const manager = editor2.markdown;
       const marked = manager?.instance;
       if (manager && marked && typeof marked.lexer === "function") {
@@ -19743,14 +20287,15 @@ ${indentedChild}`;
           this.snapshots.push({ raw, json: jsonFingerprint(child.toJSON()) });
         });
       }
-      editor2.on("update", ({ transaction }) => {
+      this.updateHandler = ({ transaction }) => {
         if (this.ignoreNextUpdate) {
           this.ignoreNextUpdate = false;
           return;
         }
         if (transaction.getMeta("preservation:internal")) return;
         this.globalDirty = true;
-      });
+      };
+      editor2.on("update", this.updateHandler);
     }
     // Re-initialize state for a new source body. Must be followed by attach().
     beginExternalReplace(body) {
@@ -23898,542 +24443,6 @@ ${prefix}
     node.className = "ProseMirror-gapcursor";
     return DecorationSet.create(state.doc, [Decoration.widget(state.selection.head, node, { key: "gapcursor" })]);
   }
-
-  // node_modules/rope-sequence/dist/index.js
-  var GOOD_LEAF_SIZE = 200;
-  var RopeSequence = function RopeSequence2() {
-  };
-  RopeSequence.prototype.append = function append(other) {
-    if (!other.length) {
-      return this;
-    }
-    other = RopeSequence.from(other);
-    return !this.length && other || other.length < GOOD_LEAF_SIZE && this.leafAppend(other) || this.length < GOOD_LEAF_SIZE && other.leafPrepend(this) || this.appendInner(other);
-  };
-  RopeSequence.prototype.prepend = function prepend(other) {
-    if (!other.length) {
-      return this;
-    }
-    return RopeSequence.from(other).append(this);
-  };
-  RopeSequence.prototype.appendInner = function appendInner(other) {
-    return new Append(this, other);
-  };
-  RopeSequence.prototype.slice = function slice(from2, to) {
-    if (from2 === void 0) from2 = 0;
-    if (to === void 0) to = this.length;
-    if (from2 >= to) {
-      return RopeSequence.empty;
-    }
-    return this.sliceInner(Math.max(0, from2), Math.min(this.length, to));
-  };
-  RopeSequence.prototype.get = function get(i) {
-    if (i < 0 || i >= this.length) {
-      return void 0;
-    }
-    return this.getInner(i);
-  };
-  RopeSequence.prototype.forEach = function forEach2(f, from2, to) {
-    if (from2 === void 0) from2 = 0;
-    if (to === void 0) to = this.length;
-    if (from2 <= to) {
-      this.forEachInner(f, from2, to, 0);
-    } else {
-      this.forEachInvertedInner(f, from2, to, 0);
-    }
-  };
-  RopeSequence.prototype.map = function map(f, from2, to) {
-    if (from2 === void 0) from2 = 0;
-    if (to === void 0) to = this.length;
-    var result = [];
-    this.forEach(function(elt, i) {
-      return result.push(f(elt, i));
-    }, from2, to);
-    return result;
-  };
-  RopeSequence.from = function from(values) {
-    if (values instanceof RopeSequence) {
-      return values;
-    }
-    return values && values.length ? new Leaf(values) : RopeSequence.empty;
-  };
-  var Leaf = /* @__PURE__ */ (function(RopeSequence3) {
-    function Leaf2(values) {
-      RopeSequence3.call(this);
-      this.values = values;
-    }
-    if (RopeSequence3) Leaf2.__proto__ = RopeSequence3;
-    Leaf2.prototype = Object.create(RopeSequence3 && RopeSequence3.prototype);
-    Leaf2.prototype.constructor = Leaf2;
-    var prototypeAccessors = { length: { configurable: true }, depth: { configurable: true } };
-    Leaf2.prototype.flatten = function flatten() {
-      return this.values;
-    };
-    Leaf2.prototype.sliceInner = function sliceInner(from2, to) {
-      if (from2 == 0 && to == this.length) {
-        return this;
-      }
-      return new Leaf2(this.values.slice(from2, to));
-    };
-    Leaf2.prototype.getInner = function getInner(i) {
-      return this.values[i];
-    };
-    Leaf2.prototype.forEachInner = function forEachInner(f, from2, to, start) {
-      for (var i = from2; i < to; i++) {
-        if (f(this.values[i], start + i) === false) {
-          return false;
-        }
-      }
-    };
-    Leaf2.prototype.forEachInvertedInner = function forEachInvertedInner(f, from2, to, start) {
-      for (var i = from2 - 1; i >= to; i--) {
-        if (f(this.values[i], start + i) === false) {
-          return false;
-        }
-      }
-    };
-    Leaf2.prototype.leafAppend = function leafAppend(other) {
-      if (this.length + other.length <= GOOD_LEAF_SIZE) {
-        return new Leaf2(this.values.concat(other.flatten()));
-      }
-    };
-    Leaf2.prototype.leafPrepend = function leafPrepend(other) {
-      if (this.length + other.length <= GOOD_LEAF_SIZE) {
-        return new Leaf2(other.flatten().concat(this.values));
-      }
-    };
-    prototypeAccessors.length.get = function() {
-      return this.values.length;
-    };
-    prototypeAccessors.depth.get = function() {
-      return 0;
-    };
-    Object.defineProperties(Leaf2.prototype, prototypeAccessors);
-    return Leaf2;
-  })(RopeSequence);
-  RopeSequence.empty = new Leaf([]);
-  var Append = /* @__PURE__ */ (function(RopeSequence3) {
-    function Append2(left, right) {
-      RopeSequence3.call(this);
-      this.left = left;
-      this.right = right;
-      this.length = left.length + right.length;
-      this.depth = Math.max(left.depth, right.depth) + 1;
-    }
-    if (RopeSequence3) Append2.__proto__ = RopeSequence3;
-    Append2.prototype = Object.create(RopeSequence3 && RopeSequence3.prototype);
-    Append2.prototype.constructor = Append2;
-    Append2.prototype.flatten = function flatten() {
-      return this.left.flatten().concat(this.right.flatten());
-    };
-    Append2.prototype.getInner = function getInner(i) {
-      return i < this.left.length ? this.left.get(i) : this.right.get(i - this.left.length);
-    };
-    Append2.prototype.forEachInner = function forEachInner(f, from2, to, start) {
-      var leftLen = this.left.length;
-      if (from2 < leftLen && this.left.forEachInner(f, from2, Math.min(to, leftLen), start) === false) {
-        return false;
-      }
-      if (to > leftLen && this.right.forEachInner(f, Math.max(from2 - leftLen, 0), Math.min(this.length, to) - leftLen, start + leftLen) === false) {
-        return false;
-      }
-    };
-    Append2.prototype.forEachInvertedInner = function forEachInvertedInner(f, from2, to, start) {
-      var leftLen = this.left.length;
-      if (from2 > leftLen && this.right.forEachInvertedInner(f, from2 - leftLen, Math.max(to, leftLen) - leftLen, start + leftLen) === false) {
-        return false;
-      }
-      if (to < leftLen && this.left.forEachInvertedInner(f, Math.min(from2, leftLen), to, start) === false) {
-        return false;
-      }
-    };
-    Append2.prototype.sliceInner = function sliceInner(from2, to) {
-      if (from2 == 0 && to == this.length) {
-        return this;
-      }
-      var leftLen = this.left.length;
-      if (to <= leftLen) {
-        return this.left.slice(from2, to);
-      }
-      if (from2 >= leftLen) {
-        return this.right.slice(from2 - leftLen, to - leftLen);
-      }
-      return this.left.slice(from2, leftLen).append(this.right.slice(0, to - leftLen));
-    };
-    Append2.prototype.leafAppend = function leafAppend(other) {
-      var inner = this.right.leafAppend(other);
-      if (inner) {
-        return new Append2(this.left, inner);
-      }
-    };
-    Append2.prototype.leafPrepend = function leafPrepend(other) {
-      var inner = this.left.leafPrepend(other);
-      if (inner) {
-        return new Append2(inner, this.right);
-      }
-    };
-    Append2.prototype.appendInner = function appendInner2(other) {
-      if (this.left.depth >= Math.max(this.right.depth, other.depth) + 1) {
-        return new Append2(this.left, new Append2(this.right, other));
-      }
-      return new Append2(this, other);
-    };
-    return Append2;
-  })(RopeSequence);
-  var dist_default2 = RopeSequence;
-
-  // node_modules/prosemirror-history/dist/index.js
-  var max_empty_items = 500;
-  var Branch = class _Branch {
-    constructor(items, eventCount) {
-      this.items = items;
-      this.eventCount = eventCount;
-    }
-    // Pop the latest event off the branch's history and apply it
-    // to a document transform.
-    popEvent(state, preserveItems) {
-      if (this.eventCount == 0)
-        return null;
-      let end = this.items.length;
-      for (; ; end--) {
-        let next = this.items.get(end - 1);
-        if (next.selection) {
-          --end;
-          break;
-        }
-      }
-      let remap, mapFrom;
-      if (preserveItems) {
-        remap = this.remapping(end, this.items.length);
-        mapFrom = remap.maps.length;
-      }
-      let transform = state.tr;
-      let selection, remaining;
-      let addAfter = [], addBefore = [];
-      this.items.forEach((item, i) => {
-        if (!item.step) {
-          if (!remap) {
-            remap = this.remapping(end, i + 1);
-            mapFrom = remap.maps.length;
-          }
-          mapFrom--;
-          addBefore.push(item);
-          return;
-        }
-        if (remap) {
-          addBefore.push(new Item(item.map));
-          let step = item.step.map(remap.slice(mapFrom)), map2;
-          if (step && transform.maybeStep(step).doc) {
-            map2 = transform.mapping.maps[transform.mapping.maps.length - 1];
-            addAfter.push(new Item(map2, void 0, void 0, addAfter.length + addBefore.length));
-          }
-          mapFrom--;
-          if (map2)
-            remap.appendMap(map2, mapFrom);
-        } else {
-          transform.maybeStep(item.step);
-        }
-        if (item.selection) {
-          selection = remap ? item.selection.map(remap.slice(mapFrom)) : item.selection;
-          remaining = new _Branch(this.items.slice(0, end).append(addBefore.reverse().concat(addAfter)), this.eventCount - 1);
-          return false;
-        }
-      }, this.items.length, 0);
-      return { remaining, transform, selection };
-    }
-    // Create a new branch with the given transform added.
-    addTransform(transform, selection, histOptions, preserveItems) {
-      let newItems = [], eventCount = this.eventCount;
-      let oldItems = this.items, lastItem = !preserveItems && oldItems.length ? oldItems.get(oldItems.length - 1) : null;
-      for (let i = 0; i < transform.steps.length; i++) {
-        let step = transform.steps[i].invert(transform.docs[i]);
-        let item = new Item(transform.mapping.maps[i], step, selection), merged;
-        if (merged = lastItem && lastItem.merge(item)) {
-          item = merged;
-          if (i)
-            newItems.pop();
-          else
-            oldItems = oldItems.slice(0, oldItems.length - 1);
-        }
-        newItems.push(item);
-        if (selection) {
-          eventCount++;
-          selection = void 0;
-        }
-        if (!preserveItems)
-          lastItem = item;
-      }
-      let overflow = eventCount - histOptions.depth;
-      if (overflow > DEPTH_OVERFLOW) {
-        oldItems = cutOffEvents(oldItems, overflow);
-        eventCount -= overflow;
-      }
-      return new _Branch(oldItems.append(newItems), eventCount);
-    }
-    remapping(from2, to) {
-      let maps = new Mapping();
-      this.items.forEach((item, i) => {
-        let mirrorPos = item.mirrorOffset != null && i - item.mirrorOffset >= from2 ? maps.maps.length - item.mirrorOffset : void 0;
-        maps.appendMap(item.map, mirrorPos);
-      }, from2, to);
-      return maps;
-    }
-    addMaps(array) {
-      if (this.eventCount == 0)
-        return this;
-      return new _Branch(this.items.append(array.map((map2) => new Item(map2))), this.eventCount);
-    }
-    // When the collab module receives remote changes, the history has
-    // to know about those, so that it can adjust the steps that were
-    // rebased on top of the remote changes, and include the position
-    // maps for the remote changes in its array of items.
-    rebased(rebasedTransform, rebasedCount) {
-      if (!this.eventCount)
-        return this;
-      let rebasedItems = [], start = Math.max(0, this.items.length - rebasedCount);
-      let mapping = rebasedTransform.mapping;
-      let newUntil = rebasedTransform.steps.length;
-      let eventCount = this.eventCount;
-      this.items.forEach((item) => {
-        if (item.selection)
-          eventCount--;
-      }, start);
-      let iRebased = rebasedCount;
-      this.items.forEach((item) => {
-        let pos = mapping.getMirror(--iRebased);
-        if (pos == null)
-          return;
-        newUntil = Math.min(newUntil, pos);
-        let map2 = mapping.maps[pos];
-        if (item.step) {
-          let step = rebasedTransform.steps[pos].invert(rebasedTransform.docs[pos]);
-          let selection = item.selection && item.selection.map(mapping.slice(iRebased + 1, pos));
-          if (selection)
-            eventCount++;
-          rebasedItems.push(new Item(map2, step, selection));
-        } else {
-          rebasedItems.push(new Item(map2));
-        }
-      }, start);
-      let newMaps = [];
-      for (let i = rebasedCount; i < newUntil; i++)
-        newMaps.push(new Item(mapping.maps[i]));
-      let items = this.items.slice(0, start).append(newMaps).append(rebasedItems);
-      let branch = new _Branch(items, eventCount);
-      if (branch.emptyItemCount() > max_empty_items)
-        branch = branch.compress(this.items.length - rebasedItems.length);
-      return branch;
-    }
-    emptyItemCount() {
-      let count = 0;
-      this.items.forEach((item) => {
-        if (!item.step)
-          count++;
-      });
-      return count;
-    }
-    // Compressing a branch means rewriting it to push the air (map-only
-    // items) out. During collaboration, these naturally accumulate
-    // because each remote change adds one. The `upto` argument is used
-    // to ensure that only the items below a given level are compressed,
-    // because `rebased` relies on a clean, untouched set of items in
-    // order to associate old items with rebased steps.
-    compress(upto = this.items.length) {
-      let remap = this.remapping(0, upto), mapFrom = remap.maps.length;
-      let items = [], events = 0;
-      this.items.forEach((item, i) => {
-        if (i >= upto) {
-          items.push(item);
-          if (item.selection)
-            events++;
-        } else if (item.step) {
-          let step = item.step.map(remap.slice(mapFrom)), map2 = step && step.getMap();
-          mapFrom--;
-          if (map2)
-            remap.appendMap(map2, mapFrom);
-          if (step) {
-            let selection = item.selection && item.selection.map(remap.slice(mapFrom));
-            if (selection)
-              events++;
-            let newItem = new Item(map2.invert(), step, selection), merged, last = items.length - 1;
-            if (merged = items.length && items[last].merge(newItem))
-              items[last] = merged;
-            else
-              items.push(newItem);
-          }
-        } else if (item.map) {
-          mapFrom--;
-        }
-      }, this.items.length, 0);
-      return new _Branch(dist_default2.from(items.reverse()), events);
-    }
-  };
-  Branch.empty = new Branch(dist_default2.empty, 0);
-  function cutOffEvents(items, n) {
-    let cutPoint;
-    items.forEach((item, i) => {
-      if (item.selection && n-- == 0) {
-        cutPoint = i;
-        return false;
-      }
-    });
-    return items.slice(cutPoint);
-  }
-  var Item = class _Item {
-    constructor(map2, step, selection, mirrorOffset) {
-      this.map = map2;
-      this.step = step;
-      this.selection = selection;
-      this.mirrorOffset = mirrorOffset;
-    }
-    merge(other) {
-      if (this.step && other.step && !other.selection) {
-        let step = other.step.merge(this.step);
-        if (step)
-          return new _Item(step.getMap().invert(), step, this.selection);
-      }
-    }
-  };
-  var HistoryState = class {
-    constructor(done, undone, prevRanges, prevTime, prevComposition) {
-      this.done = done;
-      this.undone = undone;
-      this.prevRanges = prevRanges;
-      this.prevTime = prevTime;
-      this.prevComposition = prevComposition;
-    }
-  };
-  var DEPTH_OVERFLOW = 20;
-  function applyTransaction(history2, state, tr2, options) {
-    let historyTr = tr2.getMeta(historyKey), rebased;
-    if (historyTr)
-      return historyTr.historyState;
-    if (tr2.getMeta(closeHistoryKey))
-      history2 = new HistoryState(history2.done, history2.undone, null, 0, -1);
-    let appended = tr2.getMeta("appendedTransaction");
-    if (tr2.steps.length == 0) {
-      return history2;
-    } else if (appended && appended.getMeta(historyKey)) {
-      if (appended.getMeta(historyKey).redo)
-        return new HistoryState(history2.done.addTransform(tr2, void 0, options, mustPreserveItems(state)), history2.undone, rangesFor(tr2.mapping.maps), history2.prevTime, history2.prevComposition);
-      else
-        return new HistoryState(history2.done, history2.undone.addTransform(tr2, void 0, options, mustPreserveItems(state)), null, history2.prevTime, history2.prevComposition);
-    } else if (tr2.getMeta("addToHistory") !== false && !(appended && appended.getMeta("addToHistory") === false)) {
-      let composition = tr2.getMeta("composition");
-      let newGroup = history2.prevTime == 0 || !appended && history2.prevComposition != composition && (history2.prevTime < (tr2.time || 0) - options.newGroupDelay || !isAdjacentTo(tr2, history2.prevRanges));
-      let prevRanges = appended ? mapRanges(history2.prevRanges, tr2.mapping) : rangesFor(tr2.mapping.maps);
-      return new HistoryState(history2.done.addTransform(tr2, newGroup ? state.selection.getBookmark() : void 0, options, mustPreserveItems(state)), Branch.empty, prevRanges, tr2.time, composition == null ? history2.prevComposition : composition);
-    } else if (rebased = tr2.getMeta("rebased")) {
-      return new HistoryState(history2.done.rebased(tr2, rebased), history2.undone.rebased(tr2, rebased), mapRanges(history2.prevRanges, tr2.mapping), history2.prevTime, history2.prevComposition);
-    } else {
-      return new HistoryState(history2.done.addMaps(tr2.mapping.maps), history2.undone.addMaps(tr2.mapping.maps), mapRanges(history2.prevRanges, tr2.mapping), history2.prevTime, history2.prevComposition);
-    }
-  }
-  function isAdjacentTo(transform, prevRanges) {
-    if (!prevRanges)
-      return false;
-    if (!transform.docChanged)
-      return true;
-    let adjacent = false;
-    transform.mapping.maps[0].forEach((start, end) => {
-      for (let i = 0; i < prevRanges.length; i += 2)
-        if (start <= prevRanges[i + 1] && end >= prevRanges[i])
-          adjacent = true;
-    });
-    return adjacent;
-  }
-  function rangesFor(maps) {
-    let result = [];
-    for (let i = maps.length - 1; i >= 0 && result.length == 0; i--)
-      maps[i].forEach((_from, _to, from2, to) => result.push(from2, to));
-    return result;
-  }
-  function mapRanges(ranges, mapping) {
-    if (!ranges)
-      return null;
-    let result = [];
-    for (let i = 0; i < ranges.length; i += 2) {
-      let from2 = mapping.map(ranges[i], 1), to = mapping.map(ranges[i + 1], -1);
-      if (from2 <= to)
-        result.push(from2, to);
-    }
-    return result;
-  }
-  function histTransaction(history2, state, redo2) {
-    let preserveItems = mustPreserveItems(state);
-    let histOptions = historyKey.get(state).spec.config;
-    let pop = (redo2 ? history2.undone : history2.done).popEvent(state, preserveItems);
-    if (!pop)
-      return null;
-    let selection = pop.selection.resolve(pop.transform.doc);
-    let added = (redo2 ? history2.done : history2.undone).addTransform(pop.transform, state.selection.getBookmark(), histOptions, preserveItems);
-    let newHist = new HistoryState(redo2 ? added : pop.remaining, redo2 ? pop.remaining : added, null, 0, -1);
-    return pop.transform.setSelection(selection).setMeta(historyKey, { redo: redo2, historyState: newHist });
-  }
-  var cachedPreserveItems = false;
-  var cachedPreserveItemsPlugins = null;
-  function mustPreserveItems(state) {
-    let plugins = state.plugins;
-    if (cachedPreserveItemsPlugins != plugins) {
-      cachedPreserveItems = false;
-      cachedPreserveItemsPlugins = plugins;
-      for (let i = 0; i < plugins.length; i++)
-        if (plugins[i].spec.historyPreserveItems) {
-          cachedPreserveItems = true;
-          break;
-        }
-    }
-    return cachedPreserveItems;
-  }
-  var historyKey = new PluginKey("history");
-  var closeHistoryKey = new PluginKey("closeHistory");
-  function history(config = {}) {
-    config = {
-      depth: config.depth || 100,
-      newGroupDelay: config.newGroupDelay || 500
-    };
-    return new Plugin({
-      key: historyKey,
-      state: {
-        init() {
-          return new HistoryState(Branch.empty, Branch.empty, null, 0, -1);
-        },
-        apply(tr2, hist, state) {
-          return applyTransaction(hist, state, tr2, config);
-        }
-      },
-      config,
-      props: {
-        handleDOMEvents: {
-          beforeinput(view, e) {
-            let inputType = e.inputType;
-            let command2 = inputType == "historyUndo" ? undo : inputType == "historyRedo" ? redo : null;
-            if (!command2 || !view.editable)
-              return false;
-            e.preventDefault();
-            return command2(view.state, view.dispatch);
-          }
-        }
-      }
-    });
-  }
-  function buildCommand(redo2, scroll) {
-    return (state, dispatch) => {
-      let hist = historyKey.getState(state);
-      if (!hist || (redo2 ? hist.undone : hist.done).eventCount == 0)
-        return false;
-      if (dispatch) {
-        let tr2 = histTransaction(hist, state, redo2);
-        if (tr2)
-          dispatch(scroll ? tr2.scrollIntoView() : tr2);
-      }
-      return true;
-    };
-  }
-  var undo = buildCommand(false, true);
-  var redo = buildCommand(true, true);
-  var undoNoScroll = buildCommand(false, false);
-  var redoNoScroll = buildCommand(true, false);
 
   // node_modules/@tiptap/extensions/dist/index.js
   var CharacterCount = Extension.create({
@@ -48518,6 +48527,19 @@ ${code}`;
       true
     );
   }
+  function replaceEditorBody(body) {
+    if (!editor) return;
+    if (body.length === 0) {
+      editor.commands.clearContent();
+    } else {
+      editor.commands.setContent(body, { contentType: "markdown" });
+    }
+  }
+  function resetUndoHistory() {
+    if (!editor) return;
+    editor.unregisterPlugin("history");
+    editor.registerPlugin(history());
+  }
   function ensureMounted(initialMarkdown, epoch, appearance, fontSize) {
     const root = document.getElementById("editor");
     if (!root) throw new Error("missing #editor root");
@@ -48527,10 +48549,11 @@ ${code}`;
     if (editor) {
       withSuppressedUpdates(() => {
         preservation?.beginExternalReplace(split2.body);
-        editor.commands.setContent(split2.body, { contentType: "markdown" });
+        replaceEditorBody(split2.body);
         editor.commands.setTextSelection(0);
         if (preservation) preservation.attach(editor);
       });
+      resetUndoHistory();
       pendingEpoch = epoch;
       return;
     }
@@ -48585,10 +48608,11 @@ ${code}`;
       storedFrontmatter = split2.frontmatter;
       withSuppressedUpdates(() => {
         preservation?.beginExternalReplace(split2.body);
-        editor.commands.setContent(split2.body, { contentType: "markdown" });
+        replaceEditorBody(split2.body);
         editor.commands.setTextSelection(0);
         if (preservation) preservation.attach(editor);
       });
+      resetUndoHistory();
     },
     setTheme({ appearance, fontSize }) {
       applyAppearance(appearance, fontSize);


### PR DESCRIPTION
## Summary
- Drop redundant `WYSIWYGSession.update(...)` calls from `WYSIWYGView.makeNSView`/`updateNSView`. During SwiftUI teardown after ⌘N (mode flips to `.edit`) those calls fired one last time with the stale view-struct `documentID`/`documentEpoch`, overwriting the authoritative session set by `WorkspaceManager.activateDocument`. The async `getDocument` callback's epoch guard then passed against the re-staled session and wrote the previous note's content into the new doc's binding.
- In the WYSIWYG JS bundle, route empty-body swaps through `clearContent()` (the markdown extension's `setContent("")` is a silent no-op against PM's `block+` schema), reset the `history` plugin on every doc swap so ⌘Z stops crossing documents, and store `SourcePreservation`'s update listener so `attach()` detaches the prior one instead of leaking one per switch.

Fixes #313

## Test plan
- [x] Original repro: Help → Sample Document → switch to preview → ⌘N produces an empty untitled tab (verified manually with /verify build)
- [x] Round-trip tests pass (11/11) — `cd ClearlyWYSIWYGWeb && npm run test:round-trip`
- [x] Typecheck clean — `npm run typecheck`
- [x] App builds — `xcodebuild -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData build`