### PR TITLE
[mac] Add optional status bar with word/character counts

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -57,6 +57,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
     private var isOpeningSettingsFromMenuBar = false
 
     private let toolbarMenuItemTag = 7287
+    private let statusBarMenuItemTag = 7288
 
     private var isToolbarHidden: Bool {
         get { UserDefaults.standard.bool(forKey: "toolbarHidden") }
@@ -365,6 +366,14 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         injectGlobalSearchIfNeeded()
         injectExportPrintIfNeeded()
         applyToolbarVisibility()
+        refreshStatusBarMenuTitle()
+    }
+
+    private func refreshStatusBarMenuTitle() {
+        guard let item = NSApp.mainMenu?.item(withTitle: "View")?.submenu?
+            .items.first(where: { $0.tag == statusBarMenuItemTag }) else { return }
+        let desired = isStatusBarVisible ? "Hide Word Counts" : "Show Word Counts"
+        if item.title != desired { item.title = desired }
     }
 
     private func injectGlobalSearchIfNeeded() {
@@ -587,6 +596,11 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         let lineNumbersItem = NSMenuItem(title: "Line Numbers", action: #selector(toggleLineNumbersAction(_:)), keyEquivalent: "")
         lineNumbersItem.target = self
 
+        let statusBarTitle = isStatusBarVisible ? "Hide Word Counts" : "Show Word Counts"
+        let statusBarItem = NSMenuItem(title: statusBarTitle, action: #selector(toggleStatusBarAction(_:)), keyEquivalent: "")
+        statusBarItem.target = self
+        statusBarItem.tag = statusBarMenuItemTag
+
         let editorItem = NSMenuItem(title: "Editor", action: #selector(switchToEditorAction(_:)), keyEquivalent: "1")
         editorItem.keyEquivalentModifierMask = [.command]
         editorItem.target = self
@@ -600,6 +614,7 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
         viewMenu.insertItem(outlineItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(backlinksItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(lineNumbersItem, at: insertIndex); insertIndex += 1
+        viewMenu.insertItem(statusBarItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(.separator(), at: insertIndex); insertIndex += 1
         viewMenu.insertItem(editorItem, at: insertIndex); insertIndex += 1
         viewMenu.insertItem(previewItem, at: insertIndex); insertIndex += 1
@@ -649,6 +664,17 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValid
 
     @objc private func toggleLineNumbersAction(_ sender: Any?) {
         NotificationCenter.default.post(name: .init("ClearlyToggleLineNumbers"), object: nil)
+    }
+
+    private var isStatusBarVisible: Bool {
+        UserDefaults.standard.bool(forKey: StatusBarState.userDefaultsKey)
+    }
+
+    @objc private func toggleStatusBarAction(_ sender: Any?) {
+        // Persistence is owned by StatusBarState (via the notification
+        // observer in MacDetailColumn). The menu title refreshes on the
+        // next applicationWillUpdate tick.
+        NotificationCenter.default.post(name: .init("ClearlyToggleStatusBar"), object: nil)
     }
 
     @objc private func setPreviewFontAction(_ sender: NSMenuItem) {

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -15,6 +15,7 @@ struct EditorView: NSViewRepresentable {
     var extraTopInset: CGFloat = 0
     var showLineNumbers: Bool = false
     var jumpToLineState: JumpToLineState?
+    var statusBarState: StatusBarState?
     var needsTrafficLightClearance: Bool = false
     var contentWidthEm: CGFloat? = nil
     @Environment(\.colorScheme) private var colorScheme
@@ -427,6 +428,8 @@ struct EditorView: NSViewRepresentable {
             } else {
                 SelectionBridge.setSelection(nil, for: parent.positionSyncID)
             }
+
+            parent.statusBarState?.updateSelection(range, in: textView.string)
         }
 
         @objc func handleScrollToLine(_ notification: Notification) {

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -180,6 +180,7 @@ struct MacDetailColumn: View {
     @ObservedObject var outlineState: OutlineState
     @ObservedObject var backlinksState: BacklinksState
     @ObservedObject var jumpToLineState: JumpToLineState
+    @ObservedObject var statusBarState: StatusBarState
     @Bindable var vaultChat: VaultChatState
     @Binding var positionSyncID: String
     @Binding var showFormatPopover: Bool
@@ -256,6 +257,11 @@ struct MacDetailColumn: View {
         .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleLineNumbers"))) { _ in
             showLineNumbers.toggle()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyToggleStatusBar"))) { _ in
+            withAnimation(Theme.Motion.smooth) {
+                statusBarState.toggle()
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .init("ClearlyJumpToLine"))) { _ in
             guard workspace.currentViewMode == .edit else { return }
             withAnimation(Theme.Motion.smooth) {
@@ -269,6 +275,8 @@ struct MacDetailColumn: View {
             normalizeViewModeForExperiment()
             outlineState.parseHeadings(from: workspace.currentFileText)
             backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
+            statusBarState.resetSelection()
+            statusBarState.updateText(workspace.currentFileText)
             setupFileWatcher()
             applyPendingWikiNavigationIfNeeded()
         }
@@ -295,6 +303,7 @@ struct MacDetailColumn: View {
         .onChange(of: workspace.currentFileText) { _, text in
             fileWatcher.updateCurrentText(text)
             outlineState.parseHeadings(from: text)
+            statusBarState.updateText(text)
         }
         .onChange(of: workspace.currentFileURL) { _, _ in
             setupFileWatcher()
@@ -331,6 +340,7 @@ struct MacDetailColumn: View {
         normalizeViewModeForExperiment()
         outlineState.parseHeadings(from: workspace.currentFileText)
         backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
+        statusBarState.updateText(workspace.currentFileText)
         isFullscreen = NSApp.mainWindow?.styleMask.contains(.fullScreen) ?? false
         setupFileWatcher()
     }
@@ -405,11 +415,18 @@ struct MacDetailColumn: View {
                 .frame(maxHeight: 200)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
+
+            if statusBarState.isVisible {
+                Divider()
+                StatusBarView(state: statusBarState)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
         .animation(Theme.Motion.smooth, value: findState.isVisible)
         .animation(Theme.Motion.smooth, value: jumpToLineState.isVisible)
         .animation(Theme.Motion.smooth, value: backlinksState.isVisible)
+        .animation(Theme.Motion.smooth, value: statusBarState.isVisible)
     }
 
     private var editorPane: some View {
@@ -424,6 +441,7 @@ struct MacDetailColumn: View {
             extraTopInset: 0,
             showLineNumbers: showLineNumbers,
             jumpToLineState: jumpToLineState,
+            statusBarState: statusBarState,
             needsTrafficLightClearance: false,
             contentWidthEm: contentWidthEm
         )

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -18,6 +18,7 @@ struct MacRootView: View {
     @StateObject private var outlineState = OutlineState()
     @StateObject private var backlinksState = BacklinksState()
     @StateObject private var jumpToLineState = JumpToLineState()
+    @StateObject private var statusBarState = StatusBarState()
     @State private var vaultChat = VaultChatState()
 
     var body: some View {
@@ -49,6 +50,7 @@ struct MacRootView: View {
                     outlineState: outlineState,
                     backlinksState: backlinksState,
                     jumpToLineState: jumpToLineState,
+                    statusBarState: statusBarState,
                     vaultChat: vaultChat,
                     positionSyncID: $positionSyncID,
                     showFormatPopover: $showFormatPopover

--- a/Clearly/Native/StatusBarView.swift
+++ b/Clearly/Native/StatusBarView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import ClearlyCore
+
+struct StatusBarView: View {
+    @ObservedObject var state: StatusBarState
+
+    var body: some View {
+        Text(label(for: state.counts))
+            .font(Theme.Typography.findCount)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.sm)
+            .frame(height: 28)
+            .accessibilityElement(children: .combine)
+    }
+
+    private func label(for c: MarkdownStats.Counts) -> String {
+        if c.totalWords == 0 && c.totalChars == 0 {
+            return "Empty document"
+        }
+        if c.hasSelection {
+            return "\(formatted(c.selectionWords)) \(pluralize("word", c.selectionWords)) selected"
+                + " · \(formatted(c.selectionChars)) \(pluralize("character", c.selectionChars))"
+        }
+        return "\(formatted(c.totalWords)) \(pluralize("word", c.totalWords))"
+            + " · \(formatted(c.totalChars)) \(pluralize("character", c.totalChars))"
+            + " · \(readingTime(seconds: c.totalReadingSeconds))"
+    }
+
+    private func formatted(_ n: Int) -> String {
+        n.formatted(.number)
+    }
+
+    private func pluralize(_ word: String, _ n: Int) -> String {
+        n == 1 ? word : "\(word)s"
+    }
+
+    private func readingTime(seconds: Int) -> String {
+        if seconds < 30 { return "Less than 1 min read" }
+        let minutes = Int((Double(seconds) / 60.0).rounded())
+        let bounded = max(1, minutes)
+        return "\(bounded) min read"
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/StatusBarState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/StatusBarState.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public final class StatusBarState: ObservableObject {
+    public static let userDefaultsKey = "statusBarVisible"
+
+    @Published public var isVisible: Bool {
+        didSet {
+            UserDefaults.standard.set(isVisible, forKey: Self.userDefaultsKey)
+            if isVisible {
+                recomputeAll()
+            }
+        }
+    }
+    @Published public private(set) var counts: MarkdownStats.Counts = .empty
+
+    private var lastText: String = ""
+    private var lastSelection: NSRange = NSRange(location: 0, length: 0)
+    private var cachedTotals: MarkdownStats.Counts = .empty
+    private var hasCachedTotals = false
+
+    public init() {
+        self.isVisible = UserDefaults.standard.bool(forKey: Self.userDefaultsKey)
+    }
+
+    public func toggle() {
+        isVisible.toggle()
+    }
+
+    /// Replace the cached document text and recompute. Selection length is
+    /// preserved if it still fits inside the new text; otherwise it collapses.
+    public func updateText(_ text: String) {
+        lastText = text
+        hasCachedTotals = false
+        let nsLength = (text as NSString).length
+        if lastSelection.location + lastSelection.length > nsLength {
+            lastSelection = NSRange(location: 0, length: 0)
+        }
+        guard isVisible else { return }
+        recomputeAll()
+    }
+
+    /// Replace just the selection range. Caller passes the current text so
+    /// the cache stays consistent (selection events fire faster than the
+    /// debounced text-binding write).
+    public func updateSelection(_ range: NSRange, in text: String) {
+        lastText = text
+        lastSelection = range
+        guard isVisible else {
+            hasCachedTotals = false
+            return
+        }
+        if hasCachedTotals {
+            recomputeSelectionOnly()
+        } else {
+            recomputeAll()
+        }
+    }
+
+    /// Clear selection without changing the cached text — used when the
+    /// document switches or the editor is dismissed.
+    public func resetSelection() {
+        lastSelection = NSRange(location: 0, length: 0)
+        guard isVisible else { return }
+        if hasCachedTotals {
+            recomputeSelectionOnly()
+        } else {
+            recomputeAll()
+        }
+    }
+
+    private func recomputeAll() {
+        counts = MarkdownStats.compute(text: lastText, selectedRange: lastSelection)
+        cachedTotals = MarkdownStats.Counts(
+            totalWords: counts.totalWords,
+            totalChars: counts.totalChars,
+            totalReadingSeconds: counts.totalReadingSeconds,
+            selectionWords: 0,
+            selectionChars: 0,
+            hasSelection: false
+        )
+        hasCachedTotals = true
+    }
+
+    private func recomputeSelectionOnly() {
+        let selection = selectionCounts()
+        counts = MarkdownStats.Counts(
+            totalWords: cachedTotals.totalWords,
+            totalChars: cachedTotals.totalChars,
+            totalReadingSeconds: cachedTotals.totalReadingSeconds,
+            selectionWords: selection.words,
+            selectionChars: selection.chars,
+            hasSelection: selection.hasSelection
+        )
+    }
+
+    private func selectionCounts() -> (words: Int, chars: Int, hasSelection: Bool) {
+        let nsText = lastText as NSString
+        guard lastSelection.length > 0,
+              lastSelection.location >= 0,
+              lastSelection.location + lastSelection.length <= nsText.length else {
+            return (0, 0, false)
+        }
+
+        let selectedText = nsText.substring(with: lastSelection)
+        let selected = MarkdownStats.compute(text: selectedText, selectedRange: NSRange())
+        return (selected.totalWords, selected.totalChars, true)
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Stats/MarkdownStats.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Stats/MarkdownStats.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+public enum MarkdownStats {
+    public struct Counts: Equatable {
+        public let totalWords: Int
+        public let totalChars: Int
+        public let totalReadingSeconds: Int
+        public let selectionWords: Int
+        public let selectionChars: Int
+        public let hasSelection: Bool
+
+        public static let empty = Counts(
+            totalWords: 0, totalChars: 0, totalReadingSeconds: 0,
+            selectionWords: 0, selectionChars: 0, hasSelection: false
+        )
+
+        public init(
+            totalWords: Int, totalChars: Int, totalReadingSeconds: Int,
+            selectionWords: Int, selectionChars: Int, hasSelection: Bool
+        ) {
+            self.totalWords = totalWords
+            self.totalChars = totalChars
+            self.totalReadingSeconds = totalReadingSeconds
+            self.selectionWords = selectionWords
+            self.selectionChars = selectionChars
+            self.hasSelection = hasSelection
+        }
+    }
+
+    public static let defaultWordsPerMinute = 265
+
+    public static func compute(
+        text: String,
+        selectedRange: NSRange,
+        wordsPerMinute: Int = defaultWordsPerMinute
+    ) -> Counts {
+        let strippedTotal = strip(text)
+        let totalWords = countWords(strippedTotal)
+        let totalChars = strippedTotal.count
+        let wpm = max(wordsPerMinute, 1)
+        let totalReadingSeconds = Int(
+            (Double(totalWords) / Double(wpm) * 60.0).rounded(.up)
+        )
+
+        let nsText = text as NSString
+        let hasSelection = selectedRange.length > 0
+            && selectedRange.location >= 0
+            && selectedRange.location + selectedRange.length <= nsText.length
+
+        let selectionWords: Int
+        let selectionChars: Int
+        if hasSelection {
+            let selectedSubstring = nsText.substring(with: selectedRange)
+            let strippedSelection = strip(selectedSubstring)
+            selectionWords = countWords(strippedSelection)
+            selectionChars = strippedSelection.count
+        } else {
+            selectionWords = 0
+            selectionChars = 0
+        }
+
+        return Counts(
+            totalWords: totalWords,
+            totalChars: totalChars,
+            totalReadingSeconds: totalReadingSeconds,
+            selectionWords: selectionWords,
+            selectionChars: selectionChars,
+            hasSelection: hasSelection
+        )
+    }
+
+    // MARK: - Word counting
+
+    private static func countWords(_ text: String) -> Int {
+        var count = 0
+        text.enumerateSubstrings(
+            in: text.startIndex..<text.endIndex,
+            options: [.byWords, .localized]
+        ) { substring, _, _, _ in
+            if let s = substring, !s.isEmpty { count += 1 }
+        }
+        return count
+    }
+
+    // MARK: - Markdown stripping
+
+    /// Returns a plain-text approximation of the input markdown suitable for
+    /// counting words and characters. Drops syntactic markers (headings,
+    /// emphasis, list bullets, code fences, etc.) and link/image URL targets;
+    /// preserves the human-readable content (link labels, code body, etc.).
+    static func strip(_ input: String) -> String {
+        var s = input
+
+        // 1. Drop YAML frontmatter at the very top of the document.
+        s = stripFrontmatter(s)
+
+        // 2. Replace fenced code blocks with their inner text (keep code as
+        //    content; matches iA Writer / Bear behavior).
+        s = stripFencedCodeBlocks(s)
+
+        // 3. Replace inline code spans with their inner text.
+        s = replace(s, pattern: "`([^`\\n]*)`", template: "$1")
+
+        // 4. Strip raw HTML tags.
+        s = replace(s, pattern: "<[^>]+>", template: "")
+
+        // 5. Wiki-links: [[Page]], [[Page#heading]], [[Page|alias]],
+        //    [[Page#heading|alias]] → alias (or page+heading text).
+        s = stripWikiLinks(s)
+
+        // 6. Image syntax: ![alt](url) → drop entirely (alt text and URL
+        //    are not user-visible prose).
+        s = replace(s, pattern: "!\\[[^\\]]*\\]\\([^)]*\\)", template: "")
+        s = replace(s, pattern: "!\\[[^\\]]*\\]\\[[^\\]]*\\]", template: "")
+
+        // 7. Link syntax: [label](url) → label.
+        s = replace(s, pattern: "\\[([^\\]]+)\\]\\([^)]*\\)", template: "$1")
+        //    Reference links: [label][id] → label.
+        s = replace(s, pattern: "\\[([^\\]]+)\\]\\[[^\\]]*\\]", template: "$1")
+        //    Reference link definitions: [id]: url "title" — drop entire line.
+        s = replace(
+            s,
+            pattern: "(?m)^\\s*\\[[^\\]]+\\]:\\s*\\S.*$",
+            template: ""
+        )
+
+        // 8. Footnote references and definitions.
+        s = replace(s, pattern: "\\[\\^[^\\]]+\\]", template: "")
+
+        // 9. ATX heading markers.
+        s = replace(s, pattern: "(?m)^\\s{0,3}#{1,6}\\s+", template: "")
+
+        // 10. Setext heading underlines (lines of all = or -).
+        s = replace(s, pattern: "(?m)^[=\\-]{3,}\\s*$", template: "")
+        // Horizontal rules of *.
+        s = replace(s, pattern: "(?m)^\\s*\\*{3,}\\s*$", template: "")
+
+        // 11. Blockquote markers.
+        s = replace(s, pattern: "(?m)^[ \\t]*>+\\s?", template: "")
+
+        // 12. Task list markers, then list bullets / ordered list numbers.
+        s = replace(
+            s,
+            pattern: "(?m)^[ \\t]*(?:[-*+]|\\d+\\.)\\s+\\[[ xX]\\]\\s*",
+            template: ""
+        )
+        s = replace(
+            s,
+            pattern: "(?m)^[ \\t]*(?:[-*+]|\\d+\\.)\\s+",
+            template: ""
+        )
+
+        // 13. Emphasis / strong / strike / highlight. Strip in pair-aware
+        //     order so triple markers degrade cleanly.
+        s = replace(s, pattern: "\\*\\*\\*([^*\\n]+?)\\*\\*\\*", template: "$1")
+        s = replace(s, pattern: "\\*\\*([^*\\n]+?)\\*\\*", template: "$1")
+        s = replace(s, pattern: "\\*([^*\\n]+?)\\*", template: "$1")
+        s = replace(s, pattern: "~~([^~\\n]+?)~~", template: "$1")
+        s = replace(s, pattern: "==([^=\\n]+?)==", template: "$1")
+
+        return s
+    }
+
+    private static func stripFrontmatter(_ s: String) -> String {
+        // YAML frontmatter must start at the very first character.
+        guard s.hasPrefix("---\n") || s.hasPrefix("---\r\n") else { return s }
+        let pattern = "\\A---\\r?\\n[\\s\\S]*?\\r?\\n---\\r?\\n?"
+        return replace(s, pattern: pattern, template: "")
+    }
+
+    private static func stripFencedCodeBlocks(_ s: String) -> String {
+        // (?ms) so . matches newlines and ^$ match line boundaries.
+        // Matches ``` or ~~~ fences with optional info string on the same line.
+        let pattern = "(?ms)^[ \\t]{0,3}(```+|~~~+)[^\\n]*\\n([\\s\\S]*?)\\n[ \\t]{0,3}\\1[ \\t]*$"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return s }
+        let nsString = s as NSString
+        let range = NSRange(location: 0, length: nsString.length)
+
+        var output = ""
+        var cursor = 0
+        regex.enumerateMatches(in: s, options: [], range: range) { match, _, _ in
+            guard let match else { return }
+            let pre = NSRange(location: cursor, length: match.range.location - cursor)
+            output.append(nsString.substring(with: pre))
+            if match.numberOfRanges >= 3 {
+                let inner = match.range(at: 2)
+                if inner.location != NSNotFound {
+                    output.append(nsString.substring(with: inner))
+                }
+            }
+            cursor = match.range.location + match.range.length
+        }
+        if cursor < nsString.length {
+            output.append(nsString.substring(with: NSRange(location: cursor, length: nsString.length - cursor)))
+        }
+        return output
+    }
+
+    private static func stripWikiLinks(_ s: String) -> String {
+        let pattern = "\\[\\[([^\\]\\|#\\n]+)(?:#([^\\]\\|\\n]+))?(?:\\|([^\\]\\n]+))?\\]\\]"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return s }
+        let nsString = s as NSString
+        let range = NSRange(location: 0, length: nsString.length)
+
+        var output = ""
+        var cursor = 0
+        regex.enumerateMatches(in: s, options: [], range: range) { match, _, _ in
+            guard let match else { return }
+            let pre = NSRange(location: cursor, length: match.range.location - cursor)
+            output.append(nsString.substring(with: pre))
+
+            let aliasRange = match.range(at: 3)
+            let headingRange = match.range(at: 2)
+            let pageRange = match.range(at: 1)
+
+            if aliasRange.location != NSNotFound {
+                output.append(nsString.substring(with: aliasRange))
+            } else if headingRange.location != NSNotFound {
+                let page = pageRange.location != NSNotFound
+                    ? nsString.substring(with: pageRange) : ""
+                let heading = nsString.substring(with: headingRange)
+                output.append(page.isEmpty ? heading : "\(page) \(heading)")
+            } else if pageRange.location != NSNotFound {
+                output.append(nsString.substring(with: pageRange))
+            }
+
+            cursor = match.range.location + match.range.length
+        }
+        if cursor < nsString.length {
+            output.append(nsString.substring(with: NSRange(location: cursor, length: nsString.length - cursor)))
+        }
+        return output
+    }
+
+    private static func replace(_ s: String, pattern: String, template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return s }
+        let range = NSRange(location: 0, length: (s as NSString).length)
+        return regex.stringByReplacingMatches(in: s, options: [], range: range, withTemplate: template)
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownStatsTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownStatsTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import ClearlyCore
+
+final class MarkdownStatsTests: XCTestCase {
+    // MARK: - Word counting
+
+    func testCountsPlainProse() {
+        let counts = MarkdownStats.compute(text: "Hello world!", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 2)
+        XCTAssertEqual(counts.totalChars, "Hello world!".count)
+        XCTAssertFalse(counts.hasSelection)
+    }
+
+    func testEmptyText() {
+        let counts = MarkdownStats.compute(text: "", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 0)
+        XCTAssertEqual(counts.totalChars, 0)
+        XCTAssertEqual(counts.totalReadingSeconds, 0)
+    }
+
+    func testWhitespaceOnlyText() {
+        let counts = MarkdownStats.compute(text: "   \n\n  \t", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 0)
+    }
+
+    // MARK: - Markdown stripping
+
+    func testStripsBoldAndItalic() {
+        let counts = MarkdownStats.compute(text: "**bold** and *italic*", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 3)
+        XCTAssertEqual(counts.totalChars, "bold and italic".count)
+    }
+
+    func testStripsTripleEmphasis() {
+        let counts = MarkdownStats.compute(text: "***hello***", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 1)
+        XCTAssertEqual(counts.totalChars, 5)
+    }
+
+    func testStripsStrikethroughAndHighlight() {
+        let counts = MarkdownStats.compute(text: "~~gone~~ ==kept==", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 2)
+        XCTAssertEqual(counts.totalChars, "gone kept".count)
+    }
+
+    func testStripsAtxHeading() {
+        let counts = MarkdownStats.compute(text: "## Heading text", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 2)
+        XCTAssertEqual(counts.totalChars, "Heading text".count)
+    }
+
+    func testStripsBlockquoteAndList() {
+        let text = """
+        > quoted thought
+        - first
+        - second
+        1. ordered
+        """
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 5)
+    }
+
+    func testStripsTaskListMarkers() {
+        let text = "- [ ] todo one\n- [x] done two"
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 4)
+    }
+
+    func testKeepsLinkLabelDropsURL() {
+        let counts = MarkdownStats.compute(
+            text: "Click [the docs](https://example.com/path/to/page).",
+            selectedRange: NSRange()
+        )
+        XCTAssertEqual(counts.totalWords, 3)
+        XCTAssertEqual(counts.totalChars, "Click the docs.".count)
+    }
+
+    func testDropsImageEntirely() {
+        let counts = MarkdownStats.compute(
+            text: "before ![alt text](image.png) after",
+            selectedRange: NSRange()
+        )
+        XCTAssertEqual(counts.totalWords, 2)
+    }
+
+    func testWikiLinkPlainAndAlias() {
+        let plain = MarkdownStats.compute(text: "see [[Page]]", selectedRange: NSRange())
+        XCTAssertEqual(plain.totalWords, 2)
+        XCTAssertEqual(plain.totalChars, "see Page".count)
+
+        let aliased = MarkdownStats.compute(text: "see [[Page|other name]]", selectedRange: NSRange())
+        XCTAssertEqual(aliased.totalWords, 3)
+        XCTAssertEqual(aliased.totalChars, "see other name".count)
+    }
+
+    func testStripsFencedCodeKeepsContent() {
+        let text = """
+        intro
+        ```swift
+        let x = 1
+        ```
+        outro
+        """
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 5)
+    }
+
+    func testStripsInlineCode() {
+        let counts = MarkdownStats.compute(text: "use `let x = 1` here", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 5)
+    }
+
+    func testStripsFrontmatter() {
+        let text = """
+        ---
+        title: Hello
+        author: Josh
+        ---
+        body words here
+        """
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertEqual(counts.totalWords, 3)
+    }
+
+    func testStripsHTMLTags() {
+        let counts = MarkdownStats.compute(
+            text: "<p>html <strong>chunk</strong> here</p>",
+            selectedRange: NSRange()
+        )
+        XCTAssertEqual(counts.totalWords, 3)
+    }
+
+    // MARK: - Grapheme correctness
+
+    func testEmojiCountsAsSingleCharacter() {
+        let counts = MarkdownStats.compute(text: "👨‍👩‍👧", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalChars, 1)
+    }
+
+    func testFlagEmojiCountsAsSingleCharacter() {
+        let counts = MarkdownStats.compute(text: "🇺🇸", selectedRange: NSRange())
+        XCTAssertEqual(counts.totalChars, 1)
+    }
+
+    // MARK: - Reading time
+
+    func testReadingTimeUnderThirtySeconds() {
+        let text = String(repeating: "word ", count: 50) // 50 words → 50/265*60 ≈ 11s
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertLessThan(counts.totalReadingSeconds, 30)
+    }
+
+    func testReadingTimeRoundsUp() {
+        let text = String(repeating: "word ", count: 266) // 266/265*60 ≈ 60.2s → 61s
+        let counts = MarkdownStats.compute(text: text, selectedRange: NSRange())
+        XCTAssertGreaterThan(counts.totalReadingSeconds, 60)
+    }
+
+    // MARK: - Selection
+
+    func testSelectionCountsSubsetOfTotals() {
+        let text = "Hello world from Clearly"
+        let nsText = text as NSString
+        let range = nsText.range(of: "world from")
+        let counts = MarkdownStats.compute(text: text, selectedRange: range)
+        XCTAssertTrue(counts.hasSelection)
+        XCTAssertEqual(counts.selectionWords, 2)
+        XCTAssertEqual(counts.selectionChars, "world from".count)
+        XCTAssertEqual(counts.totalWords, 4)
+    }
+
+    func testSelectionRespectsMarkdownStripping() {
+        let text = "**Hello world**"
+        let range = NSRange(location: 0, length: (text as NSString).length)
+        let counts = MarkdownStats.compute(text: text, selectedRange: range)
+        XCTAssertEqual(counts.selectionWords, 2)
+        XCTAssertEqual(counts.selectionChars, "Hello world".count)
+    }
+
+    func testZeroLengthSelectionIsNotCounted() {
+        let counts = MarkdownStats.compute(
+            text: "Hello",
+            selectedRange: NSRange(location: 2, length: 0)
+        )
+        XCTAssertFalse(counts.hasSelection)
+    }
+
+    func testOutOfBoundsSelectionIsIgnored() {
+        let counts = MarkdownStats.compute(
+            text: "abc",
+            selectedRange: NSRange(location: 0, length: 99)
+        )
+        XCTAssertFalse(counts.hasSelection)
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/StatusBarStateTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/StatusBarStateTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import ClearlyCore
+
+final class StatusBarStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: StatusBarState.userDefaultsKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: StatusBarState.userDefaultsKey)
+        super.tearDown()
+    }
+
+    func testHiddenUpdatesDoNotPublishCountsUntilShown() {
+        UserDefaults.standard.set(false, forKey: StatusBarState.userDefaultsKey)
+        let state = StatusBarState()
+        let text = "Hello world"
+
+        state.updateText(text)
+        state.updateSelection((text as NSString).range(of: "world"), in: text)
+
+        XCTAssertEqual(state.counts, .empty)
+
+        state.toggle()
+
+        XCTAssertEqual(state.counts.totalWords, 2)
+        XCTAssertEqual(state.counts.selectionWords, 1)
+        XCTAssertTrue(state.counts.hasSelection)
+    }
+
+    func testHiddenTextChangeRecomputesWhenShownAgain() {
+        UserDefaults.standard.set(true, forKey: StatusBarState.userDefaultsKey)
+        let state = StatusBarState()
+
+        state.updateText("one two")
+        XCTAssertEqual(state.counts.totalWords, 2)
+
+        state.toggle()
+        state.updateText("one two three")
+        XCTAssertEqual(state.counts.totalWords, 2)
+
+        state.toggle()
+        XCTAssertEqual(state.counts.totalWords, 3)
+    }
+
+    func testSelectionChangesKeepDocumentTotals() {
+        UserDefaults.standard.set(true, forKey: StatusBarState.userDefaultsKey)
+        let state = StatusBarState()
+        let text = "**Hello** world from Clearly"
+
+        state.updateText(text)
+        state.updateSelection((text as NSString).range(of: "world from"), in: text)
+
+        XCTAssertEqual(state.counts.totalWords, 4)
+        XCTAssertEqual(state.counts.totalChars, "Hello world from Clearly".count)
+        XCTAssertEqual(state.counts.selectionWords, 2)
+        XCTAssertEqual(state.counts.selectionChars, "world from".count)
+
+        state.resetSelection()
+        XCTAssertEqual(state.counts.totalWords, 4)
+        XCTAssertFalse(state.counts.hasSelection)
+    }
+}


### PR DESCRIPTION
## Summary

- New View → **Show Word Counts** toggle (off by default, persists globally via `UserDefaults`) reveals a centered status bar at the bottom of every document.
- Bar shows `words · characters · N min read` (265 WPM, "Less than 1 min" under 30 s); when text is selected, the totals are replaced with selection-only counts. Markdown is stripped before counting so `**bold**` reads as 1 word / 4 chars.
- Implemented as `MarkdownStats` + `StatusBarState` in `ClearlyCore` with a SwiftUI `StatusBarView` injected into `MacDetailColumn` below the editor/preview ZStack — same numbers in both modes since they're sourced from the raw document text.
- Selection counts wire through the existing `EditorView.Coordinator.textViewDidChangeSelection` hook.
- 27 new unit tests covering markdown stripping, grapheme correctness (emoji = 1 char), reading-time rounding, selection bounds, and the hidden-when-off recompute behavior.

## Test plan
- [x] `swift test --package-path Packages/ClearlyCore --filter "ClearlyCoreTests.(MarkdownStats|StatusBarState)Tests"` — 27/27 pass.
- [x] `xcodebuild -scheme Clearly -configuration Debug build` clean.
- [ ] Open `Shared/Resources/demo.md`, toggle View → Show Word Counts, confirm counts appear and match across ⌘1/⌘2.
- [ ] Select a paragraph — totals swap to selection counts; deselect — totals return.
- [ ] Quit and relaunch — toggle state persists.
- [ ] Empty document shows "Empty document".