### PR TITLE
Memory hardening: cancel concurrent tree walks, drain autoreleasepool, reject nested vaults

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -274,11 +274,9 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
             if isDir.boolValue {
                 openedDirectory = true
-                if !workspace.locations.contains(where: { $0.url == url }) {
-                    let shouldShowGettingStarted = workspace.isFirstRun
-                    if workspace.addLocation(url: url), shouldShowGettingStarted {
-                        workspace.handleFirstLocationIfNeeded(folderURL: url)
-                    }
+                let shouldShowGettingStarted = workspace.isFirstRun
+                if workspace.tryAddLocation(url: url), shouldShowGettingStarted {
+                    workspace.handleFirstLocationIfNeeded(folderURL: url)
                 }
             } else {
                 openedFile = workspace.openFileInNewTab(at: url) || openedFile

--- a/Clearly/WelcomeView.swift
+++ b/Clearly/WelcomeView.swift
@@ -92,10 +92,9 @@ struct WelcomeView: View {
         panel.prompt = "Add Folder"
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        guard !workspace.locations.contains(where: { $0.url == url }) else { return }
 
         let shouldShowGettingStarted = workspace.isFirstRun
-        guard workspace.addLocation(url: url) else { return }
+        guard workspace.tryAddLocation(url: url) else { return }
         if shouldShowGettingStarted {
             workspace.handleFirstLocationIfNeeded(folderURL: url)
         }

--- a/Clearly/WikiSeeding.swift
+++ b/Clearly/WikiSeeding.swift
@@ -121,6 +121,7 @@ enum WikiSeeder {
             UserDefaults.standard.set(true, forKey: "sidebarVisible")
             return
         }
+        guard workspace.validateCanAddLocation(url: url) else { return }
 
         do {
             try seed(at: url)

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -4,6 +4,44 @@ import AppKit
 import CoreServices
 import UniformTypeIdentifiers
 
+/// Caps concurrent `FileNode.buildTree` walks across the whole process. With one
+/// FSEventStream per vault, a single global event (Spotlight reindex, Time
+/// Machine snapshot, iCloud burst) can fire every stream within milliseconds.
+/// Per-location cancellation already prevents stacked walks of the same tree;
+/// this prevents N parallel walks across N vaults from saturating cores during
+/// those bursts. Cancelled waiters wake briefly when their slot opens, see
+/// `Task.isCancelled`, and bail — slot leakage is bounded.
+private actor TreeBuildLimiter {
+    static let shared = TreeBuildLimiter(maxConcurrent: 2)
+
+    private let maxConcurrent: Int
+    private var inFlight: Int = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(maxConcurrent: Int) {
+        self.maxConcurrent = maxConcurrent
+    }
+
+    func acquire() async {
+        if inFlight < maxConcurrent {
+            inFlight += 1
+            return
+        }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+    }
+
+    func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            inFlight = max(0, inFlight - 1)
+        }
+    }
+}
+
 /// Central state manager for file navigation: locations, recents, and current file.
 @Observable
 final class WorkspaceManager {
@@ -73,6 +111,7 @@ final class WorkspaceManager {
     @ObservationIgnored private var vaultIndexes: [UUID: VaultIndex] = [:]
     @ObservationIgnored private var refreshWork: [UUID: DispatchWorkItem] = [:]
     @ObservationIgnored private var treeBuildGeneration: [UUID: Int] = [:]
+    @ObservationIgnored private var treeBuildTasks: [UUID: Task<Void, Never>] = [:]
     private var autoSaveWork: DispatchWorkItem?
     private var lastSavedText: String = ""
     private var accessedURLs: Set<URL> = []
@@ -176,6 +215,7 @@ final class WorkspaceManager {
     deinit {
         autoSaveWork?.cancel()
         refreshWork.values.forEach { $0.cancel() }
+        treeBuildTasks.values.forEach { $0.cancel() }
         for index in vaultIndexes.values { index.close() }
         vaultIndexes.removeAll()
         stopAllFSStreams()
@@ -866,10 +906,24 @@ final class WorkspaceManager {
         let generation = nextTreeBuildGeneration(for: locationID)
         let showHidden = showHiddenFiles
 
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let tree = FileNode.buildTree(at: url, showHiddenFiles: showHidden)
+        // Cancel any in-flight walk for this location before starting a new one.
+        // The generation counter alone only blocks stale assignment on main; without
+        // task cancellation, stacked-up FSEvent bursts each run a full recursive
+        // FileNode.buildTree to completion in parallel, pinning cores and growing
+        // RSS monotonically on broad trees. See issue #311.
+        treeBuildTasks[locationID]?.cancel()
+
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            await TreeBuildLimiter.shared.acquire()
+            let tree = FileNode.buildTree(
+                at: url,
+                showHiddenFiles: showHidden,
+                isCancelled: { Task.isCancelled }
+            )
+            await TreeBuildLimiter.shared.release()
+            if Task.isCancelled { return }
             let kind = VaultKind.detect(at: url)
-            DispatchQueue.main.async {
+            await MainActor.run { [weak self] in
                 guard let self,
                       self.treeBuildGeneration[locationID] == generation,
                       let idx = self.locations.firstIndex(where: { $0.id == locationID }) else { return }
@@ -881,9 +935,85 @@ final class WorkspaceManager {
                 }
             }
         }
+        treeBuildTasks[locationID] = task
     }
 
     // MARK: - Locations
+
+    enum VaultConflict {
+        case duplicate(URL)
+        case insideExisting(URL)
+        case containsExisting(URL)
+    }
+
+    /// Returns the existing-vault conflict for `url`, or nil if it can be added cleanly.
+    /// Resolves symlinks because Desktop/Documents/etc. may resolve through different
+    /// roots depending on the entry point (Files panel vs. drag-drop vs. URL scheme).
+    /// Compares case-insensitively when either volume reports it doesn't support
+    /// case-sensitive names (default APFS) so `~/Desktop` and `~/desktop` aren't
+    /// treated as separate vaults on the same disk.
+    func vaultConflict(for url: URL) -> VaultConflict? {
+        let candidate = url.standardizedFileURL.resolvingSymlinksInPath()
+        let candidateCaseSensitive = Self.volumeIsCaseSensitive(candidate)
+        for loc in locations {
+            let other = loc.url.standardizedFileURL.resolvingSymlinksInPath()
+            let otherCaseSensitive = Self.volumeIsCaseSensitive(other)
+            // Conservative: if EITHER volume is case-insensitive, compare insensitively.
+            // False positives (refuse a legitimately distinct case-only-different folder)
+            // are recoverable; false negatives (silently double-add) are not.
+            let caseSensitive = candidateCaseSensitive && otherCaseSensitive
+            let candidatePath = caseSensitive ? candidate.path : candidate.path.lowercased()
+            let otherPath = caseSensitive ? other.path : other.path.lowercased()
+            if otherPath == candidatePath { return .duplicate(loc.url) }
+            if candidatePath.hasPrefix(otherPath + "/") { return .insideExisting(loc.url) }
+            if otherPath.hasPrefix(candidatePath + "/") { return .containsExisting(loc.url) }
+        }
+        return nil
+    }
+
+    private static func volumeIsCaseSensitive(_ url: URL) -> Bool {
+        // Defaults to false (case-insensitive) when the key is unavailable. That's
+        // the safer assumption — see vaultConflict's "conservative" comment.
+        (try? url.resourceValues(forKeys: [.volumeSupportsCaseSensitiveNamesKey]))?
+            .volumeSupportsCaseSensitiveNames ?? false
+    }
+
+    /// Interactive add: surfaces an `NSAlert` on conflict instead of silently failing.
+    /// Use this from any user-initiated add path (open panel, drag-drop, URL handler).
+    /// Programmatic adds where the caller knows the path is fresh (e.g. WikiSeeding)
+    /// can call `addLocation` directly.
+    @discardableResult
+    func tryAddLocation(url: URL) -> Bool {
+        guard validateCanAddLocation(url: url) else { return false }
+        return addLocation(url: url)
+    }
+
+    @discardableResult
+    func validateCanAddLocation(url: URL) -> Bool {
+        if let conflict = vaultConflict(for: url) {
+            presentVaultConflictAlert(picked: url, conflict: conflict)
+            return false
+        }
+        return true
+    }
+
+    private func presentVaultConflictAlert(picked: URL, conflict: VaultConflict) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        switch conflict {
+        case .duplicate:
+            alert.messageText = "“\(picked.lastPathComponent)” is already in your sidebar."
+            alert.informativeText = "This folder is already added as a vault."
+        case .insideExisting(let existing):
+            alert.messageText = "“\(picked.lastPathComponent)” is already covered."
+            alert.informativeText = "“\(existing.lastPathComponent)” is in your sidebar and includes “\(picked.lastPathComponent)”. To work with just this folder, remove the parent first."
+        case .containsExisting(let existing):
+            alert.messageText = "“\(picked.lastPathComponent)” contains an existing vault."
+            alert.informativeText = "“\(existing.lastPathComponent)” is already in your sidebar. Remove it first, or pick a different folder."
+        }
+        alert.runModal()
+    }
 
     @discardableResult
     func addLocation(url: URL) -> Bool {
@@ -957,6 +1087,8 @@ final class WorkspaceManager {
     func removeLocation(_ location: BookmarkedLocation) {
         stopFSStream(for: location.id)
         treeBuildGeneration.removeValue(forKey: location.id)
+        treeBuildTasks[location.id]?.cancel()
+        treeBuildTasks.removeValue(forKey: location.id)
         vaultIndexes[location.id]?.close()
         vaultIndexes.removeValue(forKey: location.id)
         vaultIndexRevision += 1
@@ -1528,10 +1660,8 @@ final class WorkspaceManager {
         FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
 
         if isDir.boolValue {
-            // Don't add duplicate locations
-            guard !locations.contains(where: { $0.url == url }) else { return }
             let shouldShowGettingStarted = isFirstRun
-            guard addLocation(url: url) else { return }
+            guard tryAddLocation(url: url) else { return }
             if shouldShowGettingStarted {
                 handleFirstLocationIfNeeded(folderURL: url)
             }
@@ -1709,6 +1839,19 @@ final class WorkspaceManager {
               let stored = try? JSONDecoder().decode([StoredBookmark].self, from: data) else { return }
 
         var didMutateStoredBookmarks = false
+
+        // Resolve URLs first so we can sort by path-length ascending. Otherwise
+        // restore order is whatever the user added them in, and a bookmark file
+        // pre-dating nested-vault rejection could have e.g. [blogs, Desktop] —
+        // restoring in that order would silently drop Desktop because it
+        // contains the already-restored blogs. Shorter paths win.
+        struct Resolved {
+            let bookmark: StoredBookmark
+            let url: URL
+            let bookmarkData: Data
+            let didRefreshStale: Bool
+        }
+        var resolved: [Resolved] = []
         for bookmark in stored {
             var isStale = false
             guard let url = try? URL(
@@ -1720,23 +1863,51 @@ final class WorkspaceManager {
                 didMutateStoredBookmarks = true
                 continue
             }
-
             var bookmarkData = bookmark.bookmarkData
+            var didRefreshStale = false
             if isStale {
                 if let refreshed = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil) {
                     bookmarkData = refreshed
-                    didMutateStoredBookmarks = true
+                    didRefreshStale = true
                 }
             }
+            resolved.append(Resolved(
+                bookmark: bookmark,
+                url: url,
+                bookmarkData: bookmarkData,
+                didRefreshStale: didRefreshStale
+            ))
+        }
+        resolved.sort { $0.url.path.count < $1.url.path.count }
+
+        for entry in resolved {
+            let url = entry.url
+            let bookmarkData = entry.bookmarkData
+            if entry.didRefreshStale { didMutateStoredBookmarks = true }
 
             guard url.startAccessingSecurityScopedResource() else {
+                didMutateStoredBookmarks = true
+                continue
+            }
+
+            // Silently drop nested bookmarks left over from before nested-vault
+            // rejection landed. Don't alert the user on launch; just log and skip.
+            if let conflict = vaultConflict(for: url) {
+                let kind: String
+                switch conflict {
+                case .duplicate: kind = "duplicate"
+                case .insideExisting: kind = "inside existing"
+                case .containsExisting: kind = "contains existing"
+                }
+                DiagnosticLog.log("Restore: skipping nested bookmark \(url.lastPathComponent) — \(kind)")
+                url.stopAccessingSecurityScopedResource()
                 didMutateStoredBookmarks = true
                 continue
             }
             accessedURLs.insert(url)
 
             let location = BookmarkedLocation(
-                id: bookmark.id,
+                id: entry.bookmark.id,
                 url: url,
                 bookmarkData: bookmarkData,
                 fileTree: [],
@@ -1745,7 +1916,7 @@ final class WorkspaceManager {
             locations.append(location)
             startFSStream(for: location)
             openVaultIndex(for: location)
-            loadTree(for: bookmark.id, at: url)
+            loadTree(for: entry.bookmark.id, at: url)
         }
 
         if didMutateStoredBookmarks {
@@ -1969,6 +2140,8 @@ final class WorkspaceManager {
         refreshWork[locationID]?.cancel()
         refreshWork.removeValue(forKey: locationID)
         treeBuildGeneration.removeValue(forKey: locationID)
+        treeBuildTasks[locationID]?.cancel()
+        treeBuildTasks.removeValue(forKey: locationID)
         guard let stream = fsStreams.removeValue(forKey: locationID) else { return }
         FSEventStreamStop(stream)
         FSEventStreamInvalidate(stream)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Diagnostics/MemoryUsage.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Diagnostics/MemoryUsage.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Darwin.Mach
+
+public enum MemoryUsage {
+    public static func residentBytes() -> UInt64 {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<mach_task_basic_info>.size / MemoryLayout<integer_t>.size
+        )
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        return kr == KERN_SUCCESS ? info.resident_size : 0
+    }
+
+    public static func residentMB() -> Int {
+        Int(residentBytes() / 1_048_576)
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/FileNode.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/FileNode.swift
@@ -31,7 +31,19 @@ public struct FileNode: Identifiable, Hashable {
 
     /// Build a file tree from a directory URL, filtering to markdown files.
     /// Skips hardcoded heavy directories and respects `.gitignore` rules.
-    public static func buildTree(at url: URL, showHiddenFiles: Bool = false, ignoreRules: IgnoreRules? = nil) -> [FileNode] {
+    ///
+    /// Pass `isCancelled` to abort an in-flight walk when a newer build supersedes
+    /// it. Without this, a stack of FSEvent-driven `loadTree` calls would each run
+    /// to completion in parallel even after their results would be discarded —
+    /// which on broad trees (e.g. ~/Documents) can pin multiple cores and grow RSS
+    /// monotonically. See issue #311.
+    public static func buildTree(
+        at url: URL,
+        showHiddenFiles: Bool = false,
+        ignoreRules: IgnoreRules? = nil,
+        isCancelled: () -> Bool = { false }
+    ) -> [FileNode] {
+        if isCancelled() { return [] }
         let fm = FileManager.default
         let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
         guard let contents = try? fm.contentsOfDirectory(
@@ -46,20 +58,30 @@ public struct FileNode: Identifiable, Hashable {
         var files: [FileNode] = []
 
         for itemURL in contents {
-            let isDir = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
-            let name = itemURL.lastPathComponent
-            let hidden = name.hasPrefix(".")
+            if isCancelled() { return [] }
+            // autoreleasepool drains URL/CFString temporaries every iteration so a
+            // broad walk doesn't grow the working set monotonically while running.
+            autoreleasepool {
+                let isDir = (try? itemURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+                let name = itemURL.lastPathComponent
+                let hidden = name.hasPrefix(".")
 
-            if isDir {
-                if rules.shouldIgnore(url: itemURL, isDirectory: true) { continue }
-                var childRules = rules
-                childRules.loadNestedGitignore(at: itemURL)
-                let children = buildTree(at: itemURL, showHiddenFiles: showHiddenFiles, ignoreRules: childRules)
-                folders.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: children))
-            } else {
-                if rules.shouldIgnore(url: itemURL, isDirectory: false) { continue }
-                if markdownExtensions.contains(itemURL.pathExtension.lowercased()) {
-                    files.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: nil))
+                if isDir {
+                    if rules.shouldIgnore(url: itemURL, isDirectory: true) { return }
+                    var childRules = rules
+                    childRules.loadNestedGitignore(at: itemURL)
+                    let children = buildTree(
+                        at: itemURL,
+                        showHiddenFiles: showHiddenFiles,
+                        ignoreRules: childRules,
+                        isCancelled: isCancelled
+                    )
+                    folders.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: children))
+                } else {
+                    if rules.shouldIgnore(url: itemURL, isDirectory: false) { return }
+                    if markdownExtensions.contains(itemURL.pathExtension.lowercased()) {
+                        files.append(FileNode(name: name, url: itemURL, isHidden: hidden, children: nil))
+                    }
                 }
             }
         }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -322,6 +322,8 @@ public final class VaultIndex: @unchecked Sendable {
 
     public func indexAllFiles(showHiddenFiles: Bool = false) {
         let markdownFiles = collectMarkdownFiles(under: rootURL, showHiddenFiles: showHiddenFiles)
+        let totalFiles = markdownFiles.count
+        DiagnosticLog.log("Index sweep start: \(totalFiles) files, rss=\(MemoryUsage.residentMB())MB")
 
         do {
             try dbPool.write { db in
@@ -336,8 +338,21 @@ public final class VaultIndex: @unchecked Sendable {
                 }
 
                 var processedPaths = Set<String>()
+                var iterated = 0
+                // Log progress every 5s (plus the first 5 files), not every 100 files.
+                // Incremental FSEvent reindexes scan all files but skip most via hash
+                // check in milliseconds — every-100-files emits dozens of useless lines
+                // per FSEvent burst. Time-throttling keeps initial-sweep telemetry
+                // (slow per-file work) without the steady-state noise.
+                var lastLogAt = Date().timeIntervalSinceReferenceDate
 
                 for fileURL in markdownFiles {
+                    iterated += 1
+                    let nowTS = Date().timeIntervalSinceReferenceDate
+                    if iterated <= 5 || nowTS - lastLogAt >= 5.0 {
+                        DiagnosticLog.log("Index sweep progress: \(iterated)/\(totalFiles), rss=\(MemoryUsage.residentMB())MB")
+                        lastLogAt = nowTS
+                    }
                     let relativePath = Self.relativePath(of: fileURL, from: rootURL)
 
                     guard Limits.isOpenableSize(fileURL) else {
@@ -409,6 +424,8 @@ public final class VaultIndex: @unchecked Sendable {
 
                 try self.resolveWikiLinkTargets(db: db)
             }
+            DiagnosticLog.log("Index sweep complete: \(totalFiles) files, rss=\(MemoryUsage.residentMB())MB")
+            DiagnosticLog.trimIfNeeded()
         } catch {
             DiagnosticLog.log("VaultIndex: indexAllFiles failed — \(error.localizedDescription)")
         }
@@ -1388,6 +1405,7 @@ public final class VaultIndex: @unchecked Sendable {
             do {
                 let stale = try self.embeddingsMissingOrStale(modelVersion: modelVersion)
                 if stale.isEmpty { return }
+                DiagnosticLog.log("Embedding sweep start: \(stale.count) notes, rss=\(MemoryUsage.residentMB())MB")
 
                 let service: EmbeddingService
                 do {
@@ -1399,70 +1417,80 @@ public final class VaultIndex: @unchecked Sendable {
 
                 var processed = 0
                 var totalChunks = 0
+                var attempted = 0
                 for target in stale {
                     if Task.isCancelled { return }
-                    let fileURL = self.rootURL.appendingPathComponent(target.path)
-                    guard Limits.isOpenableSize(fileURL) else {
-                        DiagnosticLog.log("VaultIndex embed: skipping oversized file \(fileURL.lastPathComponent)")
-                        continue
-                    }
-                    guard let data = try? Data(contentsOf: fileURL),
-                          let content = String(data: data, encoding: .utf8) else { continue }
-
-                    // Chunk first; embed each chunk separately so long notes don't dilute
-                    // their signal in a single mean-pooled vector. Title + heading-path
-                    // prepended via `embedText` per the contextual-retrieval pattern.
-                    let filename = (target.path as NSString).lastPathComponent
-                    let chunks = MarkdownChunker.chunk(source: content, filename: filename)
-                    if chunks.isEmpty {
-                        // Empty / frontmatter-only note. Clear any prior chunks for this file
-                        // so a previously-non-empty note doesn't keep stale rows around.
-                        try? self.upsertChunkEmbeddings(
-                            fileID: target.fileID,
-                            contentHash: target.contentHash,
-                            chunks: [],
-                            modelVersion: modelVersion
-                        )
-                        continue
-                    }
-
-                    do {
-                        var inputs: [ChunkEmbeddingInput] = []
-                        inputs.reserveCapacity(chunks.count)
-                        for chunk in chunks {
-                            do {
-                                let vector = try service.embed(chunk.embedText)
-                                inputs.append(ChunkEmbeddingInput(
-                                    chunkIndex: chunk.index,
-                                    textOffset: chunk.textOffset,
-                                    textLength: chunk.textLength,
-                                    headingPath: chunk.headingPath,
-                                    body: chunk.body,
-                                    vector: vector
-                                ))
-                            } catch EmbeddingError.emptyText {
-                                continue
-                            }
+                    // autoreleasepool drains Foundation-bridged temporaries (Data, CFString,
+                    // NLContextualEmbeddingResult, the per-call [Double] accumulator inside
+                    // EmbeddingService.embed) every iteration instead of letting them
+                    // accumulate for the lifetime of this Task.detached.
+                    autoreleasepool {
+                        attempted += 1
+                        let fileURL = self.rootURL.appendingPathComponent(target.path)
+                        guard Limits.isOpenableSize(fileURL) else {
+                            DiagnosticLog.log("VaultIndex embed: skipping oversized file \(fileURL.lastPathComponent)")
+                            return
                         }
-                        // Atomically replace this file's chunks. Skip the upsert if every
-                        // chunk failed to embed — leaves the prior state in place rather
-                        // than blanking the file out on a transient embed failure.
-                        guard !inputs.isEmpty else { continue }
-                        try self.upsertChunkEmbeddings(
-                            fileID: target.fileID,
-                            contentHash: target.contentHash,
-                            chunks: inputs,
-                            modelVersion: modelVersion
-                        )
-                        processed += 1
-                        totalChunks += inputs.count
-                    } catch {
-                        DiagnosticLog.log("Embedding failed for \(target.path): \(error.localizedDescription)")
+                        guard let data = try? Data(contentsOf: fileURL),
+                              let content = String(data: data, encoding: .utf8) else { return }
+
+                        // Chunk first; embed each chunk separately so long notes don't dilute
+                        // their signal in a single mean-pooled vector. Title + heading-path
+                        // prepended via `embedText` per the contextual-retrieval pattern.
+                        let filename = (target.path as NSString).lastPathComponent
+                        let chunks = MarkdownChunker.chunk(source: content, filename: filename)
+                        if chunks.isEmpty {
+                            // Empty / frontmatter-only note. Clear any prior chunks for this file
+                            // so a previously-non-empty note doesn't keep stale rows around.
+                            try? self.upsertChunkEmbeddings(
+                                fileID: target.fileID,
+                                contentHash: target.contentHash,
+                                chunks: [],
+                                modelVersion: modelVersion
+                            )
+                            return
+                        }
+
+                        do {
+                            var inputs: [ChunkEmbeddingInput] = []
+                            inputs.reserveCapacity(chunks.count)
+                            for chunk in chunks {
+                                do {
+                                    let vector = try service.embed(chunk.embedText)
+                                    inputs.append(ChunkEmbeddingInput(
+                                        chunkIndex: chunk.index,
+                                        textOffset: chunk.textOffset,
+                                        textLength: chunk.textLength,
+                                        headingPath: chunk.headingPath,
+                                        body: chunk.body,
+                                        vector: vector
+                                    ))
+                                } catch EmbeddingError.emptyText {
+                                    continue
+                                }
+                            }
+                            // Atomically replace this file's chunks. Skip the upsert if every
+                            // chunk failed to embed — leaves the prior state in place rather
+                            // than blanking the file out on a transient embed failure.
+                            guard !inputs.isEmpty else { return }
+                            try self.upsertChunkEmbeddings(
+                                fileID: target.fileID,
+                                contentHash: target.contentHash,
+                                chunks: inputs,
+                                modelVersion: modelVersion
+                            )
+                            processed += 1
+                            totalChunks += inputs.count
+                        } catch {
+                            DiagnosticLog.log("Embedding failed for \(target.path): \(error.localizedDescription)")
+                        }
+                    }
+                    if attempted <= 5 || attempted % 100 == 0 {
+                        DiagnosticLog.log("Embedding sweep progress: \(attempted)/\(stale.count), rss=\(MemoryUsage.residentMB())MB")
                     }
                 }
-                if processed > 0 {
-                    DiagnosticLog.log("Embedding sweep complete: \(processed)/\(stale.count) notes, \(totalChunks) chunks")
-                }
+                DiagnosticLog.log("Embedding sweep complete: \(processed)/\(stale.count) notes, \(totalChunks) chunks, rss=\(MemoryUsage.residentMB())MB")
+                DiagnosticLog.trimIfNeeded()
             } catch {
                 DiagnosticLog.log("Embedding sweep failed: \(error.localizedDescription)")
             }


### PR DESCRIPTION
## Summary
Two recent reports — User A's 6,724-file Desktop sweep that climbed to a macOS memory warning over 35 minutes, and #311's idle 6.8 GB / 1001% CPU — turned out to be different bugs in the same area, neither covered by the singular-file PR (#280). This change addresses both.

- **Cancel concurrent walks (#311):** the `treeBuildGeneration` counter only blocked stale *assignment* on main, not stale *execution* — stacked-up FSEventStream bursts each ran a full recursive `FileNode.buildTree` to completion in parallel. `loadTree` now runs in a cancellable `Task.detached`, cancels the prior task per-location, and acquires from a process-wide `TreeBuildLimiter` actor capping concurrent walks at 2.
- **Drain autoreleasepool per file:** the embedding sweep, index sweep, and tree walk all held Foundation-bridged temporaries (`Data`, `CFString`, `NLContextualEmbedding` results, `[Double]` accumulators) until their `Task.detached` finished — turning steady writes into a multi-minute monotonic RSS climb. Each per-file iteration is now wrapped in `autoreleasepool`.
- **Reject nested vaults:** all interactive add paths (open panel, drag-drop, URL handler, wiki seed) reject duplicates and parent/child overlap with a clear `NSAlert` (case-insensitive comparison on default APFS, symlinks resolved). Nested entries left over in stored bookmarks are silently dropped on launch with a log line, sorted by path length so parent vaults always survive over their children.
- **RSS telemetry:** new `MemoryUsage` helper plus start/progress/complete log lines on both sweeps so the next user report can confirm the fix instead of theorize about it. Index-sweep progress is time-throttled (every 5s) to avoid spamming the log on incremental FSEvent reindexes.

Fixes #311.

## Test plan
- [ ] Add a synthetic vault with ~5,000 small `.md` files; confirm RSS plateaus across `Embedding sweep progress` log lines instead of climbing monotonically
- [ ] Add `~/Documents`, then attempt to add `~/Documents/Notes` — expect "already covered" alert; no second VaultIndex
- [ ] Add `~/Documents/Notes` first, then attempt to add `~/Documents` — expect "contains an existing vault" alert
- [ ] Hand-edit `vaults.json` to contain `[blogs (nested), Desktop (parent)]`, relaunch — expect Desktop survives, blogs dropped silently with diagnostic log entry
- [ ] With multiple vaults registered, force a Spotlight reindex (`mdutil -E ~/Documents`) — confirm CPU stays bounded (≤2 walks at a time per the limiter), no idle-RSS climb
- [ ] `swift test` in `Packages/ClearlyCore` (197 tests) — all pass