### PR TITLE
Add Delete to sidebar context menus

### DIFF
--- a/Clearly/Native/MacFolderSidebar.swift
+++ b/Clearly/Native/MacFolderSidebar.swift
@@ -399,6 +399,10 @@ struct MacFolderSidebar: View {
         if let root = workspace.containingVaultRoot(for: url) {
             Button("Copy Relative Path") { CopyActions.copyRelativePath(url, vaultRoot: root) }
         }
+        Divider()
+        Button("Delete", systemImage: "trash", role: .destructive) {
+            deleteWithConfirmation(url: url, isDirectory: true)
+        }
     }
 
     private func createNewFile(in folder: URL) {
@@ -481,6 +485,53 @@ struct MacFolderSidebar: View {
         }
         if let target = workspace.wikiLinkTarget(for: url) {
             Button("Copy Wiki Link") { CopyActions.copyWikiLink(target) }
+        }
+        Divider()
+        Button("Delete", systemImage: "trash", role: .destructive) {
+            deleteWithConfirmation(url: url, isDirectory: false)
+        }
+    }
+
+    private func deleteWithConfirmation(url: URL, isDirectory: Bool) {
+        let name = url.lastPathComponent
+        let alert = NSAlert()
+        alert.messageText = isDirectory
+            ? "Move \u{201C}\(name)\u{201D} and all its contents to Trash?"
+            : "Move \u{201C}\(name)\u{201D} to Trash?"
+        alert.informativeText = "You can recover it from the Trash."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let previousSelection = selectedFileURL
+        var clearedSelection = false
+        if let selected = selectedFileURL {
+            let rootPath = url.standardizedFileURL.path
+            let selectedPath = selected.standardizedFileURL.path
+            if selectedPath == rootPath || selectedPath.hasPrefix(rootPath + "/") {
+                selectedFileURL = nil
+                clearedSelection = true
+            }
+        }
+
+        switch workspace.deleteItem(at: url) {
+        case .deleted:
+            break
+        case .cancelled:
+            if clearedSelection, selectedFileURL == nil {
+                selectedFileURL = previousSelection
+            }
+        case .failed:
+            if clearedSelection, selectedFileURL == nil {
+                selectedFileURL = previousSelection
+            }
+            let failure = NSAlert()
+            failure.messageText = "Couldn\u{2019}t move \u{201C}\(name)\u{201D} to Trash"
+            failure.alertStyle = .warning
+            failure.addButton(withTitle: "OK")
+            failure.runModal()
         }
     }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -42,6 +42,12 @@ private actor TreeBuildLimiter {
     }
 }
 
+enum DeleteItemResult {
+    case deleted
+    case cancelled
+    case failed
+}
+
 /// Central state manager for file navigation: locations, recents, and current file.
 @Observable
 final class WorkspaceManager {
@@ -1474,15 +1480,16 @@ final class WorkspaceManager {
         alert.runModal()
     }
 
-    func deleteItem(at url: URL) -> Bool {
+    func deleteItem(at url: URL) -> DeleteItemResult {
+        guard closeOpenDocumentsBeforeDeleting(at: url) else { return .cancelled }
         do {
             try FileManager.default.trashItem(at: url, resultingItemURL: nil)
             removeDeletedItemReferences(at: url)
             DiagnosticLog.log("Trashed: \(url.lastPathComponent)")
-            return true
+            return .deleted
         } catch {
             DiagnosticLog.log("Failed to trash: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 
@@ -1560,6 +1567,60 @@ final class WorkspaceManager {
         pinnedFiles.removeAll { isSameOrDescendant($0, of: url) }
         if pinnedFiles.count != previousPinnedCount {
             persistPinnedFiles()
+        }
+    }
+
+    private func closeOpenDocumentsBeforeDeleting(at url: URL) -> Bool {
+        let affectedDocumentIDs = openDocuments.compactMap { document -> UUID? in
+            guard let fileURL = document.fileURL, isSameOrDescendant(fileURL, of: url) else { return nil }
+            return document.id
+        }
+        for documentID in affectedDocumentIDs {
+            guard closeDocumentBeforeDeleting(documentID) else { return false }
+        }
+        return true
+    }
+
+    private func closeDocumentBeforeDeleting(_ id: UUID) -> Bool {
+        guard openDocuments.contains(where: { $0.id == id }) else { return true }
+        let wasCurrent = (id == activeDocumentID)
+        if wasCurrent {
+            snapshotActiveDocument()
+        }
+
+        guard let currentIndex = openDocuments.firstIndex(where: { $0.id == id }) else { return true }
+        let doc = openDocuments[currentIndex]
+        if doc.isDirty {
+            let disposition: DirtyDocumentDisposition = wasCurrent ? .save : promptToSaveChanges(for: doc)
+            switch disposition {
+            case .save:
+                guard saveDocumentBeforeDeleting(at: currentIndex) else { return false }
+            case .discard:
+                break
+            case .cancel:
+                return false
+            }
+        }
+
+        removeDocument(id)
+        return true
+    }
+
+    private func saveDocumentBeforeDeleting(at index: Int) -> Bool {
+        let doc = openDocuments[index]
+        guard let url = doc.fileURL, doc.isDirty else { return true }
+        do {
+            try CoordinatedFileIO.write(Data(doc.text.utf8), to: url)
+            openDocuments[index].lastSavedText = doc.text
+            if activeDocumentIndex == index {
+                currentFileText = doc.text
+                lastSavedText = doc.text
+                isDirty = false
+            }
+            return true
+        } catch {
+            DiagnosticLog.log("Failed to save before delete: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Clearly/iOS/FolderListView_iOS.swift
+++ b/Clearly/iOS/FolderListView_iOS.swift
@@ -24,6 +24,7 @@ struct FolderListView_iOS: View {
     @State private var operationError: String?
 
     @State private var deleteTarget: VaultFile?
+    @State private var folderDeleteTarget: URL?
     @State private var moveTarget: VaultFile?
 
     var body: some View {
@@ -93,6 +94,16 @@ struct FolderListView_iOS: View {
         } message: {
             Text("This can't be undone from within Clearly.")
         }
+        .confirmationDialog(
+            folderDeleteTarget.map { "Delete \u{201C}\($0.lastPathComponent)\u{201D}?" } ?? "",
+            isPresented: folderDeleteConfirmBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { commitFolderDelete() }
+            Button("Cancel", role: .cancel) { folderDeleteTarget = nil }
+        } message: {
+            Text("This deletes the folder and everything inside it. This can't be undone from within Clearly.")
+        }
         .alert(
             "Something went wrong",
             isPresented: Binding(
@@ -140,7 +151,8 @@ struct FolderListView_iOS: View {
                             onMoveFile: { file in moveTarget = file },
                             onDuplicateFile: { file in performDuplicate(file) },
                             onCreateFile: { folder in createFile(in: folder) },
-                            onCreateFolder: { folder in beginCreateFolder(in: folder) }
+                            onCreateFolder: { folder in beginCreateFolder(in: folder) },
+                            onDeleteFolder: { folder in folderDeleteTarget = folder }
                         )
                     } header: {
                         Text(session.currentVault?.displayName ?? "Vault")
@@ -299,6 +311,13 @@ struct FolderListView_iOS: View {
         )
     }
 
+    private var folderDeleteConfirmBinding: Binding<Bool> {
+        Binding(
+            get: { folderDeleteTarget != nil },
+            set: { if !$0 { folderDeleteTarget = nil } }
+        )
+    }
+
     private func performRename(_ file: VaultFile, to newName: String) {
         Task {
             do {
@@ -341,6 +360,18 @@ struct FolderListView_iOS: View {
         Task {
             do {
                 try await session.deleteFile(target)
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func commitFolderDelete() {
+        guard let target = folderDeleteTarget else { return }
+        folderDeleteTarget = nil
+        Task {
+            do {
+                try await session.deleteFolder(at: target)
             } catch {
                 operationError = error.localizedDescription
             }

--- a/Clearly/iOS/IOSDocumentSession.swift
+++ b/Clearly/iOS/IOSDocumentSession.swift
@@ -44,7 +44,8 @@ public final class IOSDocumentSession {
     // MARK: - Lifecycle
 
     public func open(_ file: VaultFile, via vault: VaultSession) async {
-        await close()
+        guard await flush() else { return }
+        await close(discardUnsavedChanges: true)
 
         self.vault = vault
         self.file = file
@@ -77,12 +78,15 @@ public final class IOSDocumentSession {
         }
     }
 
-    public func close(discardUnsavedChanges: Bool = false) async {
+    @discardableResult
+    public func close(discardUnsavedChanges: Bool = false, allowAutoRename: Bool = true) async -> Bool {
+        let didFlush: Bool
         if discardUnsavedChanges {
             autosaveTask?.cancel()
             autosaveTask = nil
+            didFlush = true
         } else {
-            await flush()
+            didFlush = await flush(allowAutoRename: allowAutoRename)
         }
         detachPresenter()
         autosaveTask?.cancel()
@@ -94,6 +98,7 @@ public final class IOSDocumentSession {
         wasDeletedRemotely = false
         errorMessage = nil
         isLoading = false
+        return didFlush
     }
 
     /// Called by the UI after the user has viewed the diff sheet and tapped "Done".
@@ -104,11 +109,12 @@ public final class IOSDocumentSession {
 
     // MARK: - Save path
 
-    public func flush() async {
+    @discardableResult
+    public func flush(allowAutoRename: Bool = true) async -> Bool {
         autosaveTask?.cancel()
         autosaveTask = nil
-        guard let file, isDirty else { return }
-        await performSave(text: text, url: file.url)
+        guard let file, isDirty else { return true }
+        return await performSave(text: text, url: file.url, allowAutoRename: allowAutoRename)
     }
 
     private func scheduleAutosave() {
@@ -122,7 +128,8 @@ public final class IOSDocumentSession {
         }
     }
 
-    private func performSave(text: String, url: URL) async {
+    @discardableResult
+    private func performSave(text: String, url: URL, allowAutoRename: Bool = true) async -> Bool {
         isOwnWriteInFlight = true
         defer { isOwnWriteInFlight = false }
         let data = Data(text.utf8)
@@ -132,7 +139,10 @@ public final class IOSDocumentSession {
                 try CoordinatedFileIO.write(data, to: url, presenter: capturedPresenter)
             }.value
             lastSavedText = text
-            await autoRenameIfApplicable(text: text)
+            if allowAutoRename {
+                await autoRenameIfApplicable(text: text)
+            }
+            return true
         } catch {
             // Don't clobber `errorMessage` here — that slot drives the
             // load-failure full-screen view, and a save failure must not
@@ -141,6 +151,7 @@ public final class IOSDocumentSession {
             // the nav-title bullet stays lit and the next autosave (or
             // the scene-phase flush) will retry the write.
             DiagnosticLog.log("IOSDocumentSession save failed for \(url.lastPathComponent): \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Clearly/iOS/IPadRootView.swift
+++ b/Clearly/iOS/IPadRootView.swift
@@ -23,6 +23,7 @@ struct IPadRootView: View {
     @State private var folderTree: [FileNode] = []
 
     @State private var deleteTarget: VaultFile?
+    @State private var folderDeleteTarget: URL?
     @State private var moveTarget: VaultFile?
     @State private var operationError: String?
 
@@ -85,6 +86,16 @@ struct IPadRootView: View {
             Button("Cancel", role: .cancel) { deleteTarget = nil }
         } message: {
             Text("This can't be undone from within Clearly.")
+        }
+        .confirmationDialog(
+            folderDeleteTarget.map { "Delete \u{201C}\($0.lastPathComponent)\u{201D}?" } ?? "",
+            isPresented: folderDeleteConfirmBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { commitFolderDelete() }
+            Button("Cancel", role: .cancel) { folderDeleteTarget = nil }
+        } message: {
+            Text("This deletes the folder and everything inside it. This can't be undone from within Clearly.")
         }
         .alert("New Folder", isPresented: $isCreatingFolder) {
             TextField("Name", text: $newFolderDraft)
@@ -161,7 +172,8 @@ struct IPadRootView: View {
                     onMoveFile: { file in moveTarget = file },
                     onDuplicateFile: { file in performDuplicate(file) },
                     onCreateFile: { folder in createFile(in: folder) },
-                    onCreateFolder: { folder in beginCreateFolder(in: folder) }
+                    onCreateFolder: { folder in beginCreateFolder(in: folder) },
+                    onDeleteFolder: { folder in folderDeleteTarget = folder }
                 )
             } header: {
                 Text(session.currentVault?.displayName ?? "Vault")
@@ -251,6 +263,15 @@ struct IPadRootView: View {
         )
     }
 
+    private var folderDeleteConfirmBinding: Binding<Bool> {
+        Binding(
+            get: { folderDeleteTarget != nil },
+            set: { newValue in
+                if !newValue { folderDeleteTarget = nil }
+            }
+        )
+    }
+
     private func performRename(_ file: VaultFile, to newName: String) {
         Task {
             do {
@@ -292,10 +313,27 @@ struct IPadRootView: View {
         deleteTarget = nil
         Task {
             do {
-                try await session.deleteFile(target)
-                await MainActor.run {
-                    controller.closeTabs(matching: target)
+                guard await controller.closeTabsForDeletion(matching: target) else {
+                    operationError = "Couldn't save changes before deleting."
+                    return
                 }
+                try await session.deleteFile(target)
+            } catch {
+                operationError = error.localizedDescription
+            }
+        }
+    }
+
+    private func commitFolderDelete() {
+        guard let target = folderDeleteTarget else { return }
+        folderDeleteTarget = nil
+        Task {
+            do {
+                guard await controller.closeTabsForDeletion(inSubtree: target) else {
+                    operationError = "Couldn't save changes before deleting."
+                    return
+                }
+                try await session.deleteFolder(at: target)
             } catch {
                 operationError = error.localizedDescription
             }

--- a/Clearly/iOS/IPadTabController.swift
+++ b/Clearly/iOS/IPadTabController.swift
@@ -201,11 +201,20 @@ public final class IPadTabController {
     }
 
     private func closeTab(id: UUID, discardUnsavedChanges: Bool) {
-        guard let idx = tabs.firstIndex(where: { $0.id == id }) else { return }
-        let tab = tabs[idx]
-        Task { await tab.session.close(discardUnsavedChanges: discardUnsavedChanges) }
-        tabs.remove(at: idx)
+        Task { await closeTabAndWait(id: id, discardUnsavedChanges: discardUnsavedChanges) }
+    }
 
+    @discardableResult
+    private func closeTabAndWait(id: UUID, discardUnsavedChanges: Bool, allowAutoRename: Bool = true) async -> Bool {
+        guard let idx = tabs.firstIndex(where: { $0.id == id }) else { return true }
+        let tab = tabs[idx]
+        if discardUnsavedChanges {
+            await tab.session.close(discardUnsavedChanges: true, allowAutoRename: allowAutoRename)
+        } else {
+            guard await tab.session.flush(allowAutoRename: allowAutoRename) else { return false }
+            await tab.session.close(discardUnsavedChanges: true, allowAutoRename: allowAutoRename)
+        }
+        tabs.remove(at: idx)
         if activeTabID == id {
             // Activate neighbor: next if present, otherwise previous, otherwise nil.
             if idx < tabs.count {
@@ -217,17 +226,65 @@ public final class IPadTabController {
             }
         }
         persist()
+        return true
     }
 
     public func closeTabs(matching file: VaultFile) {
+        for id in tabIDs(matching: file) {
+            closeTab(id: id, discardUnsavedChanges: true)
+        }
+    }
+
+    @discardableResult
+    public func closeTabsForDeletion(matching file: VaultFile) async -> Bool {
+        for id in tabIDs(matching: file) {
+            guard await closeTabAndWait(id: id, discardUnsavedChanges: false, allowAutoRename: false) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Close every tab whose file lives inside `folderURL` (or is `folderURL`
+    /// itself). Used when the user trashes a folder from the sidebar — any
+    /// tabs pointing at files under that subtree must close so the editor
+    /// doesn't keep a vanished file mounted.
+    public func closeTabs(inSubtree folderURL: URL) {
+        for id in tabIDs(inSubtree: folderURL) {
+            closeTab(id: id, discardUnsavedChanges: true)
+        }
+    }
+
+    @discardableResult
+    public func closeTabsForDeletion(inSubtree folderURL: URL) async -> Bool {
+        for id in tabIDs(inSubtree: folderURL) {
+            guard await closeTabAndWait(id: id, discardUnsavedChanges: false, allowAutoRename: false) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func tabIDs(matching file: VaultFile) -> [UUID] {
         let target = file.url.standardizedFileURL
-        let ids = tabs.filter { tab in
+        return tabs.filter { tab in
             if tab.file.url.standardizedFileURL == target { return true }
             return tab.session.file?.url.standardizedFileURL == target
         }.map(\.id)
-        for id in ids {
-            closeTab(id: id, discardUnsavedChanges: true)
+    }
+
+    private func tabIDs(inSubtree folderURL: URL) -> [UUID] {
+        let rootPath = folderURL.standardizedFileURL.path
+        let prefix = rootPath + "/"
+        func isInside(_ url: URL) -> Bool {
+            let path = url.standardizedFileURL.path
+            return path == rootPath || path.hasPrefix(prefix)
         }
+        return tabs.filter { tab in
+            if isInside(tab.file.url) { return true }
+            if let sessionURL = tab.session.file?.url, isInside(sessionURL) { return true }
+            return false
+        }.map(\.id)
     }
 
     public func activate(id: UUID) {

--- a/Clearly/iOS/SidebarOutline_iOS.swift
+++ b/Clearly/iOS/SidebarOutline_iOS.swift
@@ -23,6 +23,7 @@ struct SidebarOutline_iOS: View {
     let onDuplicateFile: (VaultFile) -> Void
     let onCreateFile: (URL) -> Void
     let onCreateFolder: (URL) -> Void
+    let onDeleteFolder: (URL) -> Void
 
     @Environment(VaultSession.self) private var session
     @Environment(IOSExpansionState.self) private var expansion
@@ -156,6 +157,12 @@ struct SidebarOutline_iOS: View {
             onCreateFolder(folderURL)
         } label: {
             Label("New Folder", systemImage: "folder.badge.plus")
+        }
+        Divider()
+        Button(role: .destructive) {
+            onDeleteFolder(folderURL)
+        } label: {
+            Label("Delete", systemImage: "trash")
         }
     }
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultSession.swift
@@ -612,6 +612,18 @@ public final class VaultSession {
         refresh()
     }
 
+    /// Delete a folder and everything inside it. Prunes any descendant files
+    /// from `navigationPath` and recents so the editor doesn't try to reopen
+    /// a vanished file when the user navigates back.
+    public func deleteFolder(at url: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try CoordinatedFileIO.delete(at: url)
+        }.value
+        dropSubtreeFromNavigationPath(url)
+        dropSubtreeFromRecents(url)
+        refresh()
+    }
+
     /// Files tagged with `tag` (case-insensitive). Returns an empty array when no
     /// index is attached. Maps each `IndexedFile` back to a `VaultFile` from the
     /// watcher's current list, falling back to a provisional record constructed
@@ -643,6 +655,26 @@ public final class VaultSession {
         let target = url.standardizedFileURL
         recentFiles.removeAll { $0.url.standardizedFileURL == target }
         persistRecents()
+    }
+
+    private func dropSubtreeFromNavigationPath(_ folderURL: URL) {
+        let prefix = folderURL.standardizedFileURL.path + "/"
+        navigationPath.removeAll { entry in
+            let entryPath = entry.url.standardizedFileURL.path
+            return entryPath == folderURL.standardizedFileURL.path || entryPath.hasPrefix(prefix)
+        }
+    }
+
+    private func dropSubtreeFromRecents(_ folderURL: URL) {
+        let prefix = folderURL.standardizedFileURL.path + "/"
+        let before = recentFiles.count
+        recentFiles.removeAll { file in
+            let filePath = file.url.standardizedFileURL.path
+            return filePath == folderURL.standardizedFileURL.path || filePath.hasPrefix(prefix)
+        }
+        if recentFiles.count != before {
+            persistRecents()
+        }
     }
 
     // MARK: - Recent files


### PR DESCRIPTION
## Summary

- **Mac**: file and sub-folder context menus now show a destructive **Delete** entry. NSAlert confirms, then `FileManager.trashItem` moves it to the Trash. Open documents inside a deleted subtree are closed first; dirty docs prompt to save and a Cancel at the save prompt aborts the delete.
- **iOS / iPadOS**: folder context menu gains a Delete entry mirroring the existing file delete, with a confirmation dialog. New `VaultSession.deleteFolder` deletes via `CoordinatedFileIO` and prunes any descendants from `navigationPath` and recents. iPad closes any tabs whose file lived under the deleted folder via `IPadTabController.closeTabs(inSubtree:)`.
- `IOSDocumentSession.flush` / `close` / `performSave` now return success bools so the open-replace flow can avoid clobbering unsaved edits when a save fails mid-handoff.

Fixes #320

## Test plan

- [ ] Mac: right-click a file → Delete → confirmation → file lands in Finder Trash; open tab closes
- [ ] Mac: right-click a sub-folder containing an open dirty doc → save prompt → Save / Discard / Cancel each behave correctly
- [ ] Mac: vault-root header has no Delete option
- [ ] iPhone: long-press a folder → Delete → confirmation → folder + contents removed
- [ ] iPad: delete a folder containing open tabs → all matching tabs close