### PR TITLE
[mac] Persist last-used view mode globally (#318)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -631,6 +631,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
             resolved = requestedMode
         }
         WorkspaceManager.shared.currentViewMode = resolved
+        WorkspaceManager.persistViewModePreference(resolved)
     }
 
     @objc private func toggleOutlineAction(_ sender: Any?) {

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -32,7 +32,13 @@ struct MacDetailToolbar: ToolbarContent {
             // Editable preview replaces the static preview when the toggle is
             // on; UI is 2-segment in both cases so the user sees the same
             // Edit/Preview model.
-            Picker("Mode", selection: $workspace.currentViewMode) {
+            Picker("Mode", selection: Binding(
+                get: { workspace.currentViewMode },
+                set: { newValue in
+                    workspace.currentViewMode = newValue
+                    WorkspaceManager.persistViewModePreference(newValue)
+                }
+            )) {
                 Image(systemName: "pencil").tag(ViewMode.edit)
                 Image(systemName: "eye").tag(wysiwygExperimentEnabled ? ViewMode.wysiwyg : ViewMode.preview)
             }

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -65,15 +65,54 @@ final class WorkspaceManager {
     var currentFileURL: URL?
     var currentFileText: String = ""
     var isDirty: Bool = false
-    var currentViewMode: ViewMode = .edit
+    var currentViewMode: ViewMode = WorkspaceManager.defaultViewModeForOpenedFile
     var currentConflictOutcome: ConflictResolver.Outcome?
 
-    /// View mode that newly-created untitled documents land in. Always Edit
-    /// — empty notes don't have anything to preview yet, so dropping the
-    /// user into a rendered/editable-preview surface would feel weird.
-    /// Existing files keep their persisted view mode (autosaved per-doc).
+    /// UserDefaults key for the user's last-used view mode (issue #318).
+    /// Written only at explicit user-intent sites (Picker, ⌘1/⌘2, View menu);
+    /// never from internal coercions or per-tab restore.
+    static let viewModePreferenceKey = "defaultViewMode"
+
+    static func persistViewModePreference(_ mode: ViewMode) {
+        UserDefaults.standard.set(mode.rawValue, forKey: viewModePreferenceKey)
+    }
+
+    /// View mode for a newly-created untitled (empty) document. Honors the
+    /// user's last-used mode, but a read-only `.preview` of an empty buffer
+    /// is useless and `.wysiwyg` only renders when the experiment is on —
+    /// both fall back to `.edit`.
     static var defaultViewModeForNewDocument: ViewMode {
-        .edit
+        let stored = storedViewModePreference()
+        switch stored {
+        case .edit:
+            return .edit
+        case .wysiwyg:
+            return WYSIWYGExperiment.isEnabled ? .wysiwyg : .edit
+        case .preview:
+            return .edit
+        }
+    }
+
+    /// View mode for opening or re-opening an existing file. Honors the
+    /// user's last-used mode, coercing stale `.wysiwyg` to `.preview` if
+    /// the experiment has since been turned off.
+    static var defaultViewModeForOpenedFile: ViewMode {
+        let stored = storedViewModePreference()
+        if stored == .preview && WYSIWYGExperiment.isEnabled {
+            return .wysiwyg
+        }
+        if stored == .wysiwyg && !WYSIWYGExperiment.isEnabled {
+            return .preview
+        }
+        return stored
+    }
+
+    private static func storedViewModePreference() -> ViewMode {
+        guard let raw = UserDefaults.standard.string(forKey: viewModePreferenceKey),
+              let mode = ViewMode(rawValue: raw) else {
+            return .edit
+        }
+        return mode
     }
 
     /// The vault that contains the active file, if any. Drives wiki-chrome
@@ -548,10 +587,12 @@ final class WorkspaceManager {
             openDocuments[idx].lastSavedText = text
             openDocuments[idx].untitledNumber = nil
             openDocuments[idx].conflictOutcome = nil
+            openDocuments[idx].viewMode = WorkspaceManager.defaultViewModeForOpenedFile
             currentFileURL = url
             currentFileText = text
             lastSavedText = text
             isDirty = false
+            currentViewMode = openDocuments[idx].viewMode
             currentConflictOutcome = nil
             refreshConflictOutcomeForActiveDocument()
         } else {
@@ -561,7 +602,8 @@ final class WorkspaceManager {
                 fileURL: url,
                 text: text,
                 lastSavedText: text,
-                untitledNumber: nil
+                untitledNumber: nil,
+                viewMode: WorkspaceManager.defaultViewModeForOpenedFile
             )
             openDocuments.append(doc)
             activateDocument(doc)
@@ -604,7 +646,8 @@ final class WorkspaceManager {
             fileURL: url,
             text: text,
             lastSavedText: text,
-            untitledNumber: nil
+            untitledNumber: nil,
+            viewMode: WorkspaceManager.defaultViewModeForOpenedFile
         )
         openDocuments.append(doc)
         activateDocument(doc)


### PR DESCRIPTION
## Summary

- Editor/Preview choice now survives close + reopen of any file (issue #318: opening always defaulted to Editor)
- Preference is written only on explicit user action — Picker, ⌘1/⌘2, and the View menu — so tab switching, find-bar's force-flip to Editor, wiki link navigation, and WYSIWYG toggle coercions don't corrupt it
- Brand-new empty untitled docs (⌘N) still land in Editor unless the WYSIWYG experiment is on, since read-only Preview of an empty buffer is useless

## Test plan

- [ ] Open a file, ⌘2 → Preview, close window, reopen via File → Recent: lands in Preview
- [ ] With Preview last-used, click another file in the sidebar: opens in Preview
- [ ] WYSIWYG off + Preview last-used: ⌘N still lands in Editor
- [ ] WYSIWYG on + ⌘2 (now `.wysiwyg`): ⌘N lands in WYSIWYG
- [ ] In Preview, ⌘F (force-flips to Editor for find), then open another file: still Preview (find didn't corrupt preference)
- [ ] Multi-tab session restore: tabs A/B in different modes survive a relaunch correctly

Fixes #318