### PR TITLE
[mac] fix: ⌘Z and content placement in WYSIWYG preview

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -118,6 +118,7 @@ struct EditorView: NSViewRepresentable {
         context.coordinator.gutterView = gutter
 
         context.coordinator.textView = textView
+        WorkspaceManager.shared.activeEditorTextView = textView
         context.coordinator.findState = findState
         context.coordinator.outlineState = outlineState
         if let findState {
@@ -203,6 +204,10 @@ struct EditorView: NSViewRepresentable {
 
     static func dismantleNSView(_ container: NSView, coordinator: Coordinator) {
         NotificationCenter.default.removeObserver(coordinator)
+        if let textView = coordinator.textView,
+           WorkspaceManager.shared.activeEditorTextView === textView {
+            WorkspaceManager.shared.activeEditorTextView = nil
+        }
         DiagnosticLog.log("dismantleNSView: EditorView torn down")
     }
 

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -625,7 +625,7 @@ struct MacDetailColumn: View {
                 .replacingOccurrences(of: "+ [x]", with: "+ [ ]")
                 .replacingOccurrences(of: "+ [X]", with: "+ [ ]")
         }
-        workspace.currentFileText = lines.joined(separator: "\n")
+        workspace.applyExternalText(lines.joined(separator: "\n"), actionName: "Toggle Task")
     }
 
     private func resolveWikiLink(_ target: String, in vaultRoot: URL?) -> URL? {

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -66,6 +66,7 @@ struct SettingsView: View {
     private var generalSettings: some View {
         Form {
             Toggle("Editable preview (experimental)", isOn: $wysiwygExperimentEnabled)
+                .help("Edit directly in the rendered preview. Complex markdown (footnotes, math, raw HTML) may be reformatted on save.")
             Picker("Appearance", selection: $themePreference) {
                 Text("System").tag("system")
                 Text("Light").tag("light")

--- a/Clearly/WYSIWYGView.swift
+++ b/Clearly/WYSIWYGView.swift
@@ -164,8 +164,13 @@ struct WYSIWYGView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ webView: WYSIWYGWebView, coordinator: Coordinator) {
+        // Flush BEFORE marking dismantled so the session's pending undo lands
+        // on the editor's stack — switching mode unmounts WYSIWYG, and ⌘Z
+        // after the switch is the user's only recovery if a save fires next.
+        coordinator.flushSessionUndo()
         coordinator.isDismantled = true
         coordinator.removePasteMonitor()
+        coordinator.removeUndoMonitor()
         NotificationCenter.default.removeObserver(coordinator)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "wysiwyg")
     }
@@ -213,6 +218,17 @@ struct WYSIWYGView: NSViewRepresentable {
         /// outer WKWebView.becomeFirstResponder override doesn't see Cmd+V
         /// directly — WKWebContentView (private) is the actual first-responder.
         private var pasteEventMonitor: Any?
+        /// Mirror of the paste monitor for ⌘Z / ⌘⇧Z. macOS dispatches these as
+        /// menu key-equivalents before delivering keyDown to the focused view,
+        /// so the system Edit menu eats them and Tiptap's Mod-z keymap never
+        /// fires. We intercept and route to Tiptap's commands.undo/redo.
+        private var undoEventMonitor: Any?
+        /// Source-text snapshot captured on the first docChanged after the
+        /// view mounts. When the view dismantles (mode switch / window close),
+        /// one undo entry registers on the editor's NSTextView so ⌘Z reverts
+        /// the WYSIWYG visit's changes once the user is back in edit mode.
+        /// Inside preview, Tiptap's own history handles ⌘Z directly.
+        private var sessionStartText: String?
 
         init(parent: WYSIWYGView) {
             self.parent = parent
@@ -220,12 +236,20 @@ struct WYSIWYGView: NSViewRepresentable {
 
         deinit {
             removePasteMonitor()
+            removeUndoMonitor()
         }
 
         func removePasteMonitor() {
             if let monitor = pasteEventMonitor {
                 NSEvent.removeMonitor(monitor)
                 pasteEventMonitor = nil
+            }
+        }
+
+        func removeUndoMonitor() {
+            if let monitor = undoEventMonitor {
+                NSEvent.removeMonitor(monitor)
+                undoEventMonitor = nil
             }
         }
 
@@ -326,6 +350,40 @@ struct WYSIWYGView: NSViewRepresentable {
                     }
                     return event
                 }
+
+                // ⌘Z / ⌘⇧Z: macOS dispatches these as menu key-equivalents and
+                // the system Edit menu's Undo eats them before keyDown reaches
+                // WKWebContentView, so Tiptap's Mod-z keymap never fires.
+                // Intercept here when the WKWebView owns first-responder and
+                // route to Tiptap's history via the JS bridge.
+                undoEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                    guard let self,
+                          !self.isDismantled,
+                          self.isReady,
+                          event.charactersIgnoringModifiers?.lowercased() == "z",
+                          let webView = self.webView,
+                          webView.window?.isKeyWindow == true else {
+                        return event
+                    }
+                    // Use .contains rather than `mods == .command` so caps lock
+                    // / numeric pad / function bits don't cause the equality
+                    // check to silently miss real ⌘Z / ⌘⇧Z presses. Reject
+                    // ⌘⌥Z and ⌘⌃Z so we don't shadow other shortcuts.
+                    let mods = event.modifierFlags
+                    guard mods.contains(.command),
+                          !mods.contains(.option),
+                          !mods.contains(.control) else {
+                        return event
+                    }
+                    guard let fr = webView.window?.firstResponder as? NSView,
+                          fr.isDescendant(of: webView) else {
+                        return event
+                    }
+                    let command = mods.contains(.shift) ? "redo" : "undo"
+                    DiagnosticLog.log("WYSIWYG: routing ⌘Z/⌘⇧Z → \(command)")
+                    self.call(function: "applyCommand", payload: ["command": command])
+                    return nil
+                }
             }
         }
 
@@ -384,12 +442,13 @@ struct WYSIWYGView: NSViewRepresentable {
             parent.findState?.activeMode = .wysiwyg
             guard isReady else { return }
 
-            // Detect document switches so the synchronous flush path doesn't
-            // deliver the previous document's lastSyncedText before the first
-            // docChanged from the new document arrives.
-            if parent.documentID != lastKnownDocumentID {
+            // Detect document switches so document-scoped state from the
+            // previous tab does not leak into the next one.
+            let didChangeDocument = parent.documentID != lastKnownDocumentID
+            if didChangeDocument {
                 lastKnownDocumentID = parent.documentID
                 hasReceivedDocChanged = false
+                sessionStartText = nil
             }
 
             let appearance = parent.colorScheme == .dark ? "dark" : "light"
@@ -408,7 +467,7 @@ struct WYSIWYGView: NSViewRepresentable {
 
             applyContentWidthIfNeeded()
 
-            if parent.text != lastSyncedText {
+            if didChangeDocument || parent.text != lastSyncedText {
                 lastSyncedText = parent.text
                 call(function: "setDocument", payload: ["markdown": parent.text, "epoch": parent.documentEpoch])
             }
@@ -571,6 +630,9 @@ struct WYSIWYGView: NSViewRepresentable {
 
             let apply = { [weak self] in
                 guard let self, !self.isDismantled else { return }
+                if self.sessionStartText == nil {
+                    self.sessionStartText = self.parent.text
+                }
                 self.parent.text = markdown
                 if markDirty {
                     WorkspaceManager.shared.contentDidChange()
@@ -582,6 +644,25 @@ struct WYSIWYGView: NSViewRepresentable {
             } else {
                 DispatchQueue.main.async(execute: apply)
             }
+        }
+
+        /// Register one undo entry on the editor's NSTextView covering this
+        /// WYSIWYG visit so ⌘Z reverts everything once the user is back in
+        /// edit mode. Called from `dismantleNSView` — the WYSIWYG view is
+        /// only unmounted on mode switch / window close, so one entry per
+        /// visit is the natural granularity.
+        func flushSessionUndo() {
+            guard let startText = sessionStartText else { return }
+            sessionStartText = nil
+            let endText = parent.text
+            guard startText != endText else { return }
+            guard let textView = WorkspaceManager.shared.activeEditorTextView,
+                  let undoManager = textView.undoManager else { return }
+            let actionName = "WYSIWYG Edit"
+            undoManager.registerUndo(withTarget: WorkspaceManager.shared) { workspace in
+                workspace.applyExternalText(startText, actionName: actionName)
+            }
+            undoManager.setActionName(actionName)
         }
 
         private func mountEditor() {
@@ -628,6 +709,15 @@ struct WYSIWYGView: NSViewRepresentable {
                       let markdown = body["markdown"] as? String else { return }
                 hasReceivedDocChanged = true
                 applyEditorMarkdown(markdown, markDirty: true)
+
+            case "preservationFallback":
+                let reason = body["reason"] as? String ?? "unknown"
+                let docCount = body["documentChildCount"] as? Int
+                let blockCount = body["blockTokenCount"] as? Int
+                let counts = (docCount != nil || blockCount != nil)
+                    ? " docChildren=\(docCount.map(String.init) ?? "?") blockTokens=\(blockCount.map(String.init) ?? "?")"
+                    : ""
+                DiagnosticLog.log("WYSIWYG preservation fallback: \(reason)\(counts)")
 
             case "findStatus":
                 guard WYSIWYGSession.matches(documentID: parent.documentID),

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -161,6 +161,11 @@ final class WorkspaceManager {
 
     private var fsStreams: [UUID: FSEventStreamRef] = [:]
     @ObservationIgnored private var vaultIndexes: [UUID: VaultIndex] = [:]
+    /// Live reference to the source editor's text view, set by EditorView when
+    /// it mounts. Lets non-editor surfaces (WYSIWYG flush, checkbox toggle)
+    /// register undo entries on the editor's undoManager so ⌘Z reverts the
+    /// change after switching back to edit mode.
+    @ObservationIgnored weak var activeEditorTextView: ClearlyTextView?
     @ObservationIgnored private var refreshWork: [UUID: DispatchWorkItem] = [:]
     @ObservationIgnored private var treeBuildGeneration: [UUID: Int] = [:]
     @ObservationIgnored private var treeBuildTasks: [UUID: Task<Void, Never>] = [:]
@@ -730,6 +735,33 @@ final class WorkspaceManager {
     }
 
     // MARK: - Text Changes
+
+    /// Apply a text change that originated outside the source editor (WYSIWYG
+    /// flush, checkbox toggle) and route it through the editor's NSTextView so
+    /// its undoManager records a single ⌘Z-able entry — and a redo entry on
+    /// the way back. Uses `textView.replaceCharacters` (not `textStorage`)
+    /// because only the textView path triggers NSTextView's auto-undo
+    /// registration; modifying textStorage directly skips it and breaks redo.
+    func applyExternalText(_ newText: String, actionName: String) {
+        guard currentFileText != newText else { return }
+        if let textView = activeEditorTextView {
+            let storageLength = textView.textStorage?.length ?? (textView.string as NSString).length
+            let fullRange = NSRange(location: 0, length: storageLength)
+            if textView.shouldChangeText(in: fullRange, replacementString: newText) {
+                textView.replaceCharacters(in: fullRange, with: newText)
+                textView.didChangeText()
+                textView.undoManager?.setActionName(actionName)
+            }
+        }
+        // Mirror the new text into the binding source so observers (autosave,
+        // status bar, WYSIWYG sync) see it synchronously. The textView's own
+        // textDidChange will commit the same value 150ms later — that's a
+        // no-op redundancy, not a correctness issue.
+        if currentFileText != newText {
+            currentFileText = newText
+            contentDidChange()
+        }
+    }
 
     /// Called when the editor binding updates currentFileText.
     /// Does NOT set currentFileText — the binding already did that.

--- a/ClearlyWYSIWYGWeb/src/index.ts
+++ b/ClearlyWYSIWYGWeb/src/index.ts
@@ -343,9 +343,16 @@ window.clearlyWYSIWYG = {
   },
   applyCommand({ command }) {
     if (!editor) return;
-    // Find / replace commands don't go through chain — they manipulate the
-    // find plugin state directly.
+    // Find / replace + history commands don't go through chain — they
+    // manipulate plugin state directly. Undo/redo route here because the host
+    // intercepts ⌘Z before keyDown reaches WKWebContentView (issue #340).
     switch (command) {
+      case "undo":
+        editor.commands.undo();
+        return;
+      case "redo":
+        editor.commands.redo();
+        return;
       case "findNext":
         findNavigate(editor.view, "next");
         return;

--- a/ClearlyWYSIWYGWeb/src/preservation.ts
+++ b/ClearlyWYSIWYGWeb/src/preservation.ts
@@ -32,6 +32,22 @@ interface MarkedToken {
   raw: string;
 }
 
+// Forensic-only ping to the host when block-level alignment fails or
+// degrades. Lets `DiagnosticLog` show which markdown constructs trigger
+// fallback (issue #340 follow-up) without surfacing anything to the user.
+function postFallback(reason: string, info: Record<string, unknown> = {}): void {
+  try {
+    (window as unknown as { webkit?: { messageHandlers?: { wysiwyg?: { postMessage: (m: Record<string, unknown>) => void } } } })
+      .webkit?.messageHandlers?.wysiwyg?.postMessage({
+        type: "preservationFallback",
+        reason,
+        ...info,
+      });
+  } catch {
+    // dev harness — ignore
+  }
+}
+
 interface BlockSnapshot {
   raw: string;
   json: string; // canonicalized JSON of the PM child at mount time
@@ -79,7 +95,12 @@ export class SourcePreservation {
     }
 
     const doc = editor.state.doc;
-    this.aligned = doc.childCount === this.blockTokenIndex.length;
+    const documentChildCount = doc.childCount;
+    const blockTokenCount = this.blockTokenIndex.length;
+    this.aligned = documentChildCount === blockTokenCount;
+    if (!this.aligned) {
+      postFallback("child-count-mismatch", { documentChildCount, blockTokenCount });
+    }
 
     // Up-front validation: every top-level child must accept the preserveId
     // attribute. Tiptap's markdown parser occasionally emits stray nodes at
@@ -95,6 +116,9 @@ export class SourcePreservation {
           allBlockSafe = false;
         }
       });
+    }
+    if (this.aligned && !allBlockSafe) {
+      postFallback("non-block-safe-node", { documentChildCount, blockTokenCount });
     }
     this.aligned = allBlockSafe;
 
@@ -121,6 +145,13 @@ export class SourcePreservation {
         return;
       }
       if (transaction.getMeta("preservation:internal")) return;
+      if (!this.aligned && !this.globalDirty) {
+        // Aligned-mode never reached on this document, and the user just
+        // made the first edit — switching from "emit body verbatim" to
+        // "render whole doc through @tiptap/markdown" is the formatting-
+        // drift moment. Log so we can see which docs trigger it.
+        postFallback("global-dirty");
+      }
       this.globalDirty = true;
     };
     editor.on("update", this.updateHandler);
@@ -144,63 +175,87 @@ export class SourcePreservation {
       return editor.getMarkdown();
     }
 
-    // Aligned mode: walk tokens; emit raw for clean blocks, rendered for
-    // dirty ones, raw for space tokens. Insertions appended at end;
-    // deletions skip both block and the immediately-preceding space token.
+    // Aligned mode: walk the PM doc in tree order so that blocks the user
+    // inserted via WYSIWYG land at their actual position, not appended at the
+    // end. For each preserved child, emit its original raw bytes when its
+    // JSON still matches the snapshot, otherwise re-render via @tiptap/markdown.
+    // For new children (no preserveId), emit rendered output at this position.
+    // Between two preserved children that are adjacent in original order, we
+    // re-emit the original space token to preserve whitespace fidelity;
+    // everywhere else falls back to a "\n\n" separator.
     const manager = (editor as any).markdown;
-    const pmById = new Map<number, any>();
-    const newChildren: any[] = [];
-    const seenIds = new Set<number>();
+    const out: string[] = [];
+    let prevPreservedId: number | null = null;
+    let prevWasNew = false;
+
     editor.state.doc.forEach((child) => {
       const id = child.attrs?.preserveId;
-      if (typeof id === "number" && !seenIds.has(id)) {
-        pmById.set(id, child);
-        seenIds.add(id);
-      } else {
-        // Skip empty placeholder paragraphs PM may auto-append (happens when
-        // the last source block is an atom like htmlBlock or image — PM needs
-        // a trailing editable paragraph for cursor placement). The user
-        // didn't author this, so don't emit it.
-        const isEmptyParagraph =
-          child.type.name === "paragraph" &&
-          child.content.size === 0;
-        if (!isEmptyParagraph) {
-          newChildren.push(child);
+      const isPreserved = typeof id === "number";
+      const isEmptyParagraph =
+        child.type.name === "paragraph" &&
+        child.content.size === 0;
+      // Skip PM-auto-added empty trailing paragraphs (the user didn't author
+      // them — PM needs a trailing editable paragraph after atom blocks like
+      // htmlBlock or image).
+      if (!isPreserved && isEmptyParagraph) return;
+
+      if (out.length > 0) {
+        const adjacent =
+          isPreserved &&
+          prevPreservedId !== null &&
+          !prevWasNew &&
+          id === prevPreservedId + 1;
+        if (adjacent) {
+          // The two preserved blocks sit next to each other in the original
+          // token list. Either (a) directly adjacent with no space token
+          // between them — emit nothing extra, the prev block's raw already
+          // ended where it needed; or (b) a space token sits between them —
+          // re-emit it verbatim to preserve original whitespace.
+          const prevBlockTokIdx = this.blockTokenIndex[prevPreservedId];
+          const thisBlockTokIdx = this.blockTokenIndex[id as number];
+          if (prevBlockTokIdx + 1 === thisBlockTokIdx) {
+            // Directly adjacent — no separator.
+          } else if (this.tokens[prevBlockTokIdx + 1]?.type === "space") {
+            out.push(this.tokens[prevBlockTokIdx + 1].raw);
+          } else {
+            ensureBlockSeparator(out);
+          }
+        } else {
+          ensureBlockSeparator(out);
         }
       }
-    });
 
-    const out: string[] = [];
-    let blockId = 0;
-    for (let i = 0; i < this.tokens.length; i++) {
-      const tok = this.tokens[i];
-      if (tok.type === "space") {
-        const nextBlockExists = pmById.has(blockId);
-        if (nextBlockExists) out.push(tok.raw);
-        continue;
-      }
-      const child = pmById.get(blockId);
-      if (child) {
+      if (isPreserved) {
+        const blockTokIdx = this.blockTokenIndex[id as number];
+        const tok = blockTokIdx != null ? this.tokens[blockTokIdx] : null;
         const currentJson = jsonFingerprint(child.toJSON());
-        const snap = this.snapshots[blockId]?.json;
-        if (currentJson === snap) {
+        const snap = this.snapshots[id as number]?.json;
+        if (tok && currentJson === snap) {
           out.push(tok.raw);
         } else {
-          out.push(renderChild(manager, child));
+          // Tiptap's serializer doesn't always emit trailing newlines that
+          // match the original token's raw bytes. The space tokens we emit
+          // between blocks assume each block ends exactly the way its raw
+          // ended; if the rendered output is missing a trailing \n, the
+          // following space token collapses the boundary and we fuse two
+          // blocks into one (e.g. `- [x] task### Heading`). Normalize the
+          // rendered tail to match the original.
+          const rendered = renderChild(manager, child);
+          out.push(matchTrailingNewlines(rendered, tok?.raw ?? ""));
         }
+        prevPreservedId = id as number;
+        prevWasNew = false;
+      } else {
+        // New child — render and ensure a trailing newline so the next
+        // separator behaves consistently.
+        const rendered = renderChild(manager, child);
+        out.push(rendered.endsWith("\n") ? rendered : rendered + "\n");
+        prevWasNew = true;
+        // Keep prevPreservedId so the next preserved child can still test
+        // adjacency (which will fail because prevWasNew=true) and fall back
+        // to the default separator.
       }
-      blockId++;
-    }
-
-    // Append new children at end with a default \n\n separator if needed.
-    for (const child of newChildren) {
-      if (out.length > 0 && !out[out.length - 1].endsWith("\n\n")) {
-        const last = out[out.length - 1];
-        if (last.endsWith("\n")) out.push("\n");
-        else out.push("\n\n");
-      }
-      out.push(renderChild(manager, child));
-    }
+    });
 
     return out.join("");
   }
@@ -213,6 +268,33 @@ function jsonFingerprint(json: any): string {
     if (key === "preserveId") return undefined;
     return value;
   });
+}
+
+function ensureBlockSeparator(out: string[]): void {
+  if (out.length === 0) return;
+  const last = out[out.length - 1];
+  if (last.endsWith("\n\n")) return;
+  if (last.endsWith("\n")) out.push("\n");
+  else out.push("\n\n");
+}
+
+// Pad or trim trailing "\n" on `rendered` so its trailing-newline count
+// matches the original `raw`. Lets the surrounding space tokens reproduce
+// the source's whitespace structure even when a block is re-rendered.
+function matchTrailingNewlines(rendered: string, raw: string): string {
+  const renderedTrail = countTrailingNewlines(rendered);
+  const rawTrail = countTrailingNewlines(raw);
+  if (renderedTrail === rawTrail) return rendered;
+  if (renderedTrail < rawTrail) {
+    return rendered + "\n".repeat(rawTrail - renderedTrail);
+  }
+  return rendered.slice(0, rendered.length - (renderedTrail - rawTrail));
+}
+
+function countTrailingNewlines(s: string): number {
+  let n = 0;
+  for (let i = s.length - 1; i >= 0 && s[i] === "\n"; i--) n++;
+  return n;
 }
 
 function renderChild(manager: any, child: any): string {

--- a/Shared/Resources/wysiwyg/wysiwyg.js
+++ b/Shared/Resources/wysiwyg/wysiwyg.js
@@ -20193,6 +20193,16 @@ ${indentedChild}`;
   }
 
   // src/preservation.ts
+  function postFallback(reason, info = {}) {
+    try {
+      window.webkit?.messageHandlers?.wysiwyg?.postMessage({
+        type: "preservationFallback",
+        reason,
+        ...info
+      });
+    } catch {
+    }
+  }
   var SourcePreservation = class {
     originalBody;
     tokens = [];
@@ -20230,7 +20240,12 @@ ${indentedChild}`;
         }
       }
       const doc3 = editor2.state.doc;
-      this.aligned = doc3.childCount === this.blockTokenIndex.length;
+      const documentChildCount = doc3.childCount;
+      const blockTokenCount = this.blockTokenIndex.length;
+      this.aligned = documentChildCount === blockTokenCount;
+      if (!this.aligned) {
+        postFallback("child-count-mismatch", { documentChildCount, blockTokenCount });
+      }
       let allBlockSafe = this.aligned;
       if (this.aligned) {
         doc3.forEach((child) => {
@@ -20239,6 +20254,9 @@ ${indentedChild}`;
             allBlockSafe = false;
           }
         });
+      }
+      if (this.aligned && !allBlockSafe) {
+        postFallback("non-block-safe-node", { documentChildCount, blockTokenCount });
       }
       this.aligned = allBlockSafe;
       if (this.aligned) {
@@ -20263,6 +20281,9 @@ ${indentedChild}`;
           return;
         }
         if (transaction.getMeta("preservation:internal")) return;
+        if (!this.aligned && !this.globalDirty) {
+          postFallback("global-dirty");
+        }
         this.globalDirty = true;
       };
       editor2.on("update", this.updateHandler);
@@ -20283,50 +20304,48 @@ ${indentedChild}`;
         return editor2.getMarkdown();
       }
       const manager = editor2.markdown;
-      const pmById = /* @__PURE__ */ new Map();
-      const newChildren = [];
-      const seenIds = /* @__PURE__ */ new Set();
+      const out = [];
+      let prevPreservedId = null;
+      let prevWasNew = false;
       editor2.state.doc.forEach((child) => {
         const id = child.attrs?.preserveId;
-        if (typeof id === "number" && !seenIds.has(id)) {
-          pmById.set(id, child);
-          seenIds.add(id);
-        } else {
-          const isEmptyParagraph = child.type.name === "paragraph" && child.content.size === 0;
-          if (!isEmptyParagraph) {
-            newChildren.push(child);
+        const isPreserved = typeof id === "number";
+        const isEmptyParagraph = child.type.name === "paragraph" && child.content.size === 0;
+        if (!isPreserved && isEmptyParagraph) return;
+        if (out.length > 0) {
+          const adjacent = isPreserved && prevPreservedId !== null && !prevWasNew && id === prevPreservedId + 1;
+          if (adjacent) {
+            const prevBlockTokIdx = this.blockTokenIndex[prevPreservedId];
+            const thisBlockTokIdx = this.blockTokenIndex[id];
+            if (prevBlockTokIdx + 1 === thisBlockTokIdx) {
+            } else if (this.tokens[prevBlockTokIdx + 1]?.type === "space") {
+              out.push(this.tokens[prevBlockTokIdx + 1].raw);
+            } else {
+              ensureBlockSeparator(out);
+            }
+          } else {
+            ensureBlockSeparator(out);
           }
         }
-      });
-      const out = [];
-      let blockId = 0;
-      for (let i = 0; i < this.tokens.length; i++) {
-        const tok = this.tokens[i];
-        if (tok.type === "space") {
-          const nextBlockExists = pmById.has(blockId);
-          if (nextBlockExists) out.push(tok.raw);
-          continue;
-        }
-        const child = pmById.get(blockId);
-        if (child) {
+        if (isPreserved) {
+          const blockTokIdx = this.blockTokenIndex[id];
+          const tok = blockTokIdx != null ? this.tokens[blockTokIdx] : null;
           const currentJson = jsonFingerprint(child.toJSON());
-          const snap = this.snapshots[blockId]?.json;
-          if (currentJson === snap) {
+          const snap = this.snapshots[id]?.json;
+          if (tok && currentJson === snap) {
             out.push(tok.raw);
           } else {
-            out.push(renderChild(manager, child));
+            const rendered = renderChild(manager, child);
+            out.push(matchTrailingNewlines(rendered, tok?.raw ?? ""));
           }
+          prevPreservedId = id;
+          prevWasNew = false;
+        } else {
+          const rendered = renderChild(manager, child);
+          out.push(rendered.endsWith("\n") ? rendered : rendered + "\n");
+          prevWasNew = true;
         }
-        blockId++;
-      }
-      for (const child of newChildren) {
-        if (out.length > 0 && !out[out.length - 1].endsWith("\n\n")) {
-          const last = out[out.length - 1];
-          if (last.endsWith("\n")) out.push("\n");
-          else out.push("\n\n");
-        }
-        out.push(renderChild(manager, child));
-      }
+      });
       return out.join("");
     }
   };
@@ -20335,6 +20354,27 @@ ${indentedChild}`;
       if (key === "preserveId") return void 0;
       return value;
     });
+  }
+  function ensureBlockSeparator(out) {
+    if (out.length === 0) return;
+    const last = out[out.length - 1];
+    if (last.endsWith("\n\n")) return;
+    if (last.endsWith("\n")) out.push("\n");
+    else out.push("\n\n");
+  }
+  function matchTrailingNewlines(rendered, raw) {
+    const renderedTrail = countTrailingNewlines(rendered);
+    const rawTrail = countTrailingNewlines(raw);
+    if (renderedTrail === rawTrail) return rendered;
+    if (renderedTrail < rawTrail) {
+      return rendered + "\n".repeat(rawTrail - renderedTrail);
+    }
+    return rendered.slice(0, rendered.length - (renderedTrail - rawTrail));
+  }
+  function countTrailingNewlines(s) {
+    let n = 0;
+    for (let i = s.length - 1; i >= 0 && s[i] === "\n"; i--) n++;
+    return n;
   }
   function renderChild(manager, child) {
     if (!manager || typeof manager.serialize !== "function") return "";
@@ -46469,6 +46509,12 @@ ${code}`;
     applyCommand({ command: command2 }) {
       if (!editor) return;
       switch (command2) {
+        case "undo":
+          editor.commands.undo();
+          return;
+        case "redo":
+          editor.commands.redo();
+          return;
         case "findNext":
           navigateMatch(editor.view, "next");
           return;


### PR DESCRIPTION
## Summary

Fixes three bugs in the experimental Editable Preview that combined into the data-loss scenario reported in #340:

- **⌘Z in preview never reached Tiptap** — macOS eats it as a menu key-equivalent. Added an NSEvent local monitor that routes ⌘Z / ⌘⇧Z to `editor.commands.undo/redo` via the JS bridge when the WKWebView owns first-responder.
- **⌘Z after mode switch was a no-op** — preview edits wrote the binding directly, bypassing NSTextView's undo machinery. New `WorkspaceManager.applyExternalText(_:actionName:)` helper routes through `shouldChangeText`/`replaceCharacters`/`didChangeText`. WYSIWYG snapshots pre-edit state on first docChanged and registers one coarse undo entry on dismantle. Checkbox toggle uses the same helper.
- **Typed content appeared at the end of the doc in editor mode** — the aligned-mode preservation serializer walked the original token list and dumped new PM children at the end. Rewrote it to walk the PM doc in tree order; re-rendered blocks have their trailing newlines normalized to match the original token's raw so block boundaries stay intact (fixes checkbox toggles fusing list items into headings).

Adds a `preservationFallback` diagnostic and a hover-help note on the experimental toggle. Behind the existing default-OFF `wysiwygExperimental` flag.

## Test plan

- [x] Round-trip tests pass (3/3) for `Shared/Resources/*.md`
- [x] Type-check + Mac build succeed
- [x] Manual: type in preview, ⌘Z rewinds via Tiptap; ⌘⇧Z redoes
- [x] Manual: switch to editor after preview session, ⌘Z reverts the visit
- [x] Manual: toggle a `- [ ] task` in preview, switch to editor — line break preserved, ⌘Z reverts
- [x] Manual: type at top of doc in preview, switch to editor — content appears at the typed position, not appended at end

Fixes #340