### PR TITLE
[mac] Customizable vault folder icon and tint

### DIFF
--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -43,6 +43,7 @@ struct MacFolderSidebar: View {
     @Binding var selectedFileURL: URL?
 
     @State private var customizingFolderURL: URL?
+    @State private var customizingVaultURL: URL?
     @State private var cachedTags: [(tag: String, count: Int)] = []
     @AppStorage("sidebarTagsExpanded") private var isTagsExpanded = true
     @AppStorage("sidebarPinnedExpanded") private var isPinnedExpanded = true
@@ -171,7 +172,10 @@ struct MacFolderSidebar: View {
     // MARK: - Location section
 
     private func locationSection(_ location: BookmarkedLocation) -> some View {
-        Section {
+        let defaultIcon = location.isWiki ? "book.closed" : "folder"
+        let resolvedIcon = workspace.vaultIcon(for: location.url) ?? defaultIcon
+        let resolvedTint = workspace.vaultColor(for: location.url).map(Color.init(nsColor:))
+        return Section {
             if !workspace.isLocationCollapsed(location.id.uuidString) {
                 ForEach(topLevelNodes(in: location.fileTree)) { node in
                     outlineNode(node)
@@ -180,9 +184,10 @@ struct MacFolderSidebar: View {
         } header: {
             collapsibleHeader(
                 title: location.name,
-                systemImage: location.isWiki ? "book.closed" : "folder",
+                systemImage: resolvedIcon,
                 isExpanded: locationExpandedBinding(location),
-                isWiki: location.isWiki
+                isWiki: location.isWiki,
+                iconTint: resolvedTint
             )
             .contextMenu {
                 Button("New File", systemImage: "doc.badge.plus") {
@@ -190,6 +195,10 @@ struct MacFolderSidebar: View {
                 }
                 Button("New Folder…", systemImage: "folder.badge.plus") {
                     promptForNewFolder(in: location.url)
+                }
+                Divider()
+                Button("Customize…", systemImage: "paintpalette") {
+                    customizingVaultURL = location.url
                 }
                 Divider()
                 Button("Reveal in Finder", systemImage: "folder") {
@@ -205,6 +214,9 @@ struct MacFolderSidebar: View {
                 Button("Remove from List", systemImage: "minus.circle", role: .destructive) {
                     removeLocation(location)
                 }
+            }
+            .popover(isPresented: vaultPopoverBinding(for: location.url), arrowEdge: .trailing) {
+                VaultCustomizerView(url: location.url, workspace: workspace)
             }
             .dropDestination(for: URL.self) { urls, _ in
                 workspace.handleSidebarDrop(urls: urls, into: location.url)
@@ -291,8 +303,8 @@ struct MacFolderSidebar: View {
     /// hover so the sidebar reads as quiet chrome until the user reaches for
     /// it. The entire row is the hit target. 16pt trailing padding clears
     /// the sidebar's overlay scrollbar when present.
-    private func collapsibleHeader(title: String, systemImage: String, isExpanded: Binding<Bool>, isWiki: Bool = false) -> some View {
-        CollapsibleSectionHeader(title: title, systemImage: systemImage, isExpanded: isExpanded, isWiki: isWiki)
+    private func collapsibleHeader(title: String, systemImage: String, isExpanded: Binding<Bool>, isWiki: Bool = false, iconTint: Color? = nil) -> some View {
+        CollapsibleSectionHeader(title: title, systemImage: systemImage, isExpanded: isExpanded, isWiki: isWiki, iconTint: iconTint)
     }
 
     // MARK: - Tags section
@@ -520,6 +532,13 @@ struct MacFolderSidebar: View {
         Binding(
             get: { customizingFolderURL == url },
             set: { if !$0 { customizingFolderURL = nil } }
+        )
+    }
+
+    private func vaultPopoverBinding(for url: URL) -> Binding<Bool> {
+        Binding(
+            get: { customizingVaultURL == url },
+            set: { if !$0 { customizingVaultURL = nil } }
         )
     }
 }
@@ -806,6 +825,7 @@ private struct CollapsibleSectionHeader: View {
     let systemImage: String
     @Binding var isExpanded: Bool
     var isWiki: Bool = false
+    var iconTint: Color? = nil
     @State private var isHovering = false
 
     var body: some View {
@@ -814,6 +834,7 @@ private struct CollapsibleSectionHeader: View {
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: systemImage)
+                    .foregroundStyle(iconTint ?? .primary)
                 Text(title)
                 if isWiki {
                     Text("WIKI")
@@ -982,6 +1003,43 @@ private struct FolderCustomizerView: View {
                     workspace.setFolderColor(color, for: url.path)
                 } else {
                     workspace.removeFolderColor(for: url.path)
+                }
+            }
+        )
+    }
+}
+
+/// Mirrors `FolderCustomizerView` for vault root rows.
+private struct VaultCustomizerView: View {
+    let url: URL
+    let workspace: WorkspaceManager
+
+    @State private var state: IconPickerState
+
+    init(url: URL, workspace: WorkspaceManager) {
+        self.url = url
+        self.workspace = workspace
+        _state = State(wrappedValue: IconPickerState(
+            icon: workspace.vaultIcons[url.path],
+            color: workspace.vaultColors[url.path]
+        ))
+    }
+
+    var body: some View {
+        IconPickerView(
+            state: state,
+            onSelectIcon: { icon in
+                if let icon {
+                    workspace.setVaultIcon(icon, for: url.path)
+                } else {
+                    workspace.removeVaultIcon(for: url.path)
+                }
+            },
+            onSelectColor: { color in
+                if let color {
+                    workspace.setVaultColor(color, for: url.path)
+                } else {
+                    workspace.removeVaultColor(for: url.path)
                 }
             }
         )

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -134,6 +134,8 @@ final class WorkspaceManager {
     private static let launchBehaviorKey = "launchBehavior"
     private static let folderIconsKey = "folderIcons"
     private static let folderColorsKey = "folderColors"
+    private static let vaultIconsKey = "vaultIcons"
+    private static let vaultColorsKey = "vaultColors"
     private static let expandedFolderPathsKey = "expandedFolderPaths"
     private static let collapsedLocationIDsKey = "collapsedLocationIDs"
     private static let showHiddenFilesKey = "showHiddenFiles"
@@ -146,6 +148,10 @@ final class WorkspaceManager {
     var folderIcons: [String: String] = [:]
     /// Custom folder colors keyed by folder path (URL.path → color name).
     var folderColors: [String: String] = [:]
+    /// Custom vault icons keyed by vault root path (URL.path → SF Symbol name).
+    var vaultIcons: [String: String] = [:]
+    /// Custom vault colors keyed by vault root path (URL.path → color name).
+    var vaultColors: [String: String] = [:]
     /// Expanded folder paths (URL.path). Presence = expanded; absence = collapsed.
     var expandedFolderPaths: Set<String> = []
     /// Collapsed vault section IDs (BookmarkedLocation.id.uuidString). Presence = collapsed; absence = expanded (default).
@@ -188,6 +194,8 @@ final class WorkspaceManager {
         showHiddenFiles = UserDefaults.standard.bool(forKey: Self.showHiddenFilesKey)
         folderIcons = UserDefaults.standard.dictionary(forKey: Self.folderIconsKey) as? [String: String] ?? [:]
         folderColors = UserDefaults.standard.dictionary(forKey: Self.folderColorsKey) as? [String: String] ?? [:]
+        vaultIcons = UserDefaults.standard.dictionary(forKey: Self.vaultIconsKey) as? [String: String] ?? [:]
+        vaultColors = UserDefaults.standard.dictionary(forKey: Self.vaultColorsKey) as? [String: String] ?? [:]
         expandedFolderPaths = Set(UserDefaults.standard.stringArray(forKey: Self.expandedFolderPathsKey) ?? [])
         collapsedLocationIDs = Set(UserDefaults.standard.stringArray(forKey: Self.collapsedLocationIDsKey) ?? [])
         restoreLocations()
@@ -1098,6 +1106,12 @@ final class WorkspaceManager {
         }
         removeDeletedItemReferences(at: location.url)
         pruneExpandedFolderPaths(under: location.url)
+        if vaultIcons.removeValue(forKey: location.url.path) != nil {
+            UserDefaults.standard.set(vaultIcons, forKey: Self.vaultIconsKey)
+        }
+        if vaultColors.removeValue(forKey: location.url.path) != nil {
+            UserDefaults.standard.set(vaultColors, forKey: Self.vaultColorsKey)
+        }
         locations.removeAll { $0.id == location.id }
         persistLocations()
     }
@@ -1696,6 +1710,28 @@ final class WorkspaceManager {
         UserDefaults.standard.set(folderColors, forKey: Self.folderColorsKey)
     }
 
+    // MARK: - Vault Icons & Colors
+
+    func setVaultIcon(_ iconName: String, for vaultPath: String) {
+        vaultIcons[vaultPath] = iconName
+        UserDefaults.standard.set(vaultIcons, forKey: Self.vaultIconsKey)
+    }
+
+    func removeVaultIcon(for vaultPath: String) {
+        vaultIcons.removeValue(forKey: vaultPath)
+        UserDefaults.standard.set(vaultIcons, forKey: Self.vaultIconsKey)
+    }
+
+    func setVaultColor(_ colorName: String, for vaultPath: String) {
+        vaultColors[vaultPath] = colorName
+        UserDefaults.standard.set(vaultColors, forKey: Self.vaultColorsKey)
+    }
+
+    func removeVaultColor(for vaultPath: String) {
+        vaultColors.removeValue(forKey: vaultPath)
+        UserDefaults.standard.set(vaultColors, forKey: Self.vaultColorsKey)
+    }
+
     // MARK: - Folder Expansion
 
     func isFolderExpanded(_ url: URL) -> Bool {
@@ -1739,6 +1775,17 @@ final class WorkspaceManager {
     /// Direct folder icon lookup (no ancestor walk). Returns nil if unset.
     func folderIcon(for url: URL) -> String? {
         folderIcons[url.path]
+    }
+
+    /// Direct vault color lookup. Returns nil if unset.
+    func vaultColor(for url: URL) -> NSColor? {
+        guard let name = vaultColors[url.path] else { return nil }
+        return Theme.folderColor(named: name)
+    }
+
+    /// Direct vault icon lookup. Returns nil if unset.
+    func vaultIcon(for url: URL) -> String? {
+        vaultIcons[url.path]
     }
 
     /// Walks ancestors of `url` up to — and including — the containing vault


### PR DESCRIPTION
## Summary
- Right-click a vault root in the Mac sidebar → **Customize…** opens the existing icon picker (25 SF Symbols + 8-color palette).
- Per-vault icon and color persist in UserDefaults via new \`vaultIcons\` / \`vaultColors\` dicts that mirror the existing \`folderIcons\` / \`folderColors\` pattern, and are cleaned up when a vault is removed.
- Reset falls back to the kind-aware default (\`book.closed\` for wiki vaults, \`folder\` otherwise).

Fixes #317

## Test plan
- [ ] Add a vault → right-click → Customize… → pick a symbol + color, confirm sidebar header updates immediately.
- [ ] Quit and relaunch — confirm icon and tint persist.
- [ ] Reset All — confirm fallback to default (and \`book.closed\` for wiki vaults).
- [ ] Verify child folder Customize… still works (regression check on shared header).
- [ ] Remove the vault, re-add it at the same path — confirm no stale icon/tint.