### PR TITLE
[mac] Forget deleted documents from Recents (#302)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -140,6 +140,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         observers.append(nc.addObserver(forName: NSApplication.didResignActiveNotification, object: nil, queue: .main) { [weak self] _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { self?.updateActivationPolicy() }
         })
+        observers.append(nc.addObserver(forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main) { _ in
+            Task { @MainActor in
+                WorkspaceManager.shared.pruneMissingRecents()
+            }
+        })
         observers.append(nc.addObserver(forName: NSWindow.didResignMainNotification, object: nil, queue: .main) { [weak self] _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { self?.updateActivationPolicy() }
         })

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -1950,16 +1950,47 @@ final class WorkspaceManager {
                 if isStale {
                     shouldPersist = true
                 }
-                if !hasActiveAccess(to: url), url.startAccessingSecurityScopedResource() {
+                var hasAccess = hasActiveAccess(to: url)
+                if !hasAccess, url.startAccessingSecurityScopedResource() {
                     accessedURLs.insert(url)
+                    hasAccess = true
                 }
-                urls.append(url)
+                // Only treat a missing file as "deleted" when we actually have
+                // access — fileExists returns false for both gone-from-disk
+                // and we-can't-reach-it-due-to-sandbox. Keep the entry on
+                // no-access so a transient scope failure can't silently nuke
+                // recents.
+                if hasAccess && !FileManager.default.fileExists(atPath: url.path) {
+                    shouldPersist = true
+                } else {
+                    urls.append(url)
+                }
             } else {
                 shouldPersist = true
             }
         }
         recentFiles = urls
         if shouldPersist || urls.count != bookmarks.count {
+            persistRecents()
+        }
+    }
+
+    func pruneMissingRecents() {
+        // Build kept[] without mutating recentFiles in place — @Observable
+        // would fire a setter on every call otherwise, re-rendering the
+        // sidebar every time the app becomes active.
+        var kept: [URL] = []
+        kept.reserveCapacity(recentFiles.count)
+        var droppedAny = false
+        for url in recentFiles {
+            if hasActiveAccess(to: url) && !FileManager.default.fileExists(atPath: url.path) {
+                droppedAny = true
+            } else {
+                kept.append(url)
+            }
+        }
+        if droppedAny {
+            recentFiles = kept
             persistRecents()
         }
     }


### PR DESCRIPTION
## Summary

- Filters Recents at app launch in `WorkspaceManager.restoreRecents()` so bookmarks resolving to gone-from-disk files are dropped instead of restored as stale entries.
- Adds `WorkspaceManager.pruneMissingRecents()` plus an `NSApplication.didBecomeActiveNotification` observer in `ClearlyAppDelegate` so the list is re-validated every time the app returns to the foreground (catches deletes that happened while Clearly wasn't running or wasn't watching).
- Both checks gate on `hasActiveAccess(to:)` so a transient sandbox-scope failure can't be misread as a deletion. iOS already filters orphaned paths in `VaultSession.restoreRecents()`, so this stays Mac-only.

Fixes #302

## Test plan

- [ ] Open 2–3 notes from a vault, quit Clearly, trash one of them in Finder, relaunch — that note must be gone from both the sidebar Recents section and File → Open Recent.
- [ ] With Clearly still running, trash a file outside its watched scope, cmd-tab back to Clearly — the entry disappears from Recents.
- [ ] Right-click a recent in the sidebar and "Remove from Recents" still works.
- [ ] In-app delete still removes the deleted file from Recents (existing FSEvent path).