### PR TITLE
[mac] Auto-bind Chat to first vault when none is active

### DIFF
--- a/Clearly/VaultChat/VaultChatCoordinator.swift
+++ b/Clearly/VaultChat/VaultChatCoordinator.swift
@@ -17,7 +17,8 @@ enum VaultChatCoordinator {
             chat.hide()
             return
         }
-        guard let vaultURL = workspace.activeLocation?.url else {
+        let vaultURL = workspace.activeLocation?.url ?? workspace.locations.first?.url
+        guard let vaultURL else {
             presentError("Open a vault to start chatting.")
             return
         }


### PR DESCRIPTION
## Summary
- Hitting ⌃⌘A with no file open showed "Open a vault to start chatting." even when vaults were registered. Now `VaultChatCoordinator.startChat` falls back to `workspace.locations.first?.url` and only alerts when zero vaults are registered.
- Chat-only change: does not mutate `WorkspaceManager.activeLocation`, so the sidebar/editor stay put. The reactive rebind on active-vault change still wins when the user later opens a file.

## Test plan
- [ ] Zero vaults: closing all files and hitting ⌃⌘A still shows the alert.
- [ ] One vault, no file open: ⌃⌘A opens Chat bound to that vault, no alert.
- [ ] Multiple vaults, no file open: ⌃⌘A opens Chat bound to the top sidebar vault, no alert.
- [ ] File open in vault B: ⌃⌘A binds Chat to vault B, not `locations.first`.
- [ ] ⌃⌘A while Chat is visible still toggles it closed.