### PR TITLE
[mac] fix: prompt before discarding unsaved changes on navigation (#327)

### DIFF
--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -66,7 +66,7 @@ struct MacRootView: View {
         }
         .navigationTitle(windowTitle)
         .navigationDocument(workspace.currentFileURL ?? URL(fileURLWithPath: "/"))
-        .onChange(of: selectedFileURL) { _, newURL in
+        .onChange(of: selectedFileURL) { oldURL, newURL in
             guard let url = newURL else { return }
             guard workspace.currentFileURL != url else { return }
             let isCmdClick: Bool = {
@@ -75,10 +75,14 @@ struct MacRootView: View {
             }()
             lastSidebarClickModifiers = []
             lastSidebarClickTime = nil
-            if isCmdClick {
-                workspace.openFileInNewTab(at: url)
-            } else {
-                workspace.openFile(at: url)
+            let succeeded = isCmdClick
+                ? workspace.openFileInNewTab(at: url)
+                : workspace.openFile(at: url)
+            if !succeeded {
+                // User cancelled the unsaved-changes prompt. The selection
+                // already moved in the binding — revert it so the sidebar
+                // doesn't lie about which file is open.
+                DispatchQueue.main.async { selectedFileURL = oldURL }
             }
         }
         .onChange(of: workspace.currentFileURL) { _, newURL in

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -75,14 +75,21 @@ struct MacRootView: View {
             }()
             lastSidebarClickModifiers = []
             lastSidebarClickTime = nil
-            let succeeded = isCmdClick
-                ? workspace.openFileInNewTab(at: url)
-                : workspace.openFile(at: url)
-            if !succeeded {
-                // User cancelled the unsaved-changes prompt. The selection
-                // already moved in the binding — revert it so the sidebar
-                // doesn't lie about which file is open.
-                DispatchQueue.main.async { selectedFileURL = oldURL }
+            // Defer to the next runloop tick. `openFile` may present an
+            // NSAlert sheet (unsaved-changes prompt), and AppKit aborts a
+            // modal session if you start it inside a SwiftUI binding-update
+            // cycle — the alert flashes invisibly and `runModal()` returns
+            // .abort, which previously silently discarded the user's edits.
+            // See issue #327.
+            DispatchQueue.main.async {
+                let succeeded = isCmdClick
+                    ? workspace.openFileInNewTab(at: url)
+                    : workspace.openFile(at: url)
+                if !succeeded {
+                    // User cancelled (or modal failed). Revert the sidebar
+                    // selection so the highlight doesn't lie.
+                    selectedFileURL = oldURL
+                }
             }
         }
         .onChange(of: workspace.currentFileURL) { _, newURL in

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -2606,8 +2606,14 @@ final class WorkspaceManager {
             return .save
         case .alertSecondButtonReturn:
             return .cancel
-        default:
+        case .alertThirdButtonReturn:
             return .discard
+        default:
+            // Abort / unexpected response (e.g. AppKit refusing to nest
+            // runModal inside a SwiftUI binding-update cycle — see #327).
+            // Treat as Cancel so user data is never silently discarded.
+            DiagnosticLog.log("promptToSaveChanges: modal aborted, treating as Cancel")
+            return .cancel
         }
     }
 

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -70,9 +70,22 @@ final class WorkspaceManager {
 
     var currentFileURL: URL?
     var currentFileText: String = ""
-    var isDirty: Bool = false
     var currentViewMode: ViewMode = WorkspaceManager.defaultViewModeForOpenedFile
     var currentConflictOutcome: ConflictResolver.Outcome?
+
+    /// The currently-active open document, if any. Source of truth for
+    /// dirty/clean state — see `isDirty`.
+    var activeDocument: OpenDocument? {
+        guard let idx = activeDocumentIndex else { return nil }
+        return openDocuments[idx]
+    }
+
+    /// True when the active document has unsaved changes.
+    /// Computed from `OpenDocument.isDirty` (text != lastSavedText). No
+    /// parallel shadow state — single source of truth lives on the doc itself.
+    var isDirty: Bool {
+        activeDocument?.isDirty ?? false
+    }
 
     /// UserDefaults key for the user's last-used view mode (issue #318).
     /// Written only at explicit user-intent sites (Picker, ⌘1/⌘2, View menu);
@@ -152,7 +165,6 @@ final class WorkspaceManager {
     @ObservationIgnored private var treeBuildGeneration: [UUID: Int] = [:]
     @ObservationIgnored private var treeBuildTasks: [UUID: Task<Void, Never>] = [:]
     private var autoSaveWork: DispatchWorkItem?
-    private var lastSavedText: String = ""
     private var accessedURLs: Set<URL> = []
     private var hasPreparedInitialDocuments = false
 
@@ -337,8 +349,7 @@ final class WorkspaceManager {
 
     @discardableResult
     func createUntitledDocument() -> Bool {
-        guard saveFileBacked() else { return false }
-        snapshotActiveDocument()
+        guard confirmNavigationAwayFromActiveDoc() else { return false }
         let doc = OpenDocument(
             id: UUID(),
             fileURL: nil,
@@ -410,8 +421,7 @@ final class WorkspaceManager {
 
     @discardableResult
     func createDocumentWithContent(_ content: String) -> Bool {
-        guard saveFileBacked() else { return false }
-        snapshotActiveDocument()
+        guard confirmNavigationAwayFromActiveDoc() else { return false }
         let doc = OpenDocument(
             id: UUID(),
             fileURL: nil,
@@ -431,8 +441,10 @@ final class WorkspaceManager {
     func switchToDocument(_ id: UUID) -> Bool {
         guard id != activeDocumentID else { return true }
         guard openDocuments.contains(where: { $0.id == id }) else { return false }
-        guard saveFileBacked() else { return false }
-        snapshotActiveDocument()
+        guard confirmNavigationAwayFromActiveDoc() else { return false }
+        // Helper may have removed the previously-active untitled tab on Discard;
+        // the target id is unrelated and still resolves correctly.
+        guard openDocuments.contains(where: { $0.id == id }) else { return false }
         activeDocumentID = id
         restoreActiveDocument()
         return true
@@ -544,6 +556,70 @@ final class WorkspaceManager {
         return true
     }
 
+    // MARK: - Navigation Guard
+
+    /// Returns true if it's safe to navigate away from the currently active document.
+    ///
+    /// - File-backed dirty: silent-saves; on save failure shows an alert and returns false.
+    /// - Untitled dirty: presents Save/Don't Save/Cancel sheet. On Save, runs the save
+    ///   panel; cancellation of either the prompt or the save panel returns false.
+    /// - Clean / no active doc: returns true immediately.
+    ///
+    /// - Parameter removeUntitledOnDiscard: When true (default), an untitled-dirty
+    ///   active doc is removed from `openDocuments` on Discard. Pass false from
+    ///   callers that intend to replace the active tab's content in place
+    ///   (e.g. `openFile`) so the tab survives and can be reused.
+    @discardableResult
+    private func confirmNavigationAwayFromActiveDoc(removeUntitledOnDiscard: Bool = true) -> Bool {
+        snapshotActiveDocument()
+        guard let idx = activeDocumentIndex else { return true }
+        let doc = openDocuments[idx]
+
+        switch NavigationGuard.decide(for: doc) {
+        case .proceed:
+            return true
+        case .silentSave:
+            if !saveDocument(at: idx, treatCancelAsFailure: false) {
+                presentSaveFailureAlert(for: doc)
+                return false
+            }
+            return true
+        case .promptUser:
+            switch promptToSaveChanges(for: doc) {
+            case .save:
+                return saveDocument(at: idx, treatCancelAsFailure: true)
+            case .discard:
+                if removeUntitledOnDiscard {
+                    discardChanges(to: doc.id)
+                } else {
+                    resetUntitledToEmptyInPlace(at: idx)
+                }
+                return true
+            case .cancel:
+                return false
+            }
+        }
+    }
+
+    /// Resets an untitled doc to empty in place, leaving the tab so a caller
+    /// can fill it with new content. Used by `openFile`'s in-place replace path.
+    private func resetUntitledToEmptyInPlace(at idx: Int) {
+        openDocuments[idx].text = ""
+        openDocuments[idx].lastSavedText = ""
+        if activeDocumentID == openDocuments[idx].id {
+            currentFileText = ""
+        }
+    }
+
+    private func presentSaveFailureAlert(for doc: OpenDocument) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn't save “\(doc.displayName)”."
+        alert.informativeText = "Your changes are still in the editor. Try again or check disk / iCloud status."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
     // MARK: - Open File
 
     /// Opens a file by replacing the active tab's content (no new tab created).
@@ -554,8 +630,10 @@ final class WorkspaceManager {
             return switchToDocument(existing.id)
         }
 
-        // Save current file-backed document before switching
-        guard saveFileBacked() else { return false }
+        // Save (or prompt about) the active doc before swapping its content.
+        // `removeUntitledOnDiscard: false` keeps an untitled tab around so it
+        // can be re-used as the slot for the new file (preserves tab order).
+        guard confirmNavigationAwayFromActiveDoc(removeUntitledOnDiscard: false) else { return false }
 
         guard Limits.isOpenableSize(url) else {
             DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
@@ -571,19 +649,6 @@ final class WorkspaceManager {
         }
 
         if let idx = activeDocumentIndex {
-            // If the active document is dirty and untitled, prompt before replacing
-            snapshotActiveDocument()
-            let activeDoc = openDocuments[idx]
-            if activeDoc.isDirty && activeDoc.isUntitled {
-                switch promptToSaveChanges(for: activeDoc) {
-                case .save:
-                    guard saveDocument(at: idx, treatCancelAsFailure: true) else { return false }
-                case .discard:
-                    break
-                case .cancel:
-                    return false
-                }
-            }
             // Replacing the active tab's file is a host-driven same-document revision.
             // Bump the live editor epoch before mutating text so stale callbacks from
             // the previously loaded file cannot overwrite the newly opened content.
@@ -598,8 +663,6 @@ final class WorkspaceManager {
             openDocuments[idx].viewMode = WorkspaceManager.defaultViewModeForOpenedFile
             currentFileURL = url
             currentFileText = text
-            lastSavedText = text
-            isDirty = false
             currentViewMode = openDocuments[idx].viewMode
             currentConflictOutcome = nil
             refreshConflictOutcomeForActiveDocument()
@@ -633,7 +696,7 @@ final class WorkspaceManager {
             return switchToDocument(existing.id)
         }
 
-        guard saveFileBacked() else { return false }
+        guard confirmNavigationAwayFromActiveDoc() else { return false }
 
         guard Limits.isOpenableSize(url) else {
             DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
@@ -646,8 +709,6 @@ final class WorkspaceManager {
             DiagnosticLog.log("Failed to read file: \(url.lastPathComponent)")
             return false
         }
-
-        snapshotActiveDocument()
 
         let doc = OpenDocument(
             id: UUID(),
@@ -673,8 +734,8 @@ final class WorkspaceManager {
     /// Called when the editor binding updates currentFileText.
     /// Does NOT set currentFileText — the binding already did that.
     func contentDidChange() {
-        isDirty = currentFileText != lastSavedText
-        // Sync text to the open document
+        // Sync text to the active doc — this is what `isDirty` (computed)
+        // will read on its next access.
         if let idx = activeDocumentIndex {
             openDocuments[idx].text = currentFileText
         }
@@ -691,8 +752,6 @@ final class WorkspaceManager {
         documentEpoch += 1
         WYSIWYGSession.update(documentID: activeDocumentID, epoch: documentEpoch)
         currentFileText = newText
-        lastSavedText = newText
-        isDirty = false
         if let idx = activeDocumentIndex {
             openDocuments[idx].text = newText
             openDocuments[idx].lastSavedText = newText
@@ -784,8 +843,6 @@ final class WorkspaceManager {
                 if activeDocumentIndex == openDocumentIndex {
                     currentFileURL = fileURL
                     currentFileText = updatedContent
-                    lastSavedText = updatedContent
-                    isDirty = false
                 }
             }
 
@@ -836,8 +893,6 @@ final class WorkspaceManager {
             if activeDocumentIndex == index {
                 currentFileURL = finalURL
                 currentFileText = doc.text
-                lastSavedText = doc.text
-                isDirty = false
                 if finalURL != url {
                     persistLastOpenFile(finalURL)
                 }
@@ -869,8 +924,6 @@ final class WorkspaceManager {
             if activeDocumentIndex == index {
                 currentFileURL = url
                 currentFileText = text
-                lastSavedText = text
-                isDirty = false
                 persistLastOpenFile(url)
             }
 
@@ -1663,8 +1716,6 @@ final class WorkspaceManager {
             openDocuments[index].lastSavedText = doc.text
             if activeDocumentIndex == index {
                 currentFileText = doc.text
-                lastSavedText = doc.text
-                isDirty = false
             }
             return true
         } catch {
@@ -2353,8 +2404,6 @@ final class WorkspaceManager {
                 WYSIWYGSession.update(documentID: nil, epoch: documentEpoch)
                 currentFileURL = nil
                 currentFileText = ""
-                lastSavedText = ""
-                isDirty = false
             } else {
                 let nextIndex = min(idx, openDocuments.count - 1)
                 activeDocumentID = openDocuments[nextIndex].id
@@ -2378,12 +2427,12 @@ final class WorkspaceManager {
         }
     }
 
-    /// Save current stored properties back into the openDocuments array.
+    /// Flushes the live editor buffer into the active document. `lastSavedText`
+    /// stays untouched — it's owned by save/load paths, not the live editor.
     private func snapshotActiveDocument() {
         guard let idx = activeDocumentIndex else { return }
         flushActiveEditorBuffer()
         openDocuments[idx].text = currentFileText
-        openDocuments[idx].lastSavedText = lastSavedText
         openDocuments[idx].viewMode = currentViewMode
     }
 
@@ -2411,8 +2460,6 @@ final class WorkspaceManager {
         WYSIWYGSession.update(documentID: doc.id, epoch: documentEpoch)
         currentFileURL = doc.fileURL
         currentFileText = doc.text
-        lastSavedText = doc.lastSavedText
-        isDirty = doc.isDirty
         currentViewMode = doc.viewMode
         currentConflictOutcome = doc.conflictOutcome
         if doc.fileURL != nil {
@@ -2427,8 +2474,6 @@ final class WorkspaceManager {
         activeDocumentID = doc.id
         currentFileURL = doc.fileURL
         currentFileText = doc.text
-        lastSavedText = doc.lastSavedText
-        isDirty = doc.isDirty
         currentViewMode = doc.viewMode
         currentConflictOutcome = doc.conflictOutcome
         if doc.fileURL != nil {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/NavigationGuard.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/NavigationGuard.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// What a navigation-away guard should do for a given active document.
+public enum NavigationGuardDecision: Equatable {
+    /// Doc is clean (or there is no active doc) — proceed without prompting or saving.
+    case proceed
+    /// File-backed dirty — caller should silently write to disk before navigating.
+    case silentSave
+    /// Untitled dirty — caller should present a Save / Don't Save / Cancel sheet.
+    case promptUser
+}
+
+public enum NavigationGuard {
+    /// Pure decision: given the active document's state, what should the
+    /// caller do before navigating away? Side-effecting save / prompt logic
+    /// stays at the platform layer; this function exists so the decision
+    /// itself is unit-testable without touching AppKit.
+    public static func decide(for doc: OpenDocument?) -> NavigationGuardDecision {
+        guard let doc, doc.isDirty else { return .proceed }
+        return doc.isUntitled ? .promptUser : .silentSave
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/NavigationGuardTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/NavigationGuardTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import ClearlyCore
+
+struct NavigationGuardTests {
+    @Test func cleanFileBackedDocProceeds() {
+        let doc = OpenDocument(
+            fileURL: URL(fileURLWithPath: "/tmp/x.md"),
+            text: "a",
+            lastSavedText: "a"
+        )
+        #expect(NavigationGuard.decide(for: doc) == .proceed)
+    }
+
+    @Test func cleanUntitledDocProceeds() {
+        let doc = OpenDocument(fileURL: nil, text: "", lastSavedText: "")
+        #expect(NavigationGuard.decide(for: doc) == .proceed)
+    }
+
+    @Test func dirtyFileBackedDocSilentSaves() {
+        let doc = OpenDocument(
+            fileURL: URL(fileURLWithPath: "/tmp/x.md"),
+            text: "edited",
+            lastSavedText: "original"
+        )
+        #expect(NavigationGuard.decide(for: doc) == .silentSave)
+    }
+
+    @Test func dirtyUntitledDocPromptsUser() {
+        let doc = OpenDocument(fileURL: nil, text: "draft", lastSavedText: "")
+        #expect(NavigationGuard.decide(for: doc) == .promptUser)
+    }
+
+    @Test func noActiveDocProceeds() {
+        #expect(NavigationGuard.decide(for: nil) == .proceed)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #327. Six Mac navigation paths could silently swap the active document and lose unsaved edits — sidebar click, File→Open, Recents, tab switch (for untitled docs), wiki-link click, backlink click. The dirty-prompt logic existed only in `openFile()` and was duplicated/missing elsewhere.

- **Centralized guard**: `WorkspaceManager.confirmNavigationAwayFromActiveDoc()` is now called from `openFile()`, `openFileInNewTab()`, `switchToDocument()`, `createUntitledDocument()`, `createDocumentWithContent()`. Sidebar click, File→Open, Recents, wiki-link, and backlink all route through these, so a single guard covers everything.
- **Hybrid behavior**: file-backed dirty docs silent-save (matches Notes/Bear/Obsidian); untitled dirty docs get a Save / Don't Save / Cancel sheet via `NSAlert`. Save-failure on file-backed silent-save shows an alert and aborts navigation (mirrors the iOS rule from `CLAUDE.md`).
- **Cancel rubber-banding fixed**: when the user cancels the prompt, `selectedFileURL` reverts so the sidebar highlight stops lying.
- **Unified dirty-tracking**: deleted `WorkspaceManager.isDirty` and `WorkspaceManager.lastSavedText` (parallel shadows of `OpenDocument.isDirty`/`lastSavedText`). `workspace.isDirty` is now computed from the active document — single source of truth.
- **Pure decision logic** extracted to `ClearlyCore.NavigationGuard.decide(for:)` with Swift Testing coverage (5 tests). AppKit-side prompt/save/alert machinery stays in `WorkspaceManager`.

Out of scope (per discussion): drag-and-drop file onto window (not currently implemented), tab-by-default option (Cmd-click already opens in new tab), auto-naming untitled docs (chose the prompt path instead).

## Test plan

Automated:
- [x] `swift test --package-path Packages/ClearlyCore` — 130 XCTest + 5 NavigationGuardTests pass
- [x] `xcodebuild -scheme Clearly -configuration Debug build` — succeeds

Manual (run `/verify`):
- [ ] **Sidebar click on file with untitled+dirty active doc** — Save / Don't Save / Cancel sheet appears. Save → save panel. Don't Save → tab transitions to file. Cancel → no navigation, sidebar highlight reverts.
- [ ] **Sidebar click with file-backed dirty active doc** — silent save; reopen confirms edits persisted.
- [ ] **Tab switch with untitled+dirty active doc** — prompt fires (was silently swapping before).
- [ ] **File → Open with untitled+dirty** — prompt fires.
- [ ] **Recents → pick file with untitled+dirty** — prompt fires.
- [ ] **Wiki-link click with untitled+dirty** — prompt fires.
- [ ] **Backlink click with untitled+dirty** — prompt fires.
- [ ] **Cmd+Q with multiple dirty docs** — existing per-doc prompts still fire (regression).
- [ ] **Window close (red button) with dirty docs** — existing prompts still fire (regression).
- [ ] **Save-failure simulation** (chmod -w a file, edit it, click another) — "Couldn't save" alert, navigation aborted, edits preserved in editor.