### PR TITLE
[mac] [ios] Improve large markdown preview, edit & search performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ClearlyWYSIWYGWeb/perf/dist/
 ClearlyWYSIWYGWeb/perf/fixtures/
 ClearlyWYSIWYGWeb/test/dist/
 Packages/ClearlyCore/Package.resolved
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ ClearlyWYSIWYGWeb/perf/fixtures/
 ClearlyWYSIWYGWeb/test/dist/
 Packages/ClearlyCore/Package.resolved
 tmp/
+simfixture/

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ ClearlyWYSIWYGWeb/perf/fixtures/
 ClearlyWYSIWYGWeb/test/dist/
 Packages/ClearlyCore/Package.resolved
 tmp/
-simfixture/
+debugfixture/

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -6,7 +6,16 @@ enum TextCheckingPreferences {
     private static let grammarCheckingKey = "grammarCheckingEnabled"
     private static let automaticSpellingCorrectionKey = "automaticSpellingCorrectionEnabled"
 
-    static func apply(to textView: NSTextView) {
+    static func apply(to textView: NSTextView, textLength: Int? = nil) {
+        if let textLength, textLength >= Limits.largeEditorPerformanceModeLength {
+            textView.isContinuousSpellCheckingEnabled = false
+            textView.isGrammarCheckingEnabled = false
+            textView.isAutomaticSpellingCorrectionEnabled = false
+            textView.enabledTextCheckingTypes = 0
+            return
+        }
+
+        textView.enabledTextCheckingTypes = NSTextCheckingAllTypes
         textView.isContinuousSpellCheckingEnabled = UserDefaults.standard.object(forKey: continuousSpellCheckingKey) as? Bool ?? true
         textView.isGrammarCheckingEnabled = UserDefaults.standard.object(forKey: grammarCheckingKey) as? Bool ?? true
         textView.isAutomaticSpellingCorrectionEnabled = UserDefaults.standard.object(forKey: automaticSpellingCorrectionKey) as? Bool ?? false

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -332,6 +332,10 @@ struct EditorView: NSViewRepresentable {
         if !context.coordinator.isUpdating && context.coordinator.pendingBindingUpdates == 0 && textMismatch {
             DiagnosticLog.log("updateNSView #\(count): external text change (\(text.count) chars)")
             context.coordinator.isUpdating = true
+            // Drop any deferred incremental work — those ranges referred to the
+            // previous document and would highlight stale offsets after this
+            // text replacement.
+            context.coordinator.cancelPendingHighlightWork()
             let selectedRanges = textView.selectedRanges
             textView.string = text
             context.coordinator.applyLargeDocumentEditorPolicy(to: textView)
@@ -393,6 +397,12 @@ struct EditorView: NSViewRepresentable {
         var pendingBindingUpdateToken: UUID?
         private var pendingFullHighlightWork: DispatchWorkItem?
         private var pendingIncrementalHighlightWork: DispatchWorkItem?
+        // Paragraphs (in current text-storage coordinates) waiting for the
+        // deferred highlight pass on large documents. Tracked so a quick
+        // succession of edits in different paragraphs all get highlighted on
+        // flush, rather than only the last one.
+        private var pendingDirtyParagraphs: [NSRange] = []
+        private static let maxPendingDirtyParagraphs = 6
 
         // Find state tracking
         var matchRanges: [NSRange] = []
@@ -711,22 +721,84 @@ struct EditorView: NSViewRepresentable {
         private func scheduleDeferredIncrementalHighlight(for textView: NSTextView, editedRange: NSRange?, replacementLength: Int) {
             pendingIncrementalHighlightWork?.cancel()
 
-            guard let editedRange else {
+            guard let editedRange, let nsText = textView.textStorage?.string as NSString? else {
+                pendingDirtyParagraphs = []
                 scheduleDeferredFullHighlight(for: textView, delay: 0.4, caller: "deferred-textDidChange-fallback")
+                return
+            }
+
+            let safeLocation = max(0, min(editedRange.location, nsText.length))
+            let safeLength = max(0, min(replacementLength, nsText.length - safeLocation))
+            let newParagraph = nsText.paragraphRange(for: NSRange(location: safeLocation, length: safeLength))
+
+            // Shift previously-pending paragraphs to current text coordinates:
+            // - paragraphs entirely before this edit are unchanged
+            // - paragraphs after this edit shift by delta
+            // - paragraphs overlapping this edit are dropped (the new
+            //   paragraph supersedes them — a paragraph boundary may have
+            //   moved through the overlap and the snapshot is no longer
+            //   meaningful).
+            let editStart = editedRange.location
+            let editOldEnd = editedRange.location + editedRange.length
+            let delta = replacementLength - editedRange.length
+
+            var shifted: [NSRange] = []
+            for range in pendingDirtyParagraphs {
+                if range.upperBound <= editStart {
+                    shifted.append(range)
+                } else if range.location >= editOldEnd {
+                    let shiftedLocation = range.location + delta
+                    guard shiftedLocation >= 0, shiftedLocation + range.length <= nsText.length else { continue }
+                    shifted.append(NSRange(location: shiftedLocation, length: range.length))
+                }
+            }
+            shifted.append(newParagraph)
+            pendingDirtyParagraphs = Self.mergedRanges(shifted)
+
+            if pendingDirtyParagraphs.count > Self.maxPendingDirtyParagraphs {
+                pendingDirtyParagraphs = []
+                scheduleDeferredFullHighlight(for: textView, delay: 0.35, caller: "deferred-textDidChange-overflow")
                 return
             }
 
             let work = DispatchWorkItem { [weak self] in
                 guard let self, let textView = self.textView else { return }
-                self.performIncrementalHighlight(
-                    for: textView,
-                    editedRange: editedRange,
-                    replacementLength: replacementLength,
-                    caller: "deferred-textDidChange"
-                )
+                let paragraphs = self.pendingDirtyParagraphs
+                self.pendingDirtyParagraphs = []
+                for paragraph in paragraphs {
+                    self.performIncrementalHighlight(
+                        for: textView,
+                        editedRange: paragraph,
+                        replacementLength: paragraph.length,
+                        caller: "deferred-textDidChange"
+                    )
+                }
             }
             pendingIncrementalHighlightWork = work
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: work)
+        }
+
+        private static func mergedRanges(_ ranges: [NSRange]) -> [NSRange] {
+            guard !ranges.isEmpty else { return [] }
+            let sorted = ranges.sorted { $0.location < $1.location }
+            var result: [NSRange] = []
+            for range in sorted {
+                if let last = result.last, range.location <= last.location + last.length {
+                    let newEnd = max(last.location + last.length, range.location + range.length)
+                    result[result.count - 1] = NSRange(location: last.location, length: newEnd - last.location)
+                } else {
+                    result.append(range)
+                }
+            }
+            return result
+        }
+
+        func cancelPendingHighlightWork() {
+            pendingIncrementalHighlightWork?.cancel()
+            pendingIncrementalHighlightWork = nil
+            pendingFullHighlightWork?.cancel()
+            pendingFullHighlightWork = nil
+            pendingDirtyParagraphs = []
         }
 
         private func performIncrementalHighlight(for textView: NSTextView, editedRange: NSRange?, replacementLength: Int, caller: String) {

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -50,7 +50,7 @@ struct EditorView: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
-        TextCheckingPreferences.apply(to: textView)
+        TextCheckingPreferences.apply(to: textView, textLength: (text as NSString).length)
 
         // Font
         textView.font = Theme.editorFont
@@ -97,6 +97,7 @@ struct EditorView: NSViewRepresentable {
         let highlighter = MarkdownSyntaxHighlighter()
         context.coordinator.highlighter = highlighter
         textView.string = text
+        context.coordinator.applyLargeDocumentEditorPolicy(to: textView)
         textView.delegate = context.coordinator
         textView.onWikiLinkClicked = { target, heading in
             NotificationCenter.default.post(
@@ -115,6 +116,7 @@ struct EditorView: NSViewRepresentable {
         let gutter = LineNumberGutterView()
         gutter.textView = textView
         gutter.isHidden = !showLineNumbers
+        gutter.reloadData()
         context.coordinator.gutterView = gutter
 
         context.coordinator.textView = textView
@@ -228,6 +230,9 @@ struct EditorView: NSViewRepresentable {
             let gutterWidth = showLineNumbers ? gutter.preferredWidth() : 0
             if gutter.isHidden == showLineNumbers {
                 gutter.isHidden = !showLineNumbers
+                if showLineNumbers {
+                    gutter.reloadData()
+                }
             }
             let expectedGutterWidth = showLineNumbers ? gutterWidth : 0
             if abs(gutter.frame.width - expectedGutterWidth) > 0.5 || abs(scrollView.frame.minX - expectedGutterWidth) > 0.5 {
@@ -313,7 +318,9 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.isHighlightingInProgress = false
 
             // Refresh ruler when appearance/font changes
-            context.coordinator.gutterView?.appearanceDidChange()
+            if context.coordinator.gutterView?.isHidden == false {
+                context.coordinator.gutterView?.appearanceDidChange()
+            }
         }
 
         // Only update text if it changed externally (not from user typing).
@@ -327,6 +334,7 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.isUpdating = true
             let selectedRanges = textView.selectedRanges
             textView.string = text
+            context.coordinator.applyLargeDocumentEditorPolicy(to: textView)
             textView.selectedRanges = selectedRanges
             context.coordinator.isHighlightingInProgress = true
             context.coordinator.highlighter?.highlightAll(textView.textStorage!, caller: "externalText")
@@ -341,8 +349,10 @@ struct EditorView: NSViewRepresentable {
                     findState.resultsAreStale = true
                 }
             }
-            context.coordinator.gutterView?.textDidChange()
-            context.coordinator.gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+            if context.coordinator.gutterView?.isHidden == false {
+                context.coordinator.gutterView?.reloadData()
+                context.coordinator.gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+            }
             context.coordinator.isUpdating = false
         } else if context.coordinator.isUpdating && count <= 5 {
             DiagnosticLog.log("updateNSView #\(count): skipped text check (isUpdating)")
@@ -382,6 +392,7 @@ struct EditorView: NSViewRepresentable {
         var pendingBindingUpdates = 0
         var pendingBindingUpdateToken: UUID?
         private var pendingFullHighlightWork: DispatchWorkItem?
+        private var pendingIncrementalHighlightWork: DispatchWorkItem?
 
         // Find state tracking
         var matchRanges: [NSRange] = []
@@ -436,7 +447,9 @@ struct EditorView: NSViewRepresentable {
 
         func textViewDidChangeSelection(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
-            gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+            if gutterView?.isHidden == false {
+                gutterView?.selectionDidChange(selectedRange: textView.selectedRange())
+            }
 
             // Store current selection for highlight-on-mode-switch
             let range = textView.selectedRange()
@@ -543,6 +556,9 @@ struct EditorView: NSViewRepresentable {
 
         func currentLineInfo() -> (current: Int, total: Int) {
             guard let textView else { return (1, 1) }
+            if let gutterView {
+                return gutterView.lineInfo(selectedRange: textView.selectedRange())
+            }
             let text = textView.string as NSString
             let location = min(textView.selectedRange().location, text.length)
             var lineNumber = 1
@@ -609,6 +625,7 @@ struct EditorView: NSViewRepresentable {
         }
 
         var lastReplacementString: String?
+        var lastTextCheckingPerformanceMode: Bool?
 
         func textView(_ textView: NSTextView, shouldChangeTextIn affectedCharRange: NSRange, replacementString: String?) -> Bool {
             lastEditedRange = affectedCharRange
@@ -626,61 +643,24 @@ struct EditorView: NSViewRepresentable {
                 return
             }
 
-            DiagnosticLog.log("textDidChange (\(textView.textStorage?.length ?? 0) chars)")
-
             // Block updateNSView from replacing text while binding update is pending.
             // Without this, SwiftUI can call updateNSView (e.g., from a layout pass
             // triggered by the text view growing) BEFORE the async binding update fires,
             // see a mismatch between the old binding and the new text, and overwrite
             // the text view with the stale binding value — causing the cursor to jump.
             pendingBindingUpdates = 1
+            applyLargeDocumentEditorPolicy(to: textView)
 
-            // Save scroll position before highlighting
-            let scrollView = textView.enclosingScrollView
-            let savedOrigin = scrollView?.contentView.bounds.origin
+            let editedRange = lastEditedRange
+            let replacementLength = lastReplacementLength
+            let replacementString = lastReplacementString
 
-            // Highlight only the affected range for performance on long documents
-            isHighlightingInProgress = true
-            if let editedRange = lastEditedRange {
-                highlighter?.highlightAround(textView.textStorage!, editedRange: editedRange, replacementLength: lastReplacementLength, caller: "textDidChange")
-                lastEditedRange = nil
+            if isLargeDocument(textView) {
+                scheduleDeferredIncrementalHighlight(for: textView, editedRange: editedRange, replacementLength: replacementLength)
             } else {
-                highlighter?.highlightAll(textView.textStorage!, caller: "textDidChange-fallback")
+                performIncrementalHighlight(for: textView, editedRange: editedRange, replacementLength: replacementLength, caller: "textDidChange")
             }
-            isHighlightingInProgress = false
-
-            // If a block delimiter was edited, defer the full re-highlight so it
-            // doesn't block typing. The paragraph was already highlighted above.
-            if highlighter?.needsFullHighlight == true {
-                highlighter?.needsFullHighlight = false
-                pendingFullHighlightWork?.cancel()
-                let work = DispatchWorkItem { [weak self] in
-                    guard let self, let textView = self.textView else { return }
-                    let sv = textView.enclosingScrollView
-                    let origin = sv?.contentView.bounds.origin
-                    self.isHighlightingInProgress = true
-                    self.highlighter?.highlightAll(textView.textStorage!, caller: "deferred-blockDelim")
-                    self.isHighlightingInProgress = false
-                    if let sv, let origin {
-                        sv.contentView.scroll(to: origin)
-                        sv.reflectScrolledClipView(sv.contentView)
-                    }
-                    self.invalidateVisibleRegion(of: textView)
-                }
-                pendingFullHighlightWork = work
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
-            }
-
-            // Restore scroll position that highlighting may have disturbed
-            if let scrollView, let savedOrigin {
-                scrollView.contentView.scroll(to: savedOrigin)
-                scrollView.reflectScrolledClipView(scrollView.contentView)
-            }
-
-            // Attribute-only highlighting doesn't invalidate display, so mark
-            // the viewport dirty after restoring scroll. Limit invalidation to
-            // the visible rect so large documents don't repaint end-to-end.
-            invalidateVisibleRegion(of: textView)
+            lastEditedRange = nil
 
             // Clear on edit; user retypes the query to refresh (#264).
             if let findState, findState.isVisible, !matchRanges.isEmpty {
@@ -696,21 +676,22 @@ struct EditorView: NSViewRepresentable {
             }
 
             // Update line number ruler
-            gutterView?.textDidChange()
+            gutterView?.textDidChange(editedRange: editedRange, replacementString: replacementString)
 
             // Wiki-link auto-complete trigger/update
             handleWikiLinkCompletion(textView)
 
-            // Update SwiftUI binding with a short debounce. The text view already shows
+            // Update SwiftUI binding with a debounce. The text view already shows
             // the correct content — the binding is only needed for preview, file saving,
             // and outline parsing, which are expensive on long documents and don't need
-            // to run on every keystroke.
+            // to run between individual keystrokes.
             editGeneration += 1
             let gen = editGeneration
             let token = UUID()
             pendingBindingUpdateToken = token
             let scheduledPositionSyncID = lastPositionSyncID
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            let bindingDelay = bindingUpdateDelay(for: textView)
+            DispatchQueue.main.asyncAfter(deadline: .now() + bindingDelay) { [weak self] in
                 guard let self else { return }
                 guard self.pendingBindingUpdateToken == token else { return }
                 self.pendingBindingUpdateToken = nil
@@ -722,9 +703,96 @@ struct EditorView: NSViewRepresentable {
             }
         }
 
+        private func isLargeDocument(_ textView: NSTextView) -> Bool {
+            let length = textView.textStorage?.length ?? (textView.string as NSString).length
+            return length >= Limits.largeEditorPerformanceModeLength
+        }
+
+        private func scheduleDeferredIncrementalHighlight(for textView: NSTextView, editedRange: NSRange?, replacementLength: Int) {
+            pendingIncrementalHighlightWork?.cancel()
+
+            guard let editedRange else {
+                scheduleDeferredFullHighlight(for: textView, delay: 0.4, caller: "deferred-textDidChange-fallback")
+                return
+            }
+
+            let work = DispatchWorkItem { [weak self] in
+                guard let self, let textView = self.textView else { return }
+                self.performIncrementalHighlight(
+                    for: textView,
+                    editedRange: editedRange,
+                    replacementLength: replacementLength,
+                    caller: "deferred-textDidChange"
+                )
+            }
+            pendingIncrementalHighlightWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: work)
+        }
+
+        private func performIncrementalHighlight(for textView: NSTextView, editedRange: NSRange?, replacementLength: Int, caller: String) {
+            guard let textStorage = textView.textStorage else { return }
+
+            let scrollView = textView.enclosingScrollView
+            let savedOrigin = scrollView?.contentView.bounds.origin
+
+            isHighlightingInProgress = true
+            if let editedRange {
+                highlighter?.highlightAround(textStorage, editedRange: editedRange, replacementLength: replacementLength, caller: caller)
+            } else {
+                highlighter?.highlightAll(textStorage, caller: "\(caller)-fallback")
+            }
+            isHighlightingInProgress = false
+
+            if highlighter?.needsFullHighlight == true {
+                highlighter?.needsFullHighlight = false
+                scheduleDeferredFullHighlight(for: textView, delay: 0.3, caller: "deferred-blockDelim")
+            }
+
+            if let scrollView, let savedOrigin {
+                scrollView.contentView.scroll(to: savedOrigin)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+            }
+
+            invalidateHighlightedRegion(of: textView, editedRange: editedRange, replacementLength: replacementLength)
+        }
+
+        private func scheduleDeferredFullHighlight(for textView: NSTextView, delay: TimeInterval, caller: String) {
+            pendingFullHighlightWork?.cancel()
+            let work = DispatchWorkItem { [weak self] in
+                guard let self, let textView = self.textView else { return }
+                let scrollView = textView.enclosingScrollView
+                let savedOrigin = scrollView?.contentView.bounds.origin
+                self.isHighlightingInProgress = true
+                self.highlighter?.highlightAll(textView.textStorage!, caller: caller)
+                self.isHighlightingInProgress = false
+                if let scrollView, let savedOrigin {
+                    scrollView.contentView.scroll(to: savedOrigin)
+                    scrollView.reflectScrolledClipView(scrollView.contentView)
+                }
+                self.invalidateHighlightedRegion(of: textView, editedRange: nil, replacementLength: 0)
+            }
+            pendingFullHighlightWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        }
+
         private func commitTextViewContents(_ textView: NSTextView) {
             parent.text = textView.string
             WorkspaceManager.shared.contentDidChange()
+        }
+
+        func applyLargeDocumentEditorPolicy(to textView: NSTextView) {
+            let length = textView.textStorage?.length ?? (textView.string as NSString).length
+            let performanceMode = length >= Limits.largeEditorPerformanceModeLength
+            if lastTextCheckingPerformanceMode != performanceMode {
+                lastTextCheckingPerformanceMode = performanceMode
+                TextCheckingPreferences.apply(to: textView, textLength: length)
+            }
+            textView.layoutManager?.backgroundLayoutEnabled = !performanceMode
+        }
+
+        private func bindingUpdateDelay(for textView: NSTextView) -> TimeInterval {
+            let length = textView.textStorage?.length ?? (textView.string as NSString).length
+            return length >= Limits.largeEditorPerformanceModeLength ? 2.0 : 0.15
         }
 
         // MARK: - Wiki-Link Auto-Complete
@@ -829,9 +897,33 @@ struct EditorView: NSViewRepresentable {
             gutterView?.scrollOrFrameDidChange()
         }
 
-        private func invalidateVisibleRegion(of textView: NSTextView) {
-            let visibleRect = textView.enclosingScrollView?.contentView.documentVisibleRect ?? textView.visibleRect
-            textView.setNeedsDisplay(visibleRect, avoidAdditionalLayout: true)
+        private func invalidateHighlightedRegion(of textView: NSTextView, editedRange: NSRange?, replacementLength: Int) {
+            guard let editedRange,
+                  let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else {
+                let visibleRect = textView.enclosingScrollView?.contentView.documentVisibleRect ?? textView.visibleRect
+                textView.setNeedsDisplay(visibleRect, avoidAdditionalLayout: true)
+                return
+            }
+
+            let nsText = textView.string as NSString
+            let safeLocation = max(0, min(editedRange.location, nsText.length))
+            let safeLength = max(0, min(replacementLength, nsText.length - safeLocation))
+            let paragraphRange = nsText.paragraphRange(for: NSRange(location: safeLocation, length: safeLength))
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: paragraphRange, actualCharacterRange: nil)
+            guard glyphRange.length > 0 else { return }
+
+            var rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            let origin = textView.textContainerOrigin
+            rect.origin.x += origin.x
+            rect.origin.y += origin.y
+            rect = rect.insetBy(dx: -4, dy: -4)
+
+            if let visible = textView.enclosingScrollView?.contentView.documentVisibleRect {
+                rect = rect.intersection(visible)
+            }
+            guard !rect.isNull, !rect.isEmpty else { return }
+            textView.setNeedsDisplay(rect, avoidAdditionalLayout: true)
         }
 
         // MARK: - Find

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -388,6 +388,19 @@ struct EditorView: NSViewRepresentable {
         var lastMatches: [TextMatch] = []
         private var currentMatchIdx = 0 // 0-based internal index
         private var findCancellables = Set<AnyCancellable>()
+        private var paintedFindRanges: [NSRange] = []
+        private var pendingFindWork: DispatchWorkItem?
+        private var findGeneration = 0
+
+        private static let findDebounceDelay: TimeInterval = 0.18
+        private static let maxPaintedFindHighlights = 600
+        private static let leadingPaintedFindHighlights = 120
+        private static let currentPaintedFindHighlightRadius = 120
+
+        private enum FindComputationResult {
+            case matches([TextMatch])
+            case invalidRegex(String)
+        }
 
         init(_ parent: EditorView) {
             self.parent = parent
@@ -560,7 +573,7 @@ struct EditorView: NSViewRepresentable {
                     // `@Published` fires in willSet — `findState.query` still
                     // reads the OLD value here. Pass `newQuery` explicitly so
                     // performFind doesn't run a keystroke behind.
-                    self.performFind(query: newQuery)
+                    self.scheduleFind(query: newQuery)
                 }
                 .store(in: &findCancellables)
 
@@ -570,7 +583,7 @@ struct EditorView: NSViewRepresentable {
                     guard let self else { return }
                     if visible {
                         guard self.findState?.activeMode == .edit else { return }
-                        self.performFind()
+                        self.scheduleFind(debounce: false)
                     } else {
                         self.clearFindHighlights()
                     }
@@ -586,10 +599,10 @@ struct EditorView: NSViewRepresentable {
                 .sink { [weak self] _, _ in
                     DispatchQueue.main.async {
                         guard let self,
-                              let findState = self.findState,
-                              findState.isVisible,
-                              findState.activeMode == .edit else { return }
-                        self.performFind()
+                               let findState = self.findState,
+                               findState.isVisible,
+                               findState.activeMode == .edit else { return }
+                        self.scheduleFind(debounce: false)
                     }
                 }
                 .store(in: &findCancellables)
@@ -824,12 +837,92 @@ struct EditorView: NSViewRepresentable {
         // MARK: - Find
 
         func performFind(query overrideQuery: String? = nil) {
+            scheduleFind(query: overrideQuery, debounce: false)
+        }
+
+        private func scheduleFind(query overrideQuery: String? = nil, debounce: Bool = true) {
             guard let textView else { return }
-            let didRecompute = recomputeMatches(query: overrideQuery)
-            guard didRecompute else { return }
-            applyFindHighlights()
-            if let first = matchRanges.first {
-                textView.scrollRangeToVisible(first)
+            pendingFindWork?.cancel()
+            findGeneration += 1
+            let generation = findGeneration
+            let query = overrideQuery ?? findState?.query ?? ""
+            let options = TextMatchOptions(
+                caseSensitive: findState?.caseSensitive ?? false,
+                useRegex: findState?.useRegex ?? false
+            )
+            let text = textView.string
+
+            guard !query.isEmpty else {
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                clearFindHighlights()
+                findState?.matchCount = 0
+                findState?.currentIndex = 0
+                findState?.resultsAreStale = false
+                findState?.regexError = nil
+                findState?.lastReplaceCount = nil
+                return
+            }
+
+            findState?.resultsAreStale = true
+            findState?.regexError = nil
+            findState?.lastReplaceCount = nil
+
+            let work = DispatchWorkItem { [weak self] in
+                Task.detached(priority: .userInitiated) {
+                    let result: FindComputationResult
+                    do {
+                        result = .matches(try TextMatcher.matches(of: query, in: text, options: options))
+                    } catch let TextMatcherError.invalidRegex(message) {
+                        result = .invalidRegex(message)
+                    } catch {
+                        result = .matches([])
+                    }
+
+                    await MainActor.run { [weak self] in
+                        self?.applyFindComputationResult(result, generation: generation)
+                    }
+                }
+            }
+            pendingFindWork = work
+            if debounce {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.findDebounceDelay, execute: work)
+            } else {
+                DispatchQueue.main.async(execute: work)
+            }
+        }
+
+        private func applyFindComputationResult(_ result: FindComputationResult, generation: Int) {
+            guard generation == findGeneration,
+                  let findState,
+                  findState.isVisible,
+                  findState.activeMode == .edit else { return }
+            switch result {
+            case .invalidRegex(let message):
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                clearFindHighlights()
+                findState.matchCount = 0
+                findState.currentIndex = 0
+                findState.resultsAreStale = false
+                findState.regexError = message
+                findState.lastReplaceCount = nil
+
+            case .matches(let matches):
+                matchRanges = matches.map(\.range)
+                lastMatches = matches
+                currentMatchIdx = 0
+                applyFindHighlights()
+                if let first = matchRanges.first {
+                    textView?.scrollRangeToVisible(first)
+                }
+                findState.matchCount = matches.count
+                findState.currentIndex = matches.isEmpty ? 0 : 1
+                findState.resultsAreStale = false
+                findState.regexError = nil
+                findState.lastReplaceCount = nil
             }
         }
 
@@ -946,23 +1039,51 @@ struct EditorView: NSViewRepresentable {
         private func applyFindHighlights() {
             guard let textView, let layoutManager = textView.layoutManager else { return }
             let storage = textView.textStorage!
-            let fullRange = NSRange(location: 0, length: storage.length)
-            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
-            for (i, range) in matchRanges.enumerated() {
+            for range in paintedFindRanges {
+                guard range.location < storage.length else { continue }
+                let clamped = NSRange(location: range.location, length: min(range.length, storage.length - range.location))
+                layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: clamped)
+            }
+            let rangesToPaint = paintedFindHighlightRanges()
+            for (i, range) in rangesToPaint {
                 guard range.upperBound <= storage.length else { continue }
                 let color = (i == currentMatchIdx) ? Theme.findCurrentHighlightColor : Theme.findHighlightColor
                 layoutManager.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
             }
+            paintedFindRanges = rangesToPaint.map(\.range)
         }
 
         func clearFindHighlights() {
             guard let textView, let layoutManager = textView.layoutManager else { return }
+            findGeneration += 1
+            pendingFindWork?.cancel()
             let storage = textView.textStorage!
-            let fullRange = NSRange(location: 0, length: storage.length)
-            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
+            for range in paintedFindRanges {
+                guard range.location < storage.length else { continue }
+                let clamped = NSRange(location: range.location, length: min(range.length, storage.length - range.location))
+                layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: clamped)
+            }
+            paintedFindRanges = []
             matchRanges = []
             lastMatches = []
             currentMatchIdx = 0
+        }
+
+        private func paintedFindHighlightRanges() -> [(index: Int, range: NSRange)] {
+            guard matchRanges.count > Self.maxPaintedFindHighlights else {
+                return matchRanges.enumerated().map { ($0.offset, $0.element) }
+            }
+
+            var indexes = Set<Int>()
+            let leadingCount = min(Self.leadingPaintedFindHighlights, matchRanges.count)
+            indexes.formUnion(0..<leadingCount)
+
+            let lower = max(0, currentMatchIdx - Self.currentPaintedFindHighlightRadius)
+            let upper = min(matchRanges.count - 1, currentMatchIdx + Self.currentPaintedFindHighlightRadius)
+            indexes.formUnion(lower...upper)
+            indexes.insert(currentMatchIdx)
+
+            return indexes.sorted().map { ($0, matchRanges[$0]) }
         }
 
         // MARK: - Replace

--- a/Clearly/LineNumberRulerView.swift
+++ b/Clearly/LineNumberRulerView.swift
@@ -4,6 +4,9 @@ import ClearlyCore
 final class LineNumberGutterView: NSView {
     weak var textView: NSTextView?
     private var currentLineIndex: Int = 0 // 0-based
+    private var lineStarts: [Int] = [0]
+    private var cachedTextLength: Int = 0
+    private var lineCacheValid = false
 
     override var isFlipped: Bool { true }
 
@@ -19,8 +22,8 @@ final class LineNumberGutterView: NSView {
     // MARK: - Width
 
     func preferredWidth() -> CGFloat {
-        guard let textView else { return 36 }
-        let lineCount = max(1, (textView.string as NSString).components(separatedBy: "\n").count)
+        ensureLineCache()
+        let lineCount = max(1, lineStarts.count)
         let digits = max(2, String(lineCount).count)
         let charWidth = NSString(string: "8").size(withAttributes: [.font: Theme.editorFont]).width
         return ceil(CGFloat(digits) * charWidth + 20)
@@ -36,6 +39,7 @@ final class LineNumberGutterView: NSView {
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer else { return }
 
+        ensureLineCache()
         let text = textView.string as NSString
 
         // Convert coordinate systems: gutter ↔ text view
@@ -56,16 +60,7 @@ final class LineNumberGutterView: NSView {
 
         let visibleCharRange = layoutManager.characterRange(forGlyphRange: visibleGlyphRange, actualGlyphRange: nil)
 
-        // Find the logical line number at the start of the visible range
-        var lineNumber = 1
-        var scanIndex = 0
         let startChar = visibleCharRange.location
-        while scanIndex < startChar {
-            if text.character(at: scanIndex) == 0x0A {
-                lineNumber += 1
-            }
-            scanIndex += 1
-        }
 
         // Walk back to the start of the first visible logical line
         var lineStart = startChar
@@ -73,6 +68,7 @@ final class LineNumberGutterView: NSView {
             let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
             lineStart = lineRange.location
         }
+        var lineNumber = lineIndex(containing: lineStart) + 1
 
         let containerOrigin = textView.textContainerOrigin
 
@@ -128,31 +124,146 @@ final class LineNumberGutterView: NSView {
 
     // MARK: - Update triggers
 
-    func textDidChange() {
+    func reloadData() {
+        rebuildLineCache()
+        needsDisplay = true
+    }
+
+    func textDidChange(editedRange: NSRange? = nil, replacementString: String? = nil) {
+        guard !isHidden else {
+            lineCacheValid = false
+            return
+        }
+        if let editedRange {
+            updateLineCache(editedRange: editedRange, replacementString: replacementString ?? "")
+        } else {
+            rebuildLineCache()
+        }
         needsDisplay = true
     }
 
     func selectionDidChange(selectedRange: NSRange) {
-        guard let textView else { return }
-        let text = textView.string as NSString
-        var line = 0
-        var i = 0
-        let location = min(selectedRange.location, text.length)
-        while i < location {
-            if text.character(at: i) == 0x0A { line += 1 }
-            i += 1
-        }
+        guard !isHidden else { return }
+        ensureLineCache()
+        let line = lineIndex(containing: selectedRange.location)
         if currentLineIndex != line {
             currentLineIndex = line
             needsDisplay = true
         }
     }
 
+    func lineInfo(selectedRange: NSRange) -> (current: Int, total: Int) {
+        ensureLineCache()
+        return (lineIndex(containing: selectedRange.location) + 1, max(1, lineStarts.count))
+    }
+
     func scrollOrFrameDidChange() {
+        guard !isHidden else { return }
         needsDisplay = true
     }
 
     func appearanceDidChange() {
         needsDisplay = true
+    }
+
+    private func ensureLineCache() {
+        guard let textView else { return }
+        let textLength = (textView.string as NSString).length
+        if !lineCacheValid || cachedTextLength != textLength {
+            rebuildLineCache()
+        }
+    }
+
+    private func rebuildLineCache() {
+        guard let textView else {
+            lineStarts = [0]
+            cachedTextLength = 0
+            lineCacheValid = true
+            return
+        }
+        let text = textView.string as NSString
+        var starts = [0]
+        starts.reserveCapacity(max(1, text.length / 80))
+        if text.length > 0 {
+            for i in 0..<text.length where text.character(at: i) == 0x0A {
+                starts.append(i + 1)
+            }
+        }
+        lineStarts = starts
+        cachedTextLength = text.length
+        lineCacheValid = true
+        currentLineIndex = min(currentLineIndex, max(0, starts.count - 1))
+    }
+
+    private func updateLineCache(editedRange: NSRange, replacementString: String) {
+        guard let textView else {
+            lineCacheValid = false
+            return
+        }
+        if !lineCacheValid {
+            rebuildLineCache()
+            return
+        }
+
+        let replacementLength = (replacementString as NSString).length
+        let newLength = (textView.string as NSString).length
+        let oldLength = newLength - replacementLength + editedRange.length
+        guard oldLength == cachedTextLength else {
+            rebuildLineCache()
+            return
+        }
+
+        let editStart = max(0, min(editedRange.location, oldLength))
+        let editEnd = max(editStart, min(editedRange.location + editedRange.length, oldLength))
+        let delta = replacementLength - editedRange.length
+        var updated: [Int] = []
+        updated.reserveCapacity(lineStarts.count + max(1, replacementLength / 80))
+
+        for start in lineStarts {
+            if start <= editStart {
+                updated.append(start)
+            } else if start > editEnd {
+                updated.append(start + delta)
+            }
+        }
+
+        let replacement = replacementString as NSString
+        if replacement.length > 0 {
+            for i in 0..<replacement.length where replacement.character(at: i) == 0x0A {
+                updated.append(editStart + i + 1)
+            }
+        }
+
+        updated.sort()
+        var deduped: [Int] = []
+        deduped.reserveCapacity(updated.count)
+        for start in updated where start >= 0 && start <= newLength {
+            if deduped.last != start {
+                deduped.append(start)
+            }
+        }
+        if deduped.first != 0 {
+            deduped.insert(0, at: 0)
+        }
+
+        lineStarts = deduped
+        cachedTextLength = newLength
+        lineCacheValid = true
+        currentLineIndex = min(currentLineIndex, max(0, deduped.count - 1))
+    }
+
+    private func lineIndex(containing utf16Offset: Int) -> Int {
+        let location = max(0, min(utf16Offset, cachedTextLength))
+        var low = 0
+        var high = lineStarts.count
+        while low < high {
+            let mid = (low + high) / 2
+            if lineStarts[mid] <= location {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        return max(0, low - 1)
     }
 }

--- a/Clearly/LineNumberRulerView.swift
+++ b/Clearly/LineNumberRulerView.swift
@@ -126,6 +126,13 @@ final class LineNumberGutterView: NSView {
 
     func reloadData() {
         rebuildLineCache()
+        // After a full reload (e.g. external text replacement on document
+        // switch), the cached currentLineIndex is for the previous document.
+        // Re-derive from the live selection so the highlight lands on the
+        // right line until the next selectionDidChange call.
+        if let textView {
+            currentLineIndex = lineIndex(containing: textView.selectedRange().location)
+        }
         needsDisplay = true
     }
 

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -558,12 +558,11 @@ struct MacDetailColumn: View {
 
     private func previewPane(preloadWhenHidden: Bool, hideWhenInactive: Bool) -> some View {
         let fileURL = workspace.currentFileURL
-        let isLargeDocument: Bool = {
-            if let fileURL {
-                return !Limits.isFileSize(fileURL, atMost: Int64(Limits.asyncPreviewRenderLength))
-            }
-            return workspace.currentFileText.utf8.count >= Limits.asyncPreviewRenderLength
-        }()
+        // Decide based on the in-memory text — that's what the renderer
+        // actually has to process. Falling back to on-disk size lies after
+        // edits (the user has typed 600K but the file is still 50K from last
+        // save, or vice versa).
+        let isLargeDocument = workspace.currentFileText.utf8.count >= Limits.asyncPreviewRenderLength
         let allWikiFileNames: Set<String> = {
             guard !isLargeDocument else { return [] }
             _ = workspace.vaultIndexRevision
@@ -632,9 +631,6 @@ struct MacDetailColumn: View {
 
     private var usesSmallMarkdownCrossfade: Bool {
         guard workspace.currentViewMode == .edit || workspace.currentViewMode == .preview else { return false }
-        if let fileURL = workspace.currentFileURL {
-            return Limits.isFileSize(fileURL, atMost: Int64(Limits.previewCrossfadeRenderLength))
-        }
         return workspace.currentFileText.utf8.count <= Limits.previewCrossfadeRenderLength
     }
 

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -188,6 +188,8 @@ struct MacDetailColumn: View {
     @StateObject private var fileWatcher = FileWatcher()
     @State private var isFullscreen = false
     @State private var pendingWikiNavigation: PendingWikiNavigation?
+    @State private var previewFadeOutInProgress = false
+    @State private var previewTransitionGeneration = 0
 
     @AppStorage("editorFontSize") private var fontSize: Double = 16
     @AppStorage("previewFontFamily") private var previewFontFamily: String = "sanFrancisco"
@@ -277,6 +279,7 @@ struct MacDetailColumn: View {
             backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
             statusBarState.resetSelection()
             statusBarState.updateText(workspace.currentFileText)
+            resetPreviewTransitionStateForCurrentDocument()
             setupFileWatcher()
             applyPendingWikiNavigationIfNeeded()
         }
@@ -290,6 +293,7 @@ struct MacDetailColumn: View {
             if newMode != .edit {
                 jumpToLineState.dismiss()
             }
+            updatePreviewTransitionState(from: oldMode, to: newMode)
             guard oldMode != newMode,
                   let text = SelectionBridge.selection(for: positionSyncID) else { return }
             if oldMode == .edit && newMode == .preview {
@@ -342,6 +346,7 @@ struct MacDetailColumn: View {
         backlinksState.update(for: workspace.currentFileURL, using: workspace.activeVaultIndexes)
         statusBarState.updateText(workspace.currentFileText)
         isFullscreen = NSApp.mainWindow?.styleMask.contains(.fullScreen) ?? false
+        resetPreviewTransitionStateForCurrentDocument()
         setupFileWatcher()
     }
 
@@ -385,15 +390,15 @@ struct MacDetailColumn: View {
                 Divider()
             }
 
-            ZStack {
-                editorPane
-                    .opacity(workspace.currentViewMode == .edit ? 1 : 0)
-                    .allowsHitTesting(workspace.currentViewMode == .edit)
-                previewPane
-                    .opacity(workspace.currentViewMode == .preview ? 1 : 0)
-                    .allowsHitTesting(workspace.currentViewMode == .preview)
-                if wysiwygExperimentEnabled && workspace.currentViewMode == .wysiwyg {
+            Group {
+                if usesSmallMarkdownCrossfade {
+                    crossfadeEditorPreviewPane
+                } else if isMarkdownEditorPreviewMode {
+                    nonPreloadedEditorPreviewPane
+                } else if wysiwygExperimentEnabled && workspace.currentViewMode == .wysiwyg {
                     wysiwygPane
+                } else {
+                    editorPane
                 }
             }
             .layoutPriority(1)
@@ -422,7 +427,6 @@ struct MacDetailColumn: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
         .animation(Theme.Motion.smooth, value: findState.isVisible)
         .animation(Theme.Motion.smooth, value: jumpToLineState.isVisible)
         .animation(Theme.Motion.smooth, value: backlinksState.isVisible)
@@ -445,6 +449,34 @@ struct MacDetailColumn: View {
             needsTrafficLightClearance: false,
             contentWidthEm: contentWidthEm
         )
+    }
+
+    private var crossfadeEditorPreviewPane: some View {
+        ZStack {
+            editorPane
+                .opacity(workspace.currentViewMode == .edit ? 1 : 0)
+                .allowsHitTesting(workspace.currentViewMode == .edit)
+
+            previewPane(preloadWhenHidden: true, hideWhenInactive: false)
+                .opacity(workspace.currentViewMode == .preview ? 1 : 0)
+                .allowsHitTesting(workspace.currentViewMode == .preview)
+        }
+        .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
+    }
+
+    private var nonPreloadedEditorPreviewPane: some View {
+        ZStack {
+            editorPane
+                .opacity(workspace.currentViewMode == .edit ? 1 : 0)
+                .allowsHitTesting(workspace.currentViewMode == .edit)
+
+            if workspace.currentViewMode == .preview || previewFadeOutInProgress {
+                previewPane(preloadWhenHidden: false, hideWhenInactive: false)
+                    .opacity(workspace.currentViewMode == .preview ? 1 : 0)
+                    .allowsHitTesting(workspace.currentViewMode == .preview)
+            }
+        }
+        .animation(Theme.Motion.smooth, value: workspace.currentViewMode)
     }
 
     private var wysiwygPane: some View {
@@ -510,10 +542,17 @@ struct MacDetailColumn: View {
         )
     }
 
-    private var previewPane: some View {
+    private func previewPane(preloadWhenHidden: Bool, hideWhenInactive: Bool) -> some View {
         let fileURL = workspace.currentFileURL
-        _ = workspace.vaultIndexRevision
+        let isLargeDocument: Bool = {
+            if let fileURL {
+                return !Limits.isFileSize(fileURL, atMost: Int64(Limits.asyncPreviewRenderLength))
+            }
+            return workspace.currentFileText.utf8.count >= Limits.asyncPreviewRenderLength
+        }()
         let allWikiFileNames: Set<String> = {
+            guard !isLargeDocument else { return [] }
+            _ = workspace.vaultIndexRevision
             var names = Set<String>()
             for index in workspace.activeVaultIndexes {
                 for file in index.allFiles() {
@@ -526,9 +565,12 @@ struct MacDetailColumn: View {
         }()
         return PreviewView(
             markdown: workspace.currentFileText,
+            contentVersion: workspace.currentFileRevision,
             fontSize: CGFloat(fontSize),
             fontFamily: previewFontFamily,
             mode: workspace.currentViewMode,
+            preloadWhenHidden: preloadWhenHidden,
+            hideWhenInactive: hideWhenInactive,
             positionSyncID: positionSyncID,
             fileURL: fileURL,
             findState: findState,
@@ -574,7 +616,40 @@ struct MacDetailColumn: View {
         }
     }
 
+    private var usesSmallMarkdownCrossfade: Bool {
+        guard workspace.currentViewMode == .edit || workspace.currentViewMode == .preview else { return false }
+        if let fileURL = workspace.currentFileURL {
+            return Limits.isFileSize(fileURL, atMost: Int64(Limits.previewCrossfadeRenderLength))
+        }
+        return workspace.currentFileText.utf8.count <= Limits.previewCrossfadeRenderLength
+    }
+
+    private var isMarkdownEditorPreviewMode: Bool {
+        workspace.currentViewMode == .edit || workspace.currentViewMode == .preview
+    }
+
     // MARK: - Helpers
+
+    private func resetPreviewTransitionStateForCurrentDocument() {
+        previewTransitionGeneration += 1
+        previewFadeOutInProgress = false
+    }
+
+    private func updatePreviewTransitionState(from oldMode: ViewMode, to newMode: ViewMode) {
+        previewTransitionGeneration += 1
+        let generation = previewTransitionGeneration
+
+        if oldMode == .preview && newMode == .edit {
+            previewFadeOutInProgress = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                guard previewTransitionGeneration == generation else { return }
+                previewFadeOutInProgress = false
+            }
+            return
+        }
+
+        previewFadeOutInProgress = false
+    }
 
     private func handleActiveVaultChanged() {
         // Chat works in any vault. Auto-rebind to the new active vault — but

--- a/Clearly/Native/MacDetailColumn.swift
+++ b/Clearly/Native/MacDetailColumn.swift
@@ -421,9 +421,14 @@ struct MacDetailColumn: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
-            if statusBarState.isVisible {
+            if statusBarState.isVisible || isLargeDocumentMode {
                 Divider()
-                StatusBarView(state: statusBarState)
+                StatusBarView(
+                    state: statusBarState,
+                    showsCounts: statusBarState.isVisible,
+                    showsLargeDocumentMode: isLargeDocumentMode,
+                    documentCharacterCount: documentCharacterCount
+                )
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
@@ -431,6 +436,15 @@ struct MacDetailColumn: View {
         .animation(Theme.Motion.smooth, value: jumpToLineState.isVisible)
         .animation(Theme.Motion.smooth, value: backlinksState.isVisible)
         .animation(Theme.Motion.smooth, value: statusBarState.isVisible)
+        .animation(Theme.Motion.smooth, value: isLargeDocumentMode)
+    }
+
+    private var documentCharacterCount: Int {
+        (workspace.currentFileText as NSString).length
+    }
+
+    private var isLargeDocumentMode: Bool {
+        documentCharacterCount >= Limits.largeEditorPerformanceModeLength
     }
 
     private var editorPane: some View {

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -127,6 +127,14 @@ private struct DocumentLoadingOverlay: View {
             Rectangle()
                 .fill(.black.opacity(0.12))
                 .ignoresSafeArea()
+                // Block clicks from reaching the editor/sidebar underneath
+                // while the load is in flight. Without this the overlay is
+                // purely cosmetic — the user can interact with the content
+                // they "can't see" and clicks on toolbar/sidebar items race
+                // against the document load, which can land on the wrong
+                // document by the time the load resolves.
+                .contentShape(Rectangle())
+                .onTapGesture {}
 
             VStack(spacing: 14) {
                 ProgressView(value: state.progress)

--- a/Clearly/Native/MacRootView.swift
+++ b/Clearly/Native/MacRootView.swift
@@ -25,7 +25,15 @@ struct MacRootView: View {
         if workspace.isFirstRun && workspace.locations.isEmpty && workspace.activeDocumentID == nil {
             WelcomeView(workspace: workspace)
         } else {
-            splitView
+            ZStack {
+                splitView
+                if let loading = workspace.documentLoadingState {
+                    DocumentLoadingOverlay(state: loading) {
+                        workspace.cancelDocumentLoad()
+                    }
+                    .transition(.opacity)
+                }
+            }
         }
     }
 
@@ -107,5 +115,45 @@ struct MacRootView: View {
             return "Clearly"
         }
         return workspace.isDirty ? "\u{2022} \(doc.displayName)" : doc.displayName
+    }
+}
+
+private struct DocumentLoadingOverlay: View {
+    let state: DocumentLoadingState
+    let onCancel: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.black.opacity(0.12))
+                .ignoresSafeArea()
+
+            VStack(spacing: 14) {
+                ProgressView(value: state.progress)
+                    .progressViewStyle(.linear)
+                    .frame(width: 260)
+
+                VStack(spacing: 4) {
+                    Text(state.message)
+                        .font(.headline)
+                    Text(state.fileName)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 320)
+                }
+
+                if state.canCancel {
+                    Button("Cancel") {
+                        onCancel()
+                    }
+                    .keyboardShortcut(.cancelAction)
+                }
+            }
+            .padding(24)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .shadow(radius: 20)
+        }
     }
 }

--- a/Clearly/Native/StatusBarView.swift
+++ b/Clearly/Native/StatusBarView.swift
@@ -3,19 +3,33 @@ import ClearlyCore
 
 struct StatusBarView: View {
     @ObservedObject var state: StatusBarState
+    var showsCounts: Bool = true
+    var showsLargeDocumentMode: Bool = false
+    var documentCharacterCount: Int = 0
 
     var body: some View {
-        Text(label(for: state.counts))
-            .font(Theme.Typography.findCount)
-            .foregroundStyle(.secondary)
-            .monospacedDigit()
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.horizontal, Theme.Spacing.lg)
-            .padding(.vertical, Theme.Spacing.sm)
-            .frame(height: 28)
-            .accessibilityElement(children: .combine)
+        ZStack {
+            if showsCounts {
+                Text(label(for: state.counts))
+                    .font(Theme.Typography.findCount)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            HStack {
+                Spacer()
+                if showsLargeDocumentMode {
+                    LargeDocumentModeIndicator(characterCount: documentCharacterCount)
+                }
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.xs)
+        .frame(height: 28)
+        .accessibilityElement(children: .contain)
     }
 
     private func label(for c: MarkdownStats.Counts) -> String {
@@ -44,5 +58,64 @@ struct StatusBarView: View {
         let minutes = Int((Double(seconds) / 60.0).rounded())
         let bounded = max(1, minutes)
         return "\(bounded) min read"
+    }
+}
+
+private struct LargeDocumentModeIndicator: View {
+    let characterCount: Int
+
+    @State private var showsExplanation = false
+
+    var body: some View {
+        Button {
+            showsExplanation.toggle()
+        } label: {
+            Label("Large Document Mode", systemImage: "speedometer")
+                .labelStyle(.titleAndIcon)
+                .font(Theme.Typography.findCount)
+                .foregroundStyle(Theme.warningColorSwiftUI)
+                .padding(.horizontal, Theme.Spacing.sm)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule()
+                        .fill(Theme.warningColorSwiftUI.opacity(0.12))
+                )
+        }
+        .buttonStyle(.plain)
+        .help("Large Document Mode is active")
+        .accessibilityLabel("Large Document Mode")
+        .accessibilityHint("Shows what changes for performance in large documents")
+        .popover(isPresented: $showsExplanation, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                Label("Large Document Mode", systemImage: "speedometer")
+                    .font(.headline)
+
+                Text("This document has \(formatted(characterCount)) characters, so Clearly changes a few editor behaviors to keep typing responsive.")
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                    explanationRow("Live spelling, grammar, and autocorrect are disabled.")
+                    explanationRow("Syntax highlighting waits until you pause typing.")
+                    explanationRow("Word counts, outline, preview, and save-state updates may refresh after a short delay.")
+                }
+                .foregroundStyle(.secondary)
+            }
+            .padding(Theme.Spacing.lg)
+            .frame(width: 340, alignment: .leading)
+        }
+    }
+
+    private func explanationRow(_ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(Theme.warningColorSwiftUI)
+            Text(text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func formatted(_ n: Int) -> String {
+        n.formatted(.number)
     }
 }

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -22,9 +22,12 @@ private final class DraggableWKWebView: WKWebView {
 
 struct PreviewView: NSViewRepresentable {
     let markdown: String
+    var contentVersion: Int = 0
     var fontSize: CGFloat = 18
     var fontFamily: String = "sanFrancisco"
     var mode: ViewMode
+    var preloadWhenHidden = false
+    var hideWhenInactive = true
     var positionSyncID: String
     var fileURL: URL?
     var findState: FindState?
@@ -46,7 +49,7 @@ struct PreviewView: NSViewRepresentable {
     }
 
     private var contentKey: String {
-        "\(markdown.count)|\(markdown.hashValue)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")__\(hideFrontmatterInPreview)"
+        "\(contentVersion)__\(fontSize)__\(fontFamily)__\(colorScheme == .dark ? "dark" : "light")__\(LocalImageSupport.fileURLKeyFragment(fileURL))__\(wikiFilesKey)__\(contentWidthEm.map { "\($0)" } ?? "off")__\(hideFrontmatterInPreview)"
     }
 
     private var wikiFilesKey: String {
@@ -67,11 +70,14 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "foldToggle")
         config.userContentController.add(context.coordinator, name: "selectionCapture")
         config.userContentController.add(context.coordinator, name: "jumpToSource")
+        config.userContentController.add(context.coordinator, name: "loadPreviewChunk")
         config.userContentController.addUserScript(PreviewUserScripts.codeBlockChromeScript())
         let webView = DraggableWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.underPageBackgroundColor = Theme.backgroundColor
+        webView.isHidden = hideWhenInactive && mode != .preview
         webView.alphaValue = 0 // hidden until content loads
+        context.coordinator.webView = webView
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID
         context.coordinator.findState = findState
@@ -106,12 +112,14 @@ struct PreviewView: NSViewRepresentable {
             object: nil
         )
 
-        loadHTML(in: webView, context: context)
+        if mode == .preview || preloadWhenHidden {
+            loadHTML(in: webView, context: context)
+        }
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        webView.isHidden = mode != .preview
+        webView.isHidden = hideWhenInactive && mode != .preview
         webView.underPageBackgroundColor = Theme.backgroundColor
         context.coordinator.fileURL = fileURL
         context.coordinator.positionSyncID = positionSyncID
@@ -129,10 +137,11 @@ struct PreviewView: NSViewRepresentable {
         }
         context.coordinator.lastMode = mode
 
-        // Skip expensive content rendering when preview is hidden.
+        // Skip expensive content rendering when preview is hidden unless the
+        // caller explicitly opts into preloading small documents for crossfade.
         // When content changes while hidden, lastContentKey stays stale,
         // so the normal key comparison below will trigger a reload once visible.
-        guard mode == .preview else { return }
+        guard mode == .preview || preloadWhenHidden else { return }
 
         if context.coordinator.lastContentKey != contentKey {
             if context.coordinator.skipNextReload {
@@ -154,21 +163,116 @@ struct PreviewView: NSViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "foldToggle")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "selectionCapture")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "jumpToSource")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "loadPreviewChunk")
+        coordinator.renderTask?.cancel()
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
         context.coordinator.lastContentKey = contentKey
         context.coordinator.isLoadingContent = true
-        let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true, includeFrontmatter: !hideFrontmatterInPreview)
+        context.coordinator.renderGeneration += 1
+        context.coordinator.renderTask?.cancel()
+        let generation = context.coordinator.renderGeneration
+        let coordinator = context.coordinator
+        let markdownByteCount = markdown.utf8.count
+        DiagnosticLog.log("PreviewTiming start generation=\(generation) bytes=\(markdownByteCount) version=\(contentVersion) file=\(fileURL?.lastPathComponent ?? "<untitled>")")
+
+        if markdownByteCount >= Limits.asyncPreviewRenderLength {
+            loadChunkedPreview(in: webView, coordinator: coordinator, generation: generation)
+            return
+        }
+
+        coordinator.lazyChunks = []
+        coordinator.lazyPreviewContext = nil
+        let rawBody = MarkdownRenderer.renderHTML(
+            markdown,
+            appLinkURLs: true,
+            includeFrontmatter: !hideFrontmatterInPreview,
+            diagnosticsLabel: "small.renderHTML"
+        )
+        let imageStart = Self.timingStart()
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
-        let wikiFilesJSON: String = {
-            guard let names = wikiFileNames, !names.isEmpty else { return "[]" }
-            guard let data = try? JSONSerialization.data(withJSONObject: Array(names)),
-                  var json = String(data: data, encoding: .utf8) else { return "[]" }
-            // Prevent </script> injection in HTML context
-            json = json.replacingOccurrences(of: "</", with: "<\\/")
-            return json
-        }()
+        Self.logTiming("small.imageRewrite", since: imageStart)
+        loadHTMLBody(htmlBody, in: webView, coordinator: coordinator)
+    }
+
+    private func loadChunkedPreview(in webView: WKWebView, coordinator: Coordinator, generation: Int) {
+        coordinator.lazyChunks = []
+        coordinator.nextLazyChunkIndex = 0
+        coordinator.isLazyChunkRendering = false
+        coordinator.lazyPreviewContext = nil
+
+        let markdown = markdown
+        let fileURL = fileURL
+        let includeFrontmatter = !hideFrontmatterInPreview
+        coordinator.renderTask = Task {
+            do {
+                let backgroundStart = Self.timingStart()
+                let result = try await Task.detached(priority: .userInitiated) {
+                    try Task.checkCancellation()
+                    let chunkStart = Self.timingStart()
+                    let chunks = Self.previewChunks(from: markdown)
+                    Self.logTiming("large.planChunks count=\(chunks.count)", since: chunkStart)
+                    guard let firstChunk = chunks.first else {
+                        return (chunks: chunks, htmlBody: "")
+                    }
+                    let rawBody = MarkdownRenderer.renderHTML(
+                        firstChunk.markdown,
+                        appLinkURLs: true,
+                        includeFrontmatter: includeFrontmatter,
+                        sourceLineOffset: firstChunk.startLine - 1,
+                        diagnosticsLabel: "large.firstChunk.renderHTML"
+                    )
+                    try Task.checkCancellation()
+                    let imageStart = Self.timingStart()
+                    let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
+                    Self.logTiming("large.firstChunk.imageRewrite", since: imageStart)
+                    return (chunks: chunks, htmlBody: htmlBody)
+                }.value
+                Self.logTiming("large.firstChunk.backgroundTotal", since: backgroundStart)
+                try Task.checkCancellation()
+
+                await MainActor.run {
+                    guard coordinator.renderGeneration == generation else { return }
+                    coordinator.renderTask = nil
+                    coordinator.lazyChunks = result.chunks
+                    coordinator.nextLazyChunkIndex = min(1, result.chunks.count)
+                    coordinator.isLazyChunkRendering = false
+                    coordinator.lazyPreviewContext = LazyPreviewContext(fileURL: fileURL)
+                    let shellStart = Self.timingStart()
+                    let html = self.lazyPreviewHTML(
+                        initialHTMLBody: result.htmlBody,
+                        loadedChunks: min(1, result.chunks.count),
+                        totalChunks: result.chunks.count
+                    )
+                    Self.logTiming("large.lazyShellAssembly", since: shellStart)
+                    coordinator.navigationTimingLabel = "large.initialWebView"
+                    coordinator.navigationTimingStart = Self.timingStart()
+                    webView.loadHTMLString(
+                        html,
+                        baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL
+                    )
+                    DiagnosticLog.log("PreviewTiming large.initialWebView.loadHTMLStringIssued")
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    guard coordinator.renderGeneration == generation else { return }
+                    coordinator.isLoadingContent = false
+                }
+            } catch {
+                await MainActor.run {
+                    guard coordinator.renderGeneration == generation else { return }
+                    coordinator.isLoadingContent = false
+                    webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
+                }
+            }
+        }
+    }
+
+    private func loadHTMLBody(_ htmlBody: String, in webView: WKWebView, coordinator: Coordinator) {
+        coordinator.renderTask = nil
+        let shellStart = Self.timingStart()
+        let wikiFilesJSON = wikiFilesJSON()
         let scrollJS = """
         // Track scroll fraction for position sync between editor and preview.
         var _scrollTicking = false;
@@ -365,7 +469,309 @@ struct PreviewView: NSViewRepresentable {
         \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
+        Self.logTiming("small.fullShellAssembly", since: shellStart)
+        coordinator.navigationTimingLabel = "small.webView"
+        coordinator.navigationTimingStart = Self.timingStart()
         webView.loadHTMLString(html, baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
+        DiagnosticLog.log("PreviewTiming small.webView.loadHTMLStringIssued")
+    }
+
+    private func wikiFilesJSON() -> String {
+        guard let names = wikiFileNames, !names.isEmpty else { return "[]" }
+        guard let data = try? JSONSerialization.data(withJSONObject: Array(names)),
+              var json = String(data: data, encoding: .utf8) else { return "[]" }
+        // Prevent </script> injection in HTML context
+        json = json.replacingOccurrences(of: "</", with: "<\\/")
+        return json
+    }
+
+    private func lazyPreviewHTML(initialHTMLBody: String, loadedChunks: Int, totalChunks: Int) -> String {
+        let hasMore = loadedChunks < totalChunks ? "true" : "false"
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: bodyMaxWidthCSS))
+        mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
+        mark.clearly-mode-highlight { background: rgba(255, 210, 50, 0.5); border-radius: 3px; padding: 0 1px; transition: background 1.5s ease; }
+        mark.clearly-mode-highlight.fade { background: transparent; }
+        mark.clearly-outline-flash { background-color: rgba(255, 245, 100, 0.95); color: inherit; border-radius: 3px; padding: 0 2px; box-shadow: 0 0 0 1px rgba(220, 180, 0, 0.5); transition: background-color 1.2s ease, box-shadow 1.2s ease; }
+        mark.clearly-outline-flash.fade { background-color: transparent; box-shadow: 0 0 0 1px transparent; }
+        mark.clearly-find.current { background-color: rgba(255, 165, 0, 0.6); }
+        @media (prefers-color-scheme: dark) {
+            mark.clearly-find { background-color: rgba(180, 150, 0, 0.4); }
+            mark.clearly-find.current { background-color: rgba(200, 150, 0, 0.6); }
+        }
+        </style>
+        </head>
+        <body\(extraTopInset > 0 ? " style=\"padding-top: \(Int(extraTopInset))px\"" : "")>
+        <main id="clearly-preview-content">\(initialHTMLBody)</main>
+        </body>
+        <script>
+        var _clearlyHasMoreChunks = \(hasMore);
+        var _clearlyChunkRequestPending = false;
+        var _clearlyLoadedChunks = \(loadedChunks);
+        var _clearlyTotalChunks = \(totalChunks);
+        var _clearlyKnownFiles = new Set(\(wikiFilesJSON()));
+
+        function clearlyUniqueHeadingID(base) {
+            var normalized = (base || 'section').toLowerCase().replace(/[^\\w]+/g, '-').replace(/^-|-$/g, '') || 'section';
+            var candidate = normalized;
+            var suffix = 1;
+            while (document.getElementById(candidate)) {
+                candidate = normalized + '-' + suffix;
+                suffix += 1;
+            }
+            return candidate;
+        }
+
+        function clearlyPreparePreviewNodes(root) {
+            root.querySelectorAll('img').forEach(function(img) {
+                if (img.dataset.clearlyPrepared) return;
+                img.dataset.clearlyPrepared = '1';
+                img.addEventListener('error', function() {
+                    var el = document.createElement('div');
+                    el.className = 'img-placeholder';
+                    var label = img.alt || '';
+                    el.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>' + (label ? '<span>' + label + '</span>' : '');
+                    img.replaceWith(el);
+                });
+                img.style.cursor = 'zoom-in';
+            });
+
+            root.querySelectorAll('h1,h2,h3,h4,h5,h6').forEach(function(h) {
+                if (h.dataset.clearlyPrepared) return;
+                h.dataset.clearlyPrepared = '1';
+                h.id = h.id || clearlyUniqueHeadingID(h.textContent.trim());
+                var link = document.createElement('a');
+                link.className = 'heading-anchor';
+                link.href = '#' + h.id;
+                link.textContent = '#';
+                link.addEventListener('click', function(e) { e.stopPropagation(); });
+                h.prepend(link);
+            });
+
+            root.querySelectorAll('input[type="checkbox"]').forEach(function(cb) {
+                if (cb.dataset.clearlyPrepared) return;
+                cb.dataset.clearlyPrepared = '1';
+                var li = cb.closest('li');
+                if (!li) return;
+                cb.removeAttribute('disabled');
+                cb.disabled = false;
+                cb.style.cursor = 'pointer';
+                cb.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var sp = li.getAttribute('data-sourcepos');
+                    if (!sp) {
+                        var parent = li.closest('[data-sourcepos]');
+                        if (parent) sp = parent.getAttribute('data-sourcepos');
+                    }
+                    if (sp && window.webkit && window.webkit.messageHandlers.taskToggle) {
+                        window.webkit.messageHandlers.taskToggle.postMessage({ sourcepos: sp, checked: cb.checked });
+                    }
+                });
+            });
+
+            root.querySelectorAll('a.wiki-link').forEach(function(a) {
+                var href = a.getAttribute('href') || '';
+                if (!href.startsWith('clearly://wiki/')) return;
+                var target = decodeURIComponent(href.replace('clearly://wiki/', '').split('#')[0]);
+                if (_clearlyKnownFiles.size > 0 && !_clearlyKnownFiles.has(target.toLowerCase())) {
+                    a.classList.add('wiki-link-broken');
+                }
+            });
+        }
+
+        document.addEventListener('click', function(e) {
+            var a = e.target.closest('a[href]');
+            if (!a) return;
+            var href = a.getAttribute('href');
+            if (!href || href.startsWith('#')) return;
+            e.preventDefault();
+            window.webkit.messageHandlers.linkClicked.postMessage(href);
+        });
+
+        document.addEventListener('dblclick', function(e) {
+            var t = e.target;
+            if (!t || t.nodeType !== 1) return;
+            if (t.closest('.mermaid-wrapper, .lightbox-overlay, .mermaid-lightbox-overlay, .footnote-popover, summary, input, button, .copy-button, .code-copy, .table-sort-button')) return;
+            var node = t.closest('[data-sourcepos]');
+            if (!node) return;
+            var sp = node.getAttribute('data-sourcepos') || '';
+            var m = /^(\\d+):/.exec(sp);
+            if (!m) return;
+            window.webkit.messageHandlers.jumpToSource.postMessage({ line: parseInt(m[1], 10) });
+        });
+
+        var _scrollTicking = false;
+        window.addEventListener('scroll', function() {
+            if (_scrollTicking) return;
+            _scrollTicking = true;
+            requestAnimationFrame(function() {
+                var maxScroll = Math.max(1, document.body.scrollHeight - window.innerHeight);
+                var fraction = window.scrollY / maxScroll;
+                window.webkit.messageHandlers.scrollSync.postMessage({ fraction: fraction });
+                if (_clearlyHasMoreChunks && !_clearlyChunkRequestPending && (window.innerHeight + window.scrollY) > document.body.scrollHeight - 1600) {
+                    _clearlyChunkRequestPending = true;
+                    window.webkit.messageHandlers.loadPreviewChunk.postMessage({});
+                }
+                _scrollTicking = false;
+            });
+        });
+
+        document.addEventListener('selectionchange', function() {
+            var sel = window.getSelection();
+            var text = sel ? sel.toString() : '';
+            window.webkit.messageHandlers.selectionCapture.postMessage({ text: text });
+        });
+
+        window.clearlyAppendPreviewChunk = function(html, loadedChunks, totalChunks, done) {
+            var container = document.getElementById('clearly-preview-content');
+            var template = document.createElement('template');
+            template.innerHTML = html;
+            var fragment = template.content;
+            clearlyPreparePreviewNodes(fragment);
+            container.appendChild(fragment);
+            _clearlyLoadedChunks = loadedChunks;
+            _clearlyTotalChunks = totalChunks;
+            _clearlyHasMoreChunks = !done;
+            _clearlyChunkRequestPending = false;
+            setTimeout(clearlyRequestNextChunkIfNeeded, 0);
+        };
+
+        function clearlyRequestNextChunkIfNeeded() {
+            if (!_clearlyHasMoreChunks || _clearlyChunkRequestPending) return;
+            if ((window.innerHeight + window.scrollY) > document.body.scrollHeight - 1600) {
+                _clearlyChunkRequestPending = true;
+                window.webkit.messageHandlers.loadPreviewChunk.postMessage({});
+            }
+        }
+
+        clearlyPreparePreviewNodes(document);
+        setTimeout(clearlyRequestNextChunkIfNeeded, 0);
+        </script>
+        \(MathSupport.scriptHTML(for: initialHTMLBody))
+        \(TableSupport.scriptHTML(for: initialHTMLBody))
+        \(MermaidSupport.scriptHTML)
+        \(MermaidLightboxSupport.scriptHTML(for: initialHTMLBody))
+        \(SyntaxHighlightSupport.scriptHTML(for: initialHTMLBody))
+        </html>
+        """
+    }
+
+    fileprivate struct PreviewChunk {
+        let markdown: String
+        let startLine: Int
+    }
+
+    fileprivate struct LazyPreviewContext {
+        let fileURL: URL?
+    }
+
+    private static func previewChunks(from markdown: String) -> [PreviewChunk] {
+        let targetCharacters = 90_000
+        let hardLimitCharacters = 140_000
+        var chunks: [PreviewChunk] = []
+        var chunkStart = markdown.startIndex
+        var currentStartLine = 1
+        var currentLine = 1
+        var currentCount = 0
+        var lineStart = markdown.startIndex
+
+        while lineStart < markdown.endIndex {
+            let lineEnd = markdown[lineStart...].firstIndex(of: "\n") ?? markdown.endIndex
+            let nextLineStart = lineEnd < markdown.endIndex ? markdown.index(after: lineEnd) : markdown.endIndex
+            if currentCount == 0 {
+                chunkStart = lineStart
+                currentStartLine = currentLine
+            }
+            currentCount += markdown.distance(from: lineStart, to: nextLineStart)
+
+            let line = markdown[lineStart..<lineEnd]
+            let canSplit = line.first == "#" || line.allSatisfy { $0 == " " || $0 == "\t" || $0 == "\r" }
+            if currentCount >= hardLimitCharacters || (currentCount >= targetCharacters && canSplit) {
+                chunks.append(PreviewChunk(markdown: String(markdown[chunkStart..<nextLineStart]), startLine: currentStartLine))
+                currentCount = 0
+            }
+
+            lineStart = nextLineStart
+            currentLine += 1
+        }
+
+        if currentCount > 0 {
+            chunks.append(PreviewChunk(markdown: String(markdown[chunkStart..<markdown.endIndex]), startLine: currentStartLine))
+        }
+
+        return chunks
+    }
+
+    private static func renderPreviewChunk(_ chunk: PreviewChunk, fileURL: URL?, includeFrontmatter: Bool) async throws -> String {
+        try await Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
+            let rawBody = MarkdownRenderer.renderHTML(
+                chunk.markdown,
+                appLinkURLs: true,
+                includeFrontmatter: includeFrontmatter,
+                sourceLineOffset: chunk.startLine - 1,
+                diagnosticsLabel: "large.lazyChunk.line\(chunk.startLine).renderHTML"
+            )
+            try Task.checkCancellation()
+            let imageStart = timingStart()
+            let html = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
+            logTiming("large.lazyChunk.line\(chunk.startLine).imageRewrite", since: imageStart)
+            return html
+        }.value
+    }
+
+    private static func timingStart() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    private static func logTiming(_ label: String, since start: UInt64) {
+        #if DEBUG
+            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+            DiagnosticLog.log("PreviewTiming \(label): \(String(format: "%.2f", Double(elapsed) / 1_000_000)) ms")
+        #endif
+    }
+
+    private static func javascriptStringLiteral(_ text: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [text]),
+              let json = String(data: data, encoding: .utf8),
+              json.count >= 2 else {
+            return "\"\""
+        }
+        return String(json.dropFirst().dropLast())
+    }
+
+    private static func errorHTML(_ error: Error) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <style>
+        :root { color-scheme: light dark; }
+        body { margin: 0; padding: 32px; background: Canvas; color: CanvasText; font: 14px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; }
+        h1 { font-size: 16px; margin: 0 0 8px; }
+        p { margin: 0; opacity: 0.7; overflow-wrap: anywhere; }
+        </style>
+        </head>
+        <body>
+        <h1>Preview failed</h1>
+        <p>\(escapeHTML(error.localizedDescription))</p>
+        </body>
+        </html>
+        """
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
@@ -383,6 +789,14 @@ struct PreviewView: NSViewRepresentable {
         var onJumpToSource: ((Int) -> Void)?
         var skipNextReload = false
         var isLoadingContent = false
+        var renderGeneration = 0
+        var renderTask: Task<Void, Never>?
+        fileprivate var lazyChunks: [PreviewChunk] = []
+        var nextLazyChunkIndex = 0
+        var isLazyChunkRendering = false
+        fileprivate var lazyPreviewContext: LazyPreviewContext?
+        var navigationTimingLabel: String?
+        var navigationTimingStart: UInt64?
         var pendingScrollLine: Int?
         var pendingHighlightText: String?
         weak var webView: WKWebView?
@@ -723,6 +1137,11 @@ struct PreviewView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            if let label = navigationTimingLabel, let start = navigationTimingStart {
+                PreviewView.logTiming("\(label).didFinish", since: start)
+                navigationTimingLabel = nil
+                navigationTimingStart = nil
+            }
             isLoadingContent = false
             if !didInitialLoad {
                 didInitialLoad = true
@@ -795,7 +1214,66 @@ struct PreviewView: NSViewRepresentable {
             NSWorkspace.shared.open(targetURL)
         }
 
+        private func loadNextLazyPreviewChunk() {
+            guard !isLazyChunkRendering,
+                  nextLazyChunkIndex < lazyChunks.count,
+                  let context = lazyPreviewContext else { return }
+
+            isLazyChunkRendering = true
+            let generation = renderGeneration
+            let index = nextLazyChunkIndex
+            let chunk = lazyChunks[index]
+            let total = lazyChunks.count
+
+            renderTask = Task { [weak self] in
+                do {
+                    let chunkStart = PreviewView.timingStart()
+                    let htmlBody = try await PreviewView.renderPreviewChunk(
+                        chunk,
+                        fileURL: context.fileURL,
+                        includeFrontmatter: false
+                    )
+                    PreviewView.logTiming("large.lazyChunk.\(index + 1).backgroundTotal", since: chunkStart)
+                    try Task.checkCancellation()
+                    let jsonStart = PreviewView.timingStart()
+                    let htmlJSON = PreviewView.javascriptStringLiteral(htmlBody)
+                    PreviewView.logTiming("large.lazyChunk.\(index + 1).jsonEncode", since: jsonStart)
+
+                    await MainActor.run {
+                        guard let self, self.renderGeneration == generation else { return }
+                        self.renderTask = nil
+                        self.isLazyChunkRendering = false
+                        self.nextLazyChunkIndex = index + 1
+                        let loaded = self.nextLazyChunkIndex
+                        let done = loaded >= total ? "true" : "false"
+                        let js = "window.clearlyAppendPreviewChunk && window.clearlyAppendPreviewChunk(\(htmlJSON), \(loaded), \(total), \(done));"
+                        let appendStart = PreviewView.timingStart()
+                        self.webView?.evaluateJavaScript(js)
+                        PreviewView.logTiming("large.lazyChunk.\(index + 1).evaluateJavaScriptIssued", since: appendStart)
+                    }
+                } catch is CancellationError {
+                    await MainActor.run {
+                        guard let self, self.renderGeneration == generation else { return }
+                        self.renderTask = nil
+                        self.isLazyChunkRendering = false
+                    }
+                } catch {
+                    await MainActor.run {
+                        guard let self, self.renderGeneration == generation else { return }
+                        self.renderTask = nil
+                        self.isLazyChunkRendering = false
+                        DiagnosticLog.log("Lazy preview chunk failed: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if message.name == "loadPreviewChunk" {
+                loadNextLazyPreviewChunk()
+                return
+            }
+
             if message.name == "copyToClipboard", let text = message.body as? String {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -661,50 +661,14 @@ struct PreviewView: NSViewRepresentable {
         """
     }
 
-    fileprivate struct PreviewChunk {
-        let markdown: String
-        let startLine: Int
-    }
+    fileprivate typealias PreviewChunk = PreviewChunker.Chunk
 
     fileprivate struct LazyPreviewContext {
         let fileURL: URL?
     }
 
     private static func previewChunks(from markdown: String) -> [PreviewChunk] {
-        let targetCharacters = 90_000
-        let hardLimitCharacters = 140_000
-        var chunks: [PreviewChunk] = []
-        var chunkStart = markdown.startIndex
-        var currentStartLine = 1
-        var currentLine = 1
-        var currentCount = 0
-        var lineStart = markdown.startIndex
-
-        while lineStart < markdown.endIndex {
-            let lineEnd = markdown[lineStart...].firstIndex(of: "\n") ?? markdown.endIndex
-            let nextLineStart = lineEnd < markdown.endIndex ? markdown.index(after: lineEnd) : markdown.endIndex
-            if currentCount == 0 {
-                chunkStart = lineStart
-                currentStartLine = currentLine
-            }
-            currentCount += markdown.distance(from: lineStart, to: nextLineStart)
-
-            let line = markdown[lineStart..<lineEnd]
-            let canSplit = line.first == "#" || line.allSatisfy { $0 == " " || $0 == "\t" || $0 == "\r" }
-            if currentCount >= hardLimitCharacters || (currentCount >= targetCharacters && canSplit) {
-                chunks.append(PreviewChunk(markdown: String(markdown[chunkStart..<nextLineStart]), startLine: currentStartLine))
-                currentCount = 0
-            }
-
-            lineStart = nextLineStart
-            currentLine += 1
-        }
-
-        if currentCount > 0 {
-            chunks.append(PreviewChunk(markdown: String(markdown[chunkStart..<markdown.endIndex]), startLine: currentStartLine))
-        }
-
-        return chunks
+        PreviewChunker.chunks(from: markdown)
     }
 
     private static func renderPreviewChunk(_ chunk: PreviewChunk, fileURL: URL?, includeFrontmatter: Bool) async throws -> String {

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -370,7 +370,7 @@ final class QuickSwitcherManager: NSObject {
         if query.count >= 2 {
             let nameMatchURLs = Set(nameMatches.map(\.fullURL))
             for index in indexes {
-                for group in index.searchFilesGrouped(query: query) {
+                for group in index.searchFilesGrouped(query: query, maxExcerptsPerFile: 1) {
                     let fileURL = group.vaultRootURL.appendingPathComponent(group.file.path)
                     guard !nameMatchURLs.contains(fileURL) else { continue }
                     let excerpt = group.excerpts.first

--- a/Clearly/QuickSwitcherPanel.swift
+++ b/Clearly/QuickSwitcherPanel.swift
@@ -3,7 +3,7 @@ import ClearlyCore
 
 // MARK: - Quick Switcher File Item
 
-struct QuickSwitcherItem {
+struct QuickSwitcherItem: Sendable {
     let filename: String       // e.g. "My Note"
     let relativePath: String   // e.g. "folder/My Note.md"
     let fullURL: URL
@@ -40,7 +40,7 @@ struct QuickSwitcherItem {
 final class QuickSwitcherManager: NSObject {
     static let shared = QuickSwitcherManager()
 
-    private enum TagFilterMode {
+    private enum TagFilterMode: Sendable {
         case contains
         case exact(String)
     }
@@ -54,6 +54,10 @@ final class QuickSwitcherManager: NSObject {
     private var items: [QuickSwitcherItem] = []
     private var allFiles: [(filename: String, path: String, url: URL)] = []
     private var tagFilterMode: TagFilterMode = .contains
+    private var searchTask: Task<Void, Never>?
+    private var searchGeneration = 0
+
+    private static let searchDebounceNanoseconds: UInt64 = 180_000_000
 
     var isVisible: Bool { panel?.isVisible ?? false }
 
@@ -87,6 +91,7 @@ final class QuickSwitcherManager: NSObject {
     }
 
     func dismiss() {
+        searchTask?.cancel()
         panel?.orderOut(nil)
     }
 
@@ -241,6 +246,10 @@ final class QuickSwitcherManager: NSObject {
     }
 
     private func updateResults(query: String) {
+        searchTask?.cancel()
+        searchGeneration += 1
+        let generation = searchGeneration
+
         if query.isEmpty {
             // Show recent files
             let recents = WorkspaceManager.shared.recentFiles
@@ -262,11 +271,52 @@ final class QuickSwitcherManager: NSObject {
                     isCreateNew: false
                 )
             }
-        } else if query.hasPrefix("#") && query.count >= 2 {
+        } else {
+            let files = allFiles
+            let indexes = WorkspaceManager.shared.activeVaultIndexes
+            let mode = tagFilterMode
+            searchTask = Task {
+                do {
+                    try await Task.sleep(nanoseconds: Self.searchDebounceNanoseconds)
+                } catch {
+                    return
+                }
+
+                let computedItems = await Task.detached(priority: .userInitiated) {
+                    Self.computeItems(query: query, files: files, indexes: indexes, tagFilterMode: mode)
+                }.value
+
+                guard !Task.isCancelled, generation == self.searchGeneration else { return }
+                self.applyItems(computedItems)
+            }
+            return
+        }
+
+        applyItems(items)
+    }
+
+    private func applyItems(_ newItems: [QuickSwitcherItem]) {
+        items = newItems
+
+        tableView?.reloadData()
+        if !items.isEmpty {
+            tableView?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            tableView?.scrollRowToVisible(0)
+        }
+        resizePanelToFit()
+    }
+
+    nonisolated private static func computeItems(
+        query: String,
+        files: [(filename: String, path: String, url: URL)],
+        indexes: [VaultIndex],
+        tagFilterMode: TagFilterMode
+    ) -> [QuickSwitcherItem] {
+        if query.hasPrefix("#") && query.count >= 2 {
             // Tag filter: show files matching the tag
             let tagQuery = String(query.dropFirst()).lowercased()
             var tagResults: [QuickSwitcherItem] = []
-            for index in WorkspaceManager.shared.activeVaultIndexes {
+            for index in indexes {
                 // Find tags that match the query
                 let matchingTags = index.allTags().filter { entry in
                     switch tagFilterMode {
@@ -297,70 +347,63 @@ final class QuickSwitcherManager: NSObject {
                     }
                 }
             }
-            tagResults.sort { $0.filename.lowercased() < $1.filename.lowercased() }
-            items = tagResults
-        } else {
-            // Fuzzy match on filenames
-            var nameMatches = allFiles.compactMap { file -> QuickSwitcherItem? in
-                guard let result = FuzzyMatcher.match(query: query, target: file.filename) else { return nil }
-                return QuickSwitcherItem(
-                    filename: file.filename,
-                    relativePath: file.path,
-                    fullURL: file.url,
-                    score: result.score,
-                    matchedRanges: result.matchedRanges,
-                    isCreateNew: false
-                )
-            }
-            .sorted { $0.score > $1.score }
-            if nameMatches.count > 20 { nameMatches = Array(nameMatches.prefix(20)) }
+            return tagResults.sorted { $0.filename.lowercased() < $1.filename.lowercased() }
+        }
 
-            // Content matches via FTS5 (only if query is 2+ chars)
-            var contentMatches: [QuickSwitcherItem] = []
-            if query.count >= 2 {
-                let nameMatchURLs = Set(nameMatches.map(\.fullURL))
-                for index in WorkspaceManager.shared.activeVaultIndexes {
-                    for group in index.searchFilesGrouped(query: query) {
-                        let fileURL = group.vaultRootURL.appendingPathComponent(group.file.path)
-                        guard !nameMatchURLs.contains(fileURL) else { continue }
-                        let excerpt = group.excerpts.first
-                        contentMatches.append(QuickSwitcherItem(
-                            filename: group.file.filename,
-                            relativePath: group.file.path,
-                            fullURL: fileURL,
-                            score: 0,
-                            matchedRanges: [],
-                            isCreateNew: false,
-                            lineNumber: excerpt?.lineNumber,
-                            contextSnippet: excerpt?.contextLine.trimmingCharacters(in: .whitespaces)
-                        ))
-                    }
+        // Fuzzy match on filenames
+        var nameMatches = files.compactMap { file -> QuickSwitcherItem? in
+            guard let result = FuzzyMatcher.match(query: query, target: file.filename) else { return nil }
+            return QuickSwitcherItem(
+                filename: file.filename,
+                relativePath: file.path,
+                fullURL: file.url,
+                score: result.score,
+                matchedRanges: result.matchedRanges,
+                isCreateNew: false
+            )
+        }
+        .sorted { $0.score > $1.score }
+        if nameMatches.count > 20 { nameMatches = Array(nameMatches.prefix(20)) }
+
+        // Content matches via FTS5 (only if query is 2+ chars)
+        var contentMatches: [QuickSwitcherItem] = []
+        if query.count >= 2 {
+            let nameMatchURLs = Set(nameMatches.map(\.fullURL))
+            for index in indexes {
+                for group in index.searchFilesGrouped(query: query) {
+                    let fileURL = group.vaultRootURL.appendingPathComponent(group.file.path)
+                    guard !nameMatchURLs.contains(fileURL) else { continue }
+                    let excerpt = group.excerpts.first
+                    contentMatches.append(QuickSwitcherItem(
+                        filename: group.file.filename,
+                        relativePath: group.file.path,
+                        fullURL: fileURL,
+                        score: 0,
+                        matchedRanges: [],
+                        isCreateNew: false,
+                        lineNumber: excerpt?.lineNumber,
+                        contextSnippet: excerpt?.contextLine.trimmingCharacters(in: .whitespaces)
+                    ))
                 }
-                if contentMatches.count > 30 { contentMatches = Array(contentMatches.prefix(30)) }
             }
-
-            items = nameMatches + contentMatches
-
-            // Add create-on-miss if no results at all
-            if items.isEmpty {
-                let createName = query.hasSuffix(".md") ? query : "\(query).md"
-                items = [QuickSwitcherItem(
-                    filename: "Create \(createName)",
-                    relativePath: createName,
-                    fullURL: URL(fileURLWithPath: "/"),
-                    score: -1,
-                    matchedRanges: [],
-                    isCreateNew: true
-                )]
-            }
+            if contentMatches.count > 30 { contentMatches = Array(contentMatches.prefix(30)) }
         }
 
-        tableView?.reloadData()
-        if !items.isEmpty {
-            tableView?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
-            tableView?.scrollRowToVisible(0)
+        let results = nameMatches + contentMatches
+        if !results.isEmpty {
+            return results
         }
-        resizePanelToFit()
+
+        // Add create-on-miss if no results at all
+        let createName = query.hasSuffix(".md") ? query : "\(query).md"
+        return [QuickSwitcherItem(
+            filename: "Create \(createName)",
+            relativePath: createName,
+            fullURL: URL(fileURLWithPath: "/"),
+            score: -1,
+            matchedRanges: [],
+            isCreateNew: true
+        )]
     }
 
     private static let maxVisibleRows = 10

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -805,36 +805,27 @@ final class WorkspaceManager {
 
     private static func readUTF8Text(at url: URL, progress: @escaping @Sendable (Double) -> Void) throws -> String {
         try Task.checkCancellation()
-        let totalBytes = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-
-        var data = Data()
-        if totalBytes > 0, totalBytes <= Int64(Int.max) {
-            data.reserveCapacity(Int(totalBytes))
-        }
-
-        var bytesRead: Int64 = 0
-        while true {
-            try Task.checkCancellation()
-            let chunk = try handle.read(upToCount: 512 * 1024) ?? Data()
-            guard !chunk.isEmpty else { break }
-            bytesRead += Int64(chunk.count)
-            data.append(chunk)
-            if totalBytes > 0 {
-                progress(min(0.99, Double(bytesRead) / Double(totalBytes)))
-            }
-        }
-
+        // Memory-map when the OS thinks it's safe (i.e. the file is on a
+        // local volume) — that avoids the 2× peak of FileHandle.read(into:)
+        // followed by String(data:encoding:) for large markdown files.
+        // Falls back to a regular load for network/iCloud paths.
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
         try Task.checkCancellation()
         progress(1)
         guard let text = String(data: data, encoding: .utf8) else {
             throw DocumentLoadError.invalidUTF8
         }
+        try Task.checkCancellation()
         return text
     }
 
     private func applyLoadedFile(url: URL, text: String, inNewTab: Bool) {
+        // The dirty-state of the active document may have changed between
+        // when the load was kicked off and when its bytes are ready (the
+        // user kept typing). Re-confirm before clobbering.
+        if !inNewTab, activeDocumentIndex != nil {
+            guard confirmNavigationAwayFromActiveDoc() else { return }
+        }
         if inNewTab {
             let doc = OpenDocument(
                 id: UUID(),

--- a/Clearly/WorkspaceManager.swift
+++ b/Clearly/WorkspaceManager.swift
@@ -48,6 +48,33 @@ enum DeleteItemResult {
     case failed
 }
 
+struct DocumentLoadingState: Identifiable, Equatable {
+    let id: UUID
+    let fileName: String
+    var progress: Double?
+    var message: String
+    var canCancel: Bool
+
+    init(id: UUID = UUID(), fileName: String, progress: Double? = nil, message: String, canCancel: Bool = true) {
+        self.id = id
+        self.fileName = fileName
+        self.progress = progress
+        self.message = message
+        self.canCancel = canCancel
+    }
+}
+
+private enum DocumentLoadError: LocalizedError {
+    case invalidUTF8
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidUTF8:
+            return "The file is not valid UTF-8 text."
+        }
+    }
+}
+
 /// Central state manager for file navigation: locations, recents, and current file.
 @Observable
 final class WorkspaceManager {
@@ -70,8 +97,10 @@ final class WorkspaceManager {
 
     var currentFileURL: URL?
     var currentFileText: String = ""
+    var currentFileRevision: Int = 0
     var currentViewMode: ViewMode = WorkspaceManager.defaultViewModeForOpenedFile
     var currentConflictOutcome: ConflictResolver.Outcome?
+    var documentLoadingState: DocumentLoadingState?
 
     /// The currently-active open document, if any. Source of truth for
     /// dirty/clean state — see `isDirty`.
@@ -169,6 +198,7 @@ final class WorkspaceManager {
     @ObservationIgnored private var refreshWork: [UUID: DispatchWorkItem] = [:]
     @ObservationIgnored private var treeBuildGeneration: [UUID: Int] = [:]
     @ObservationIgnored private var treeBuildTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored private var documentLoadTask: Task<Void, Never>?
     private var autoSaveWork: DispatchWorkItem?
     private var accessedURLs: Set<URL> = []
     private var hasPreparedInitialDocuments = false
@@ -278,6 +308,7 @@ final class WorkspaceManager {
 
     deinit {
         autoSaveWork?.cancel()
+        documentLoadTask?.cancel()
         refreshWork.values.forEach { $0.cancel() }
         treeBuildTasks.values.forEach { $0.cancel() }
         for index in vaultIndexes.values { index.close() }
@@ -613,6 +644,7 @@ final class WorkspaceManager {
         openDocuments[idx].lastSavedText = ""
         if activeDocumentID == openDocuments[idx].id {
             currentFileText = ""
+            currentFileRevision += 1
         }
     }
 
@@ -625,6 +657,15 @@ final class WorkspaceManager {
         alert.runModal()
     }
 
+    private func presentFileOpenFailureAlert(for url: URL, error: Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn't open “\(url.lastPathComponent)”."
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
     // MARK: - Open File
 
     /// Opens a file by replacing the active tab's content (no new tab created).
@@ -632,6 +673,7 @@ final class WorkspaceManager {
     func openFile(at url: URL) -> Bool {
         // If already open in a tab, just switch to it
         if let existing = openDocuments.first(where: { $0.fileURL == url }) {
+            cancelDocumentLoad()
             return switchToDocument(existing.id)
         }
 
@@ -646,6 +688,11 @@ final class WorkspaceManager {
             return false
         }
 
+        if shouldLoadFileAsynchronously(url) {
+            startAsyncOpenFile(at: url, inNewTab: false)
+            return true
+        }
+
         // Load new file
         guard let data = try? Data(contentsOf: url),
               let text = String(data: data, encoding: .utf8) else {
@@ -653,13 +700,158 @@ final class WorkspaceManager {
             return false
         }
 
-        if let idx = activeDocumentIndex {
+        applyLoadedFile(url: url, text: text, inNewTab: false)
+        return true
+    }
+
+    /// Opens a file in a new tab (Cmd+click or Cmd+T then navigate).
+    @discardableResult
+    func openFileInNewTab(at url: URL) -> Bool {
+        // If already open in a tab, just switch to it
+        if let existing = openDocuments.first(where: { $0.fileURL == url }) {
+            cancelDocumentLoad()
+            return switchToDocument(existing.id)
+        }
+
+        guard confirmNavigationAwayFromActiveDoc() else { return false }
+
+        guard Limits.isOpenableSize(url) else {
+            DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
+            presentFileTooLargeAlert(for: url)
+            return false
+        }
+
+        if shouldLoadFileAsynchronously(url) {
+            startAsyncOpenFile(at: url, inNewTab: true)
+            return true
+        }
+
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            DiagnosticLog.log("Failed to read file: \(url.lastPathComponent)")
+            return false
+        }
+
+        applyLoadedFile(url: url, text: text, inNewTab: true)
+        return true
+    }
+
+    private func shouldLoadFileAsynchronously(_ url: URL) -> Bool {
+        fileSize(of: url).map { $0 >= Limits.asyncDocumentLoadFileSize } ?? false
+    }
+
+    private func fileSize(of url: URL) -> Int64? {
+        let resolvedURL = url.resolvingSymlinksInPath()
+        guard let size = try? resolvedURL.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+            return nil
+        }
+        return Int64(size)
+    }
+
+    func cancelDocumentLoad() {
+        documentLoadTask?.cancel()
+        documentLoadTask = nil
+        documentLoadingState = nil
+    }
+
+    private func startAsyncOpenFile(at url: URL, inNewTab: Bool) {
+        cancelDocumentLoad()
+
+        let loadID = UUID()
+        documentLoadingState = DocumentLoadingState(
+            id: loadID,
+            fileName: url.lastPathComponent,
+            progress: 0,
+            message: "Loading document…",
+            canCancel: true
+        )
+        presentMainWindow()
+
+        documentLoadTask = Task { [weak self] in
+            do {
+                let text = try await Task.detached(priority: .userInitiated) {
+                    try Self.readUTF8Text(at: url) { progress in
+                        DispatchQueue.main.async { [weak self] in
+                            guard self?.documentLoadingState?.id == loadID else { return }
+                            self?.documentLoadingState?.progress = progress
+                        }
+                    }
+                }.value
+                try Task.checkCancellation()
+
+                await MainActor.run {
+                    guard let self, self.documentLoadingState?.id == loadID else { return }
+                    self.documentLoadTask = nil
+                    self.documentLoadingState = nil
+                    self.applyLoadedFile(url: url, text: text, inNewTab: inNewTab)
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    guard let self, self.documentLoadingState?.id == loadID else { return }
+                    self.documentLoadTask = nil
+                    self.documentLoadingState = nil
+                }
+            } catch {
+                await MainActor.run {
+                    guard let self, self.documentLoadingState?.id == loadID else { return }
+                    self.documentLoadTask = nil
+                    self.documentLoadingState = nil
+                    DiagnosticLog.log("Failed to read file: \(url.lastPathComponent) (\(error.localizedDescription))")
+                    self.presentFileOpenFailureAlert(for: url, error: error)
+                }
+            }
+        }
+    }
+
+    private static func readUTF8Text(at url: URL, progress: @escaping @Sendable (Double) -> Void) throws -> String {
+        try Task.checkCancellation()
+        let totalBytes = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        var data = Data()
+        if totalBytes > 0, totalBytes <= Int64(Int.max) {
+            data.reserveCapacity(Int(totalBytes))
+        }
+
+        var bytesRead: Int64 = 0
+        while true {
+            try Task.checkCancellation()
+            let chunk = try handle.read(upToCount: 512 * 1024) ?? Data()
+            guard !chunk.isEmpty else { break }
+            bytesRead += Int64(chunk.count)
+            data.append(chunk)
+            if totalBytes > 0 {
+                progress(min(0.99, Double(bytesRead) / Double(totalBytes)))
+            }
+        }
+
+        try Task.checkCancellation()
+        progress(1)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw DocumentLoadError.invalidUTF8
+        }
+        return text
+    }
+
+    private func applyLoadedFile(url: URL, text: String, inNewTab: Bool) {
+        if inNewTab {
+            let doc = OpenDocument(
+                id: UUID(),
+                fileURL: url,
+                text: text,
+                lastSavedText: text,
+                untitledNumber: nil,
+                viewMode: WorkspaceManager.defaultViewModeForOpenedFile
+            )
+            openDocuments.append(doc)
+            activateDocument(doc)
+        } else if let idx = activeDocumentIndex {
             // Replacing the active tab's file is a host-driven same-document revision.
             // Bump the live editor epoch before mutating text so stale callbacks from
             // the previously loaded file cannot overwrite the newly opened content.
             documentEpoch += 1
             WYSIWYGSession.update(documentID: openDocuments[idx].id, epoch: documentEpoch)
-            // Replace the active tab's content in place
             openDocuments[idx].fileURL = url
             openDocuments[idx].text = text
             openDocuments[idx].lastSavedText = text
@@ -668,11 +860,11 @@ final class WorkspaceManager {
             openDocuments[idx].viewMode = WorkspaceManager.defaultViewModeForOpenedFile
             currentFileURL = url
             currentFileText = text
+            currentFileRevision += 1
             currentViewMode = openDocuments[idx].viewMode
             currentConflictOutcome = nil
             refreshConflictOutcomeForActiveDocument()
         } else {
-            // No active document — create one
             let doc = OpenDocument(
                 id: UUID(),
                 fileURL: url,
@@ -688,50 +880,8 @@ final class WorkspaceManager {
         addToRecents(url)
         persistLastOpenFile(url)
 
-        DiagnosticLog.log("Opened file: \(url.lastPathComponent)")
+        DiagnosticLog.log(inNewTab ? "Opened file in new tab: \(url.lastPathComponent)" : "Opened file: \(url.lastPathComponent)")
         presentMainWindow()
-        return true
-    }
-
-    /// Opens a file in a new tab (Cmd+click or Cmd+T then navigate).
-    @discardableResult
-    func openFileInNewTab(at url: URL) -> Bool {
-        // If already open in a tab, just switch to it
-        if let existing = openDocuments.first(where: { $0.fileURL == url }) {
-            return switchToDocument(existing.id)
-        }
-
-        guard confirmNavigationAwayFromActiveDoc() else { return false }
-
-        guard Limits.isOpenableSize(url) else {
-            DiagnosticLog.log("Refusing to open oversized file: \(url.lastPathComponent)")
-            presentFileTooLargeAlert(for: url)
-            return false
-        }
-
-        guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else {
-            DiagnosticLog.log("Failed to read file: \(url.lastPathComponent)")
-            return false
-        }
-
-        let doc = OpenDocument(
-            id: UUID(),
-            fileURL: url,
-            text: text,
-            lastSavedText: text,
-            untitledNumber: nil,
-            viewMode: WorkspaceManager.defaultViewModeForOpenedFile
-        )
-        openDocuments.append(doc)
-        activateDocument(doc)
-
-        addToRecents(url)
-        persistLastOpenFile(url)
-
-        DiagnosticLog.log("Opened file in new tab: \(url.lastPathComponent)")
-        presentMainWindow()
-        return true
     }
 
     // MARK: - Text Changes
@@ -770,6 +920,7 @@ final class WorkspaceManager {
         // will read on its next access.
         if let idx = activeDocumentIndex {
             openDocuments[idx].text = currentFileText
+            currentFileRevision += 1
         }
         // Only auto-save file-backed documents
         if isDirty, currentFileURL != nil {
@@ -784,6 +935,7 @@ final class WorkspaceManager {
         documentEpoch += 1
         WYSIWYGSession.update(documentID: activeDocumentID, epoch: documentEpoch)
         currentFileText = newText
+        currentFileRevision += 1
         if let idx = activeDocumentIndex {
             openDocuments[idx].text = newText
             openDocuments[idx].lastSavedText = newText
@@ -2513,6 +2665,7 @@ final class WorkspaceManager {
         WYSIWYGSession.update(documentID: doc.id, epoch: documentEpoch)
         currentFileURL = doc.fileURL
         currentFileText = doc.text
+        currentFileRevision += 1
         currentViewMode = doc.viewMode
         currentConflictOutcome = doc.conflictOutcome
         if doc.fileURL != nil {
@@ -2527,6 +2680,7 @@ final class WorkspaceManager {
         activeDocumentID = doc.id
         currentFileURL = doc.fileURL
         currentFileText = doc.text
+        currentFileRevision += 1
         currentViewMode = doc.viewMode
         currentConflictOutcome = doc.conflictOutcome
         if doc.fileURL != nil {

--- a/Clearly/iOS/ClearlyApp_iOS.swift
+++ b/Clearly/iOS/ClearlyApp_iOS.swift
@@ -13,6 +13,11 @@ struct ClearlyApp_iOS: App {
                 .environment(vaultSession)
                 .environment(expansionState)
                 .task {
+                    #if DEBUG && targetEnvironment(simulator)
+                    if attachSimulatorFixtureVaultIfAvailable() {
+                        return
+                    }
+                    #endif
                     await vaultSession.restoreFromPersistence()
                 }
                 .onChange(of: vaultSession.currentVault?.url) { _, newURL in
@@ -20,6 +25,37 @@ struct ClearlyApp_iOS: App {
                 }
         }
     }
+
+    #if DEBUG && targetEnvironment(simulator)
+    @MainActor
+    private func attachSimulatorFixtureVaultIfAvailable() -> Bool {
+        guard let bundledFixture = Bundle.main.resourceURL?
+            .appendingPathComponent("SimFixtureVault", isDirectory: true),
+            FileManager.default.fileExists(atPath: bundledFixture.path) else {
+            return false
+        }
+
+        do {
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: bundledFixture,
+                includingPropertiesForKeys: nil
+            )
+            guard !contents.isEmpty else { return false }
+
+            let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            let writableFixture = documents.appendingPathComponent("SimFixtureVault", isDirectory: true)
+            if FileManager.default.fileExists(atPath: writableFixture.path) {
+                try FileManager.default.removeItem(at: writableFixture)
+            }
+            try FileManager.default.copyItem(at: bundledFixture, to: writableFixture)
+            vaultSession.attach(VaultLocation(kind: .local, url: writableFixture))
+            return true
+        } catch {
+            DiagnosticLog.log("iOS simulator fixture vault failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+    #endif
 }
 
 /// Top-level view that picks between the iPhone `NavigationStack` path and

--- a/Clearly/iOS/ClearlyApp_iOS.swift
+++ b/Clearly/iOS/ClearlyApp_iOS.swift
@@ -13,8 +13,8 @@ struct ClearlyApp_iOS: App {
                 .environment(vaultSession)
                 .environment(expansionState)
                 .task {
-                    #if DEBUG && targetEnvironment(simulator)
-                    if attachSimulatorFixtureVaultIfAvailable() {
+                    #if DEBUG
+                    if attachDebugFixtureVaultIfAvailable() {
                         return
                     }
                     #endif
@@ -26,11 +26,11 @@ struct ClearlyApp_iOS: App {
         }
     }
 
-    #if DEBUG && targetEnvironment(simulator)
+    #if DEBUG
     @MainActor
-    private func attachSimulatorFixtureVaultIfAvailable() -> Bool {
+    private func attachDebugFixtureVaultIfAvailable() -> Bool {
         guard let bundledFixture = Bundle.main.resourceURL?
-            .appendingPathComponent("SimFixtureVault", isDirectory: true),
+            .appendingPathComponent("DebugFixtureVault", isDirectory: true),
             FileManager.default.fileExists(atPath: bundledFixture.path) else {
             return false
         }
@@ -43,7 +43,7 @@ struct ClearlyApp_iOS: App {
             guard !contents.isEmpty else { return false }
 
             let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            let writableFixture = documents.appendingPathComponent("SimFixtureVault", isDirectory: true)
+            let writableFixture = documents.appendingPathComponent("DebugFixtureVault", isDirectory: true)
             if FileManager.default.fileExists(atPath: writableFixture.path) {
                 try FileManager.default.removeItem(at: writableFixture)
             }
@@ -51,7 +51,7 @@ struct ClearlyApp_iOS: App {
             vaultSession.attach(VaultLocation(kind: .local, url: writableFixture))
             return true
         } catch {
-            DiagnosticLog.log("iOS simulator fixture vault failed: \(error.localizedDescription)")
+            DiagnosticLog.log("iOS debug fixture vault failed: \(error.localizedDescription)")
             return false
         }
     }

--- a/Clearly/iOS/EditorView_iOS.swift
+++ b/Clearly/iOS/EditorView_iOS.swift
@@ -70,6 +70,20 @@ struct EditorView_iOS: UIViewRepresentable {
         private var matchRanges: [NSRange] = []
         private var lastMatches: [TextMatch] = []
         private var currentMatchIdx: Int = 0
+        private var paintedFindRanges: [NSRange] = []
+        private var pendingFindWork: DispatchWorkItem?
+        private var findGeneration = 0
+
+        private static let findDebounceDelay: TimeInterval = 0.18
+        private static let maxPaintedFindHighlights = 600
+        private static let leadingPaintedFindHighlights = 120
+        private static let currentPaintedFindHighlightRadius = 120
+        private static let maxFindRehighlightParagraphs = 160
+
+        private enum FindComputationResult {
+            case matches([TextMatch])
+            case invalidRegex(String)
+        }
 
         init(parent: EditorView_iOS) {
             self.parent = parent
@@ -99,6 +113,7 @@ struct EditorView_iOS: UIViewRepresentable {
                 state?.editorPerformReplaceAll = { [weak self] in self?.performReplaceAll() }
             }
             guard let state else {
+                pendingFindWork?.cancel()
                 if lastFindVisible {
                     clearFindHighlights()
                     lastFindVisible = false
@@ -107,6 +122,7 @@ struct EditorView_iOS: UIViewRepresentable {
                 return
             }
             if !state.isVisible {
+                pendingFindWork?.cancel()
                 if lastFindVisible {
                     clearFindHighlights()
                 }
@@ -122,16 +138,99 @@ struct EditorView_iOS: UIViewRepresentable {
                 lastFindVisible = true
                 lastFindQuery = state.query
                 lastFindOptions = currentOptions
-                performFind(for: state)
+                scheduleFind(for: state)
             }
         }
 
         private func performFind(for state: FindState) {
+            scheduleFind(for: state, debounce: false)
+        }
+
+        private func scheduleFind(for state: FindState, debounce: Bool = true) {
             guard let textView else { return }
-            guard recomputeMatches(for: state) else { return }
-            applyFindHighlights()
-            if let first = matchRanges.first {
-                textView.scrollRangeToVisible(first)
+            pendingFindWork?.cancel()
+            findGeneration += 1
+            let generation = findGeneration
+            let query = state.query
+            let options = TextMatchOptions(
+                caseSensitive: state.caseSensitive,
+                useRegex: state.useRegex
+            )
+            let text = textView.text ?? ""
+
+            guard !query.isEmpty else {
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                clearFindHighlights()
+                state.matchCount = 0
+                state.currentIndex = 0
+                state.resultsAreStale = false
+                state.regexError = nil
+                state.lastReplaceCount = nil
+                return
+            }
+
+            state.resultsAreStale = true
+            state.regexError = nil
+            state.lastReplaceCount = nil
+
+            let work = DispatchWorkItem { [weak self, weak state] in
+                Task.detached(priority: .userInitiated) {
+                    let result: FindComputationResult
+                    do {
+                        result = .matches(try TextMatcher.matches(of: query, in: text, options: options))
+                    } catch let TextMatcherError.invalidRegex(message) {
+                        result = .invalidRegex(message)
+                    } catch {
+                        result = .matches([])
+                    }
+
+                    await MainActor.run { [weak self, weak state] in
+                        guard let self, let state else { return }
+                        self.applyFindComputationResult(result, for: state, generation: generation)
+                    }
+                }
+            }
+            pendingFindWork = work
+            if debounce {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.findDebounceDelay, execute: work)
+            } else {
+                DispatchQueue.main.async(execute: work)
+            }
+        }
+
+        private func applyFindComputationResult(
+            _ result: FindComputationResult,
+            for state: FindState,
+            generation: Int
+        ) {
+            guard generation == findGeneration, state.isVisible, state.activeMode == .edit else { return }
+            switch result {
+            case .invalidRegex(let message):
+                matchRanges = []
+                lastMatches = []
+                currentMatchIdx = 0
+                clearFindHighlights()
+                state.matchCount = 0
+                state.currentIndex = 0
+                state.resultsAreStale = false
+                state.regexError = message
+                state.lastReplaceCount = nil
+
+            case .matches(let matches):
+                matchRanges = matches.map(\.range)
+                lastMatches = matches
+                currentMatchIdx = 0
+                applyFindHighlights()
+                if let first = matchRanges.first {
+                    textView?.scrollRangeToVisible(first)
+                }
+                state.matchCount = matches.count
+                state.currentIndex = matches.isEmpty ? 0 : 1
+                state.resultsAreStale = false
+                state.regexError = nil
+                state.lastReplaceCount = nil
             }
         }
 
@@ -224,35 +323,88 @@ struct EditorView_iOS: UIViewRepresentable {
         private func applyFindHighlights() {
             guard let textView else { return }
             let storage = textView.textStorage
-            resetBackgroundsThenRehighlight(storage: storage)
+            resetFindBackgrounds(in: paintedFindRanges, storage: storage)
+            let rangesToPaint = paintedFindHighlightRanges()
             storage.beginEditing()
-            for (i, range) in matchRanges.enumerated() {
+            for (i, range) in rangesToPaint {
                 guard range.upperBound <= storage.length else { continue }
                 let color = (i == currentMatchIdx) ? Theme.findCurrentHighlightColor : Theme.findHighlightColor
                 storage.addAttribute(.backgroundColor, value: color, range: range)
             }
             storage.endEditing()
+            paintedFindRanges = rangesToPaint.map(\.range)
         }
 
         private func clearFindHighlights() {
             guard let textView else { return }
-            resetBackgroundsThenRehighlight(storage: textView.textStorage)
+            findGeneration += 1
+            pendingFindWork?.cancel()
+            resetFindBackgrounds(in: paintedFindRanges, storage: textView.textStorage)
+            paintedFindRanges = []
             matchRanges = []
             lastMatches = []
             currentMatchIdx = 0
         }
 
-        /// Wipe every `.backgroundColor` attribute, then re-run the syntax
-        /// highlighter so `==highlight==` markdown backgrounds get repainted.
-        /// Without the explicit wipe, find paints from previous queries (e.g.
-        /// the partial matches on each keystroke) stay attached to text storage
-        /// since the highlighter only adds attributes, never clears them.
-        private func resetBackgroundsThenRehighlight(storage: NSTextStorage) {
-            let fullRange = NSRange(location: 0, length: storage.length)
+        private func paintedFindHighlightRanges() -> [(index: Int, range: NSRange)] {
+            guard matchRanges.count > Self.maxPaintedFindHighlights else {
+                return matchRanges.enumerated().map { ($0.offset, $0.element) }
+            }
+
+            var indexes = Set<Int>()
+            let leadingCount = min(Self.leadingPaintedFindHighlights, matchRanges.count)
+            indexes.formUnion(0..<leadingCount)
+
+            let lower = max(0, currentMatchIdx - Self.currentPaintedFindHighlightRadius)
+            let upper = min(matchRanges.count - 1, currentMatchIdx + Self.currentPaintedFindHighlightRadius)
+            indexes.formUnion(lower...upper)
+            indexes.insert(currentMatchIdx)
+
+            return indexes.sorted().map { ($0, matchRanges[$0]) }
+        }
+
+        /// Remove old find paints only where we put them. Repainting the entire
+        /// document for every find keystroke is the expensive path on large
+        /// books; this keeps normal markdown `==highlight==` backgrounds intact
+        /// by re-highlighting just the touched paragraphs.
+        private func resetFindBackgrounds(in ranges: [NSRange], storage: NSTextStorage) {
+            let validRanges = ranges.compactMap { clampedRange($0, upperBound: storage.length) }
+            guard !validRanges.isEmpty else { return }
             storage.beginEditing()
-            storage.removeAttribute(.backgroundColor, range: fullRange)
+            for range in validRanges {
+                storage.removeAttribute(.backgroundColor, range: range)
+            }
             storage.endEditing()
-            rerunSyntaxHighlighter(on: storage)
+
+            let paragraphRanges = uniqueParagraphRanges(for: validRanges, in: storage.string)
+            for paragraphRange in paragraphRanges.prefix(Self.maxFindRehighlightParagraphs) {
+                highlighter.highlightAround(
+                    storage,
+                    editedRange: paragraphRange,
+                    replacementLength: paragraphRange.length,
+                    caller: "find-clear"
+                )
+            }
+        }
+
+        private func uniqueParagraphRanges(for ranges: [NSRange], in text: String) -> [NSRange] {
+            let nsText = text as NSString
+            var seen = Set<String>()
+            var paragraphs: [NSRange] = []
+            for range in ranges {
+                let paragraph = nsText.paragraphRange(for: range)
+                let key = "\(paragraph.location):\(paragraph.length)"
+                guard seen.insert(key).inserted else { continue }
+                paragraphs.append(paragraph)
+            }
+            return paragraphs
+        }
+
+        private func clampedRange(_ range: NSRange, upperBound: Int) -> NSRange? {
+            guard range.location != NSNotFound, range.location < upperBound else { return nil }
+            let length = min(range.length, upperBound - range.location)
+            guard length > 0 else { return nil }
+            return NSRange(location: range.location, length: length)
         }
 
         // MARK: - Replace
@@ -349,13 +501,6 @@ struct EditorView_iOS: UIViewRepresentable {
             }
             ctv.text = restoredText
             ctv.delegate?.textViewDidChange?(ctv)
-        }
-
-        private func rerunSyntaxHighlighter(on storage: NSTextStorage) {
-            let wasHighlighting = isHighlighting
-            isHighlighting = true
-            highlighter.highlightAll(storage, caller: "find-rerun")
-            isHighlighting = wasHighlighting
         }
 
         private func scrollToRange(_ range: NSRange) {

--- a/Clearly/iOS/PreviewView_iOS.swift
+++ b/Clearly/iOS/PreviewView_iOS.swift
@@ -91,6 +91,7 @@ struct PreviewView_iOS: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.renderTask?.cancel()
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "linkClicked")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "foldToggle")
@@ -98,11 +99,64 @@ struct PreviewView_iOS: UIViewRepresentable {
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
-        context.coordinator.lastContentKey = contentKey
+        let key = contentKey
+        let baseURL = fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL
+        context.coordinator.lastContentKey = key
+        context.coordinator.renderTask?.cancel()
+
+        if markdown.utf8.count >= Limits.asyncPreviewRenderLength {
+            let markdown = markdown
+            let fileURL = fileURL
+            let fontSize = fontSize
+            let fontFamily = fontFamily
+            let hideFrontmatter = hideFrontmatter
+            let coordinator = context.coordinator
+            coordinator.renderTask = Task { @MainActor [weak webView] in
+                do {
+                    let html = try await Task.detached(priority: .userInitiated) {
+                        try Task.checkCancellation()
+                        return Self.renderHTMLDocument(
+                            markdown: markdown,
+                            fileURL: fileURL,
+                            fontSize: fontSize,
+                            fontFamily: fontFamily,
+                            hideFrontmatter: hideFrontmatter
+                        )
+                    }.value
+                    guard !Task.isCancelled,
+                          coordinator.lastContentKey == key,
+                          let webView else { return }
+                    webView.loadHTMLString(html, baseURL: baseURL)
+                } catch is CancellationError {
+                    return
+                } catch {
+                    DiagnosticLog.log("iOS preview async render failed: \(error)")
+                }
+            }
+            return
+        }
+
+        let html = Self.renderHTMLDocument(
+            markdown: markdown,
+            fileURL: fileURL,
+            fontSize: fontSize,
+            fontFamily: fontFamily,
+            hideFrontmatter: hideFrontmatter
+        )
+        webView.loadHTMLString(html, baseURL: baseURL)
+    }
+
+    private static func renderHTMLDocument(
+        markdown: String,
+        fileURL: URL?,
+        fontSize: CGFloat,
+        fontFamily: String,
+        hideFrontmatter: Bool
+    ) -> String {
         let rawBody = MarkdownRenderer.renderHTML(markdown, appLinkURLs: true, includeFrontmatter: !hideFrontmatter)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
 
-        let html = """
+        return """
         <!DOCTYPE html>
         <html>
         <head>
@@ -205,12 +259,12 @@ struct PreviewView_iOS: UIViewRepresentable {
         \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
-        webView.loadHTMLString(html, baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         var lastContentKey: String?
         var skipNextReload: Bool = false
+        var renderTask: Task<Void, Never>?
         var fileURL: URL?
         var onWikiLinkClicked: ((String) -> Void)?
         var onTaskToggle: ((Int, Bool) -> Void)?

--- a/Clearly/iOS/QuickSwitcherSheet_iOS.swift
+++ b/Clearly/iOS/QuickSwitcherSheet_iOS.swift
@@ -202,7 +202,7 @@ struct QuickSwitcherSheet_iOS: View {
             let byURL = Dictionary(uniqueKeysWithValues: files.map {
                 ($0.url.standardizedFileURL, $0)
             })
-            let groups = index.searchFilesGrouped(query: trimmed)
+            let groups = index.searchFilesGrouped(query: trimmed, maxExcerptsPerFile: 1)
             for group in groups {
                 let absoluteURL = root.appendingPathComponent(group.file.path).standardizedFileURL
                 guard !filenameURLs.contains(absoluteURL) else { continue }

--- a/Clearly/iOS/QuickSwitcherSheet_iOS.swift
+++ b/Clearly/iOS/QuickSwitcherSheet_iOS.swift
@@ -13,9 +13,11 @@ struct QuickSwitcherSheet_iOS: View {
 
     @State private var query: String = ""
     @State private var rows: [QuickSwitcherRow] = []
+    @State private var searchTask: Task<Void, Never>?
 
     private static let filenameLimit = 20
     private static let contentLimit = 30
+    private static let searchDebounceNanoseconds: UInt64 = 180_000_000
 
     var body: some View {
         NavigationStack {
@@ -43,6 +45,7 @@ struct QuickSwitcherSheet_iOS: View {
         }
         .onChange(of: query) { _, _ in recomputeRows() }
         .onChange(of: vault.files) { _, _ in recomputeRows() }
+        .onDisappear { searchTask?.cancel() }
     }
 
     @ViewBuilder
@@ -132,6 +135,8 @@ struct QuickSwitcherSheet_iOS: View {
     // MARK: - Row computation
 
     private func recomputeRows() {
+        searchTask?.cancel()
+
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             if !vault.recentFiles.isEmpty {
@@ -149,8 +154,38 @@ struct QuickSwitcherSheet_iOS: View {
             return
         }
 
+        let files = vault.files
+        let index = vault.currentIndex
+        let vaultRoot = vault.currentVault?.url ?? index?.rootURL
+        searchTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: Self.searchDebounceNanoseconds)
+            } catch {
+                return
+            }
+
+            let computedRows = await Task.detached(priority: .userInitiated) {
+                Self.computeRows(
+                    query: trimmed,
+                    files: files,
+                    index: index,
+                    vaultRoot: vaultRoot
+                )
+            }.value
+
+            guard !Task.isCancelled else { return }
+            rows = computedRows
+        }
+    }
+
+    private static func computeRows(
+        query trimmed: String,
+        files: [VaultFile],
+        index: VaultIndex?,
+        vaultRoot: URL?
+    ) -> [QuickSwitcherRow] {
         var filenameMatches: [(file: VaultFile, score: Int, ranges: [Range<String.Index>])] = []
-        for file in vault.files {
+        for file in files {
             if let result = FuzzyMatcher.match(query: trimmed, target: file.name) {
                 filenameMatches.append((file, result.score, result.matchedRanges))
             }
@@ -161,15 +196,15 @@ struct QuickSwitcherSheet_iOS: View {
         }
 
         var contentHits: [QuickSwitcherRow] = []
-        if trimmed.count >= 2, let index = vault.currentIndex {
+        if trimmed.count >= 2, let index {
             let filenameURLs = Set(filenameMatches.map { $0.file.url.standardizedFileURL })
-            let vaultRoot = vault.currentVault?.url ?? index.rootURL
-            let byURL = Dictionary(uniqueKeysWithValues: vault.files.map {
+            let root = vaultRoot ?? index.rootURL
+            let byURL = Dictionary(uniqueKeysWithValues: files.map {
                 ($0.url.standardizedFileURL, $0)
             })
             let groups = index.searchFilesGrouped(query: trimmed)
             for group in groups {
-                let absoluteURL = vaultRoot.appendingPathComponent(group.file.path).standardizedFileURL
+                let absoluteURL = root.appendingPathComponent(group.file.path).standardizedFileURL
                 guard !filenameURLs.contains(absoluteURL) else { continue }
                 let file = byURL[absoluteURL] ?? VaultFile(
                     url: absoluteURL,
@@ -195,7 +230,7 @@ struct QuickSwitcherSheet_iOS: View {
         if combined.isEmpty {
             combined.append(.create(name: createName(for: trimmed)))
         }
-        rows = combined
+        return combined
     }
 
     // MARK: - Interaction
@@ -286,7 +321,7 @@ struct QuickSwitcherSheet_iOS: View {
     /// Turn the user's query into the filename we'll create. Runs through the
     /// same kebab-case sanitization as manual renames and Notes-style
     /// auto-naming so filenames across the app stay consistent.
-    private func createName(for query: String) -> String {
+    private static func createName(for query: String) -> String {
         var stem = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if stem.lowercased().hasSuffix(".md") {
             stem = String(stem.dropLast(3))

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -5,42 +5,113 @@ import WebKit
 
 class PreviewViewController: NSViewController, QLPreviewingController {
     private var webView: WKWebView!
+    private var previewTask: Task<Void, Never>?
+
+    deinit {
+        previewTask?.cancel()
+    }
 
     override func loadView() {
         webView = WKWebView()
-        self.view = webView
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+
+        self.view = container
     }
 
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
-        do {
-            let markdownText = try String(contentsOf: url, encoding: .utf8)
-            let htmlBody = MarkdownRenderer.renderHTML(markdownText)
+        previewTask?.cancel()
+        webView.loadHTMLString("", baseURL: nil)
+        handler(nil)
 
-            let html = """
-            <!DOCTYPE html>
-            <html>
-            <head>
-            <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1">
-            <style>\(PreviewCSS.css())</style>
-            <style>
-            @media (max-width: 400px) {
-                body { font-size: 14px; padding: 10px 20px 20px; }
+        previewTask = Task { [weak self] in
+            do {
+                let html = try await Task.detached(priority: .userInitiated) {
+                    try Task.checkCancellation()
+                    let markdownText = try String(contentsOf: url, encoding: .utf8)
+                    try Task.checkCancellation()
+                    let htmlBody = MarkdownRenderer.renderHTML(markdownText)
+                    return Self.previewHTML(for: htmlBody)
+                }.value
+                try Task.checkCancellation()
+
+                await MainActor.run {
+                    guard let self else { return }
+                    self.previewTask = nil
+                    self.webView.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    guard let self else { return }
+                    self.previewTask = nil
+                }
+            } catch {
+                await MainActor.run {
+                    guard let self else { return }
+                    self.previewTask = nil
+                    self.webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
+                }
             }
-            </style>
-            </head>
-            <body>\(htmlBody)</body>
-            \(MathSupport.scriptHTML(for: htmlBody))
-            \(TableSupport.scriptHTML(for: htmlBody))
-            \(MermaidSupport.scriptHTML)
-            \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
-            </html>
-            """
-
-            webView.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
-            handler(nil)
-        } catch {
-            handler(error)
         }
+    }
+
+    private static func previewHTML(for htmlBody: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>\(PreviewCSS.css())</style>
+        <style>
+        @media (max-width: 400px) {
+            body { font-size: 14px; padding: 10px 20px 20px; }
+        }
+        </style>
+        </head>
+        <body>\(htmlBody)</body>
+        \(MathSupport.scriptHTML(for: htmlBody))
+        \(TableSupport.scriptHTML(for: htmlBody))
+        \(MermaidSupport.scriptHTML)
+        \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
+        </html>
+        """
+    }
+
+    private static func errorHTML(_ error: Error) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <style>
+        :root { color-scheme: light dark; }
+        body { margin: 0; padding: 24px; background: Canvas; color: CanvasText; font: 14px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; }
+        h1 { font-size: 16px; margin: 0 0 8px; }
+        p { margin: 0; opacity: 0.7; overflow-wrap: anywhere; }
+        </style>
+        </head>
+        <body>
+        <h1>Preview failed</h1>
+        <p>\(escapeHTML(error.localizedDescription))</p>
+        </body>
+        </html>
+        """
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
     }
 }

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -3,9 +3,12 @@ import ClearlyCore
 import QuickLookUI
 import WebKit
 
-class PreviewViewController: NSViewController, QLPreviewingController {
+class PreviewViewController: NSViewController, QLPreviewingController, WKNavigationDelegate {
     private var webView: WKWebView!
     private var previewTask: Task<Void, Never>?
+    // QuickLook treats the handler as "preview ready"; only call it once the
+    // WebView has actually finished loading the rendered HTML.
+    private var pendingCompletion: ((Error?) -> Void)?
 
     deinit {
         previewTask?.cancel()
@@ -13,6 +16,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
     override func loadView() {
         webView = WKWebView()
+        webView.navigationDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()
@@ -29,8 +33,12 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
         previewTask?.cancel()
-        webView.loadHTMLString("", baseURL: nil)
-        handler(nil)
+        // Resolve any prior pending handler so QuickLook isn't left waiting.
+        if let prior = pendingCompletion {
+            pendingCompletion = nil
+            prior(nil)
+        }
+        pendingCompletion = handler
 
         previewTask = Task { [weak self] in
             do {
@@ -52,15 +60,40 @@ class PreviewViewController: NSViewController, QLPreviewingController {
                 await MainActor.run {
                     guard let self else { return }
                     self.previewTask = nil
+                    // Cancellation here means a newer preparePreview call came
+                    // in; the new handler owns completion now.
                 }
             } catch {
                 await MainActor.run {
                     guard let self else { return }
                     self.previewTask = nil
-                    self.webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
+                    if let handler = self.pendingCompletion {
+                        self.pendingCompletion = nil
+                        handler(error)
+                    }
                 }
             }
         }
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let handler = pendingCompletion else { return }
+        pendingCompletion = nil
+        handler(nil)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        guard let handler = pendingCompletion else { return }
+        pendingCompletion = nil
+        handler(error)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        guard let handler = pendingCompletion else { return }
+        pendingCompletion = nil
+        handler(error)
     }
 
     private static func previewHTML(for htmlBody: String) -> String {
@@ -86,32 +119,4 @@ class PreviewViewController: NSViewController, QLPreviewingController {
         """
     }
 
-    private static func errorHTML(_ error: Error) -> String {
-        """
-        <!DOCTYPE html>
-        <html>
-        <head>
-        <meta charset="utf-8">
-        <style>
-        :root { color-scheme: light dark; }
-        body { margin: 0; padding: 24px; background: Canvas; color: CanvasText; font: 14px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; }
-        h1 { font-size: 16px; margin: 0 0 8px; }
-        p { margin: 0; opacity: 0.7; overflow-wrap: anywhere; }
-        </style>
-        </head>
-        <body>
-        <h1>Preview failed</h1>
-        <p>\(escapeHTML(error.localizedDescription))</p>
-        </body>
-        </html>
-        """
-    }
-
-    private static func escapeHTML(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-    }
 }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
@@ -13,6 +13,8 @@ public enum Limits {
 
     public static let maxHighlightAllLength: Int = 5_000_000
 
+    public static let largeEditorPerformanceModeLength: Int = 50_000
+
     public static func isOpenableSize(_ url: URL) -> Bool {
         isFileSize(url, atMost: maxOpenableFileSize)
     }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Limits.swift
@@ -5,6 +5,12 @@ public enum Limits {
 
     public static let maxLocalImageSize: Int64 = 20_000_000
 
+    public static let asyncDocumentLoadFileSize: Int64 = 1_000_000
+
+    public static let asyncPreviewRenderLength: Int = 500_000
+
+    public static let previewCrossfadeRenderLength: Int = 100_000
+
     public static let maxHighlightAllLength: Int = 5_000_000
 
     public static func isOpenableSize(_ url: URL) -> Bool {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -6,14 +6,39 @@ public enum MarkdownRenderer {
     private static let escapedMathDollarToken = "\u{E101}"
     private static let escapedMathPaddingToken = "\u{E102}"
 
-    public static func renderHTML(_ markdown: String, appLinkURLs: Bool = false, includeFrontmatter: Bool = true) -> String {
+    public static func renderHTML(
+        _ markdown: String,
+        appLinkURLs: Bool = false,
+        includeFrontmatter: Bool = true,
+        sourceLineOffset: Int = 0,
+        diagnosticsLabel: String? = nil
+    ) -> String {
         guard !markdown.isEmpty else { return "" }
+
+        let totalStart = DispatchTime.now().uptimeNanoseconds
+        var stageStart = totalStart
+        func mark(_ stage: String) {
+            #if DEBUG
+                guard let diagnosticsLabel else { return }
+                let now = DispatchTime.now().uptimeNanoseconds
+                DiagnosticLog.log("PreviewTiming \(diagnosticsLabel).\(stage): \(formatMilliseconds(now - stageStart)) ms")
+                stageStart = now
+            #endif
+        }
+        func finishTiming() {
+            #if DEBUG
+                guard let diagnosticsLabel else { return }
+                let now = DispatchTime.now().uptimeNanoseconds
+                DiagnosticLog.log("PreviewTiming \(diagnosticsLabel).total: \(formatMilliseconds(now - totalStart)) ms")
+            #endif
+        }
 
         let frontmatter = FrontmatterSupport.extract(from: markdown)
 
         let rawBody = frontmatter?.body ?? markdown
         let (body, codeFilenames) = extractCodeFilenames(rawBody)
         let protectedBody = protectEscapedMathDelimiters(in: body)
+        mark("preprocess")
         let len = protectedBody.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)
         var html: String
@@ -28,29 +53,50 @@ public enum MarkdownRenderer {
         } else {
             return ""
         }
+        mark("cmark")
         html = processMath(html)
+        mark("math")
         html = restoreEscapedMathDelimiters(in: html)
         html = processHighlightMarks(html)
+        mark("highlightMarks")
         html = processSuperSub(html)
+        mark("superSub")
         html = processEmoji(html)
+        mark("emoji")
         html = processWikiLinks(html, appLinkURLs: appLinkURLs)
+        mark("wikiLinks")
         html = processTags(html, appLinkURLs: appLinkURLs)
+        mark("tags")
         html = processCallouts(html)
+        mark("callouts")
         html = processTOC(html)
+        mark("toc")
         html = processCaptions(html)
         html = injectCodeFilenames(html, filenames: codeFilenames)
+        mark("captionsAndCodeFilenames")
 
-        // Fix sourcepos line numbers after stripping frontmatter
+        // Fix sourcepos line numbers after stripping frontmatter and/or rendering a document chunk.
+        var sourceOffset = sourceLineOffset
         if let frontmatter, frontmatter.lineCount > 0 {
-            html = adjustSourcePositions(in: html, offset: frontmatter.lineCount)
+            sourceOffset += frontmatter.lineCount
+        }
+        if sourceOffset > 0 {
+            html = adjustSourcePositions(in: html, offset: sourceOffset)
+            mark("sourceposAdjust")
         }
 
         // Prepend frontmatter HTML
         if includeFrontmatter, let frontmatter {
             html = frontmatterHTML(from: frontmatter) + html
+            mark("frontmatterHTML")
         }
 
+        finishTiming()
         return html
+    }
+
+    private static func formatMilliseconds(_ nanoseconds: UInt64) -> String {
+        String(format: "%.2f", Double(nanoseconds) / 1_000_000)
     }
 
     // MARK: - Frontmatter
@@ -212,14 +258,31 @@ public enum MarkdownRenderer {
     }
 
     private static func restoreProtectedSegments(in html: String, segments: [String]) -> String {
-        var restored = html
-        for (index, segment) in segments.enumerated() {
-            restored = restored.replacingOccurrences(
-                of: "__CLEARLY_PROTECTED_CODE_\(index)__",
-                with: segment
-            )
+        restoreTokenizedSegments(in: html, tokenPrefix: "__CLEARLY_PROTECTED_CODE_", segments: segments)
+    }
+
+    private static func restoreTokenizedSegments(in html: String, tokenPrefix: String, segments: [String]) -> String {
+        guard !segments.isEmpty else { return html }
+        let pattern = NSRegularExpression.escapedPattern(for: tokenPrefix) + #"(\d+)__"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return html }
+
+        let nsHTML = html as NSString
+        var result = ""
+        var lastEnd = 0
+
+        for match in regex.matches(in: html, range: NSRange(location: 0, length: nsHTML.length)) {
+            result += nsHTML.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            let indexString = nsHTML.substring(with: match.range(at: 1))
+            if let index = Int(indexString), segments.indices.contains(index) {
+                result += segments[index]
+            } else {
+                result += nsHTML.substring(with: match.range)
+            }
+            lastEnd = match.range.location + match.range.length
         }
-        return restored
+
+        result += nsHTML.substring(from: lastEnd)
+        return result
     }
 
     /// Convert "Table: caption text" paragraphs immediately before a <table> into <caption> elements.
@@ -368,14 +431,7 @@ public enum MarkdownRenderer {
     }
 
     private static func restoreWikiLinkRegions(in html: String, segments: [String]) -> String {
-        var restored = html
-        for (index, segment) in segments.enumerated() {
-            restored = restored.replacingOccurrences(
-                of: "__CLEARLY_PROTECTED_WIKILINK_\(index)__",
-                with: segment
-            )
-        }
-        return restored
+        restoreTokenizedSegments(in: html, tokenPrefix: "__CLEARLY_PROTECTED_WIKILINK_", segments: segments)
     }
 
     // MARK: - Tags #tag
@@ -427,14 +483,7 @@ public enum MarkdownRenderer {
     }
 
     private static func restoreTagRegions(in html: String, segments: [String]) -> String {
-        var restored = html
-        for (index, segment) in segments.enumerated() {
-            restored = restored.replacingOccurrences(
-                of: "__CLEARLY_PROTECTED_TAG_\(index)__",
-                with: segment
-            )
-        }
-        return restored
+        restoreTokenizedSegments(in: html, tokenPrefix: "__CLEARLY_PROTECTED_TAG_", segments: segments)
     }
 
     // MARK: - Highlight/Mark ==text==

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -276,6 +276,9 @@ public enum MarkdownRenderer {
             if let index = Int(indexString), segments.indices.contains(index) {
                 result += segments[index]
             } else {
+                #if DEBUG
+                DiagnosticLog.log("MarkdownRenderer.restoreTokenizedSegments: dropped placeholder \(tokenPrefix)\(indexString)__ (segments.count=\(segments.count))")
+                #endif
                 result += nsHTML.substring(with: match.range)
             }
             lastEnd = match.range.location + match.range.length

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -5,6 +5,7 @@ import QuartzCore
 private typealias Attr = PlatformTextAttributes
 
 public final class MarkdownSyntaxHighlighter: NSObject {
+    private static let slowIncrementalHighlightLogThresholdMS: Double = 50
 
     public override init() {
         super.init()
@@ -514,34 +515,6 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         defer { isHighlighting = false }
         let startTime = CACurrentMediaTime()
 
-        textStorage.beginEditing()
-
-        // Reset attributes in the affected range. Only reset font/paragraph/baseline
-        // when the range actually has non-default fonts (headings, code, bold, italic).
-        // Skipping the font reset for plain text avoids glyph regeneration, which is
-        // the main per-keystroke cost on large documents.
-        var needsFontReset = false
-        textStorage.enumerateAttribute(Attr.font, in: paragraphRange, options: .longestEffectiveRangeNotRequired) { value, _, stop in
-            if let font = value as? PlatformFont, font != Theme.editorFont {
-                needsFontReset = true
-                stop.pointee = true
-            }
-        }
-
-        if needsFontReset {
-            let paragraph = PlatformParagraphStyle()
-            paragraph.minimumLineHeight = Theme.editorLineHeight
-            paragraph.maximumLineHeight = Theme.editorLineHeight
-            textStorage.addAttributes([
-                Attr.font: Theme.editorFont,
-                Attr.paragraphStyle: paragraph,
-                Attr.baselineOffset: Theme.editorBaselineOffset
-            ], range: paragraphRange)
-        }
-        textStorage.addAttribute(Attr.foregroundColor, value: Theme.textColor, range: paragraphRange)
-        textStorage.removeAttribute(Attr.backgroundColor, range: paragraphRange)
-        textStorage.removeAttribute(Attr.strikethroughStyle, range: paragraphRange)
-
         // Keep cached protected ranges aligned with the edit. Most edits can cheaply
         // shift the cached ranges; block delimiters need a full protected-range rescan
         // so semantic queries stay correct until the deferred highlightAll runs.
@@ -574,12 +547,55 @@ public final class MarkdownSyntaxHighlighter: NSObject {
 
         // If the paragraph is entirely inside a protected block, apply that block's base style.
         if let block = protectedRanges.first(where: { NSIntersectionRange($0.range, paragraphRange).length == paragraphRange.length }) {
+            textStorage.beginEditing()
             applyProtectedBlockStyle(block, to: textStorage, range: paragraphRange)
             textStorage.endEditing()
             let elapsed = (CACurrentMediaTime() - startTime) * 1000
-            DiagnosticLog.log("highlightAround(\(caller)): inside protected block, \(paragraphRange) in \(Int(elapsed))ms")
+            if elapsed >= Self.slowIncrementalHighlightLogThresholdMS {
+                DiagnosticLog.log("highlightAround(\(caller)): inside protected block, \(paragraphRange) in \(Int(elapsed))ms")
+            }
             return
         }
+
+        if !Self.mayContainMarkdownSyntax(paragraphText) {
+            guard !usesDefaultPlainTextStyle(textStorage, range: paragraphRange) else {
+                let elapsed = (CACurrentMediaTime() - startTime) * 1000
+                if elapsed >= Self.slowIncrementalHighlightLogThresholdMS {
+                    DiagnosticLog.log("highlightAround(\(caller)): plain paragraph skipped, \(paragraphRange) in \(Int(elapsed))ms")
+                }
+                return
+            }
+
+            textStorage.beginEditing()
+            resetPlainTextStyle(textStorage, range: paragraphRange)
+            textStorage.endEditing()
+            let elapsed = (CACurrentMediaTime() - startTime) * 1000
+            if elapsed >= Self.slowIncrementalHighlightLogThresholdMS {
+                DiagnosticLog.log("highlightAround(\(caller)): plain paragraph reset, \(paragraphRange) in \(Int(elapsed))ms")
+            }
+            return
+        }
+
+        textStorage.beginEditing()
+
+        // Reset attributes in the affected range. Only reset font/paragraph/baseline
+        // when the range actually has non-default fonts (headings, code, bold, italic).
+        // Skipping the font reset for plain text avoids glyph regeneration, which is
+        // the main per-keystroke cost on large documents.
+        var needsFontReset = false
+        textStorage.enumerateAttribute(Attr.font, in: paragraphRange, options: .longestEffectiveRangeNotRequired) { value, _, stop in
+            if let font = value as? PlatformFont, !font.isEqual(Theme.editorFont) {
+                needsFontReset = true
+                stop.pointee = true
+            }
+        }
+
+        if needsFontReset {
+            resetBaseTypography(textStorage, range: paragraphRange)
+        }
+        textStorage.addAttribute(Attr.foregroundColor, value: Theme.textColor, range: paragraphRange)
+        textStorage.removeAttribute(Attr.backgroundColor, range: paragraphRange)
+        textStorage.removeAttribute(Attr.strikethroughStyle, range: paragraphRange)
 
         // Run all patterns on the paragraph range only
         for (regex, style) in Self.patterns {
@@ -762,7 +778,9 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         textStorage.endEditing()
 
         let elapsed = (CACurrentMediaTime() - startTime) * 1000
-        DiagnosticLog.log("highlightAround(\(caller)): \(paragraphRange) in \(Int(elapsed))ms")
+        if elapsed >= Self.slowIncrementalHighlightLogThresholdMS {
+            DiagnosticLog.log("highlightAround(\(caller)): \(paragraphRange) in \(Int(elapsed))ms")
+        }
     }
 
     // MARK: - Public Query
@@ -789,5 +807,55 @@ public final class MarkdownSyntaxHighlighter: NSObject {
                 textStorage.addAttribute(Attr.foregroundColor, value: Theme.syntaxColor, range: match.range(at: 2))
             }
         }
+    }
+
+    private static func mayContainMarkdownSyntax(_ text: String) -> Bool {
+        if text.range(of: #"[#*_`\[\]!>=$|<~]"#, options: .regularExpression) != nil {
+            return true
+        }
+
+        let line = text.trimmingCharacters(in: .newlines)
+        if line.range(of: #"^\s*(?:[-+]\s|\d+\.\s|[-*_]{3,}\s*$)"#, options: .regularExpression) != nil {
+            return true
+        }
+
+        return false
+    }
+
+    private func usesDefaultPlainTextStyle(_ textStorage: PlatformTextStorage, range: NSRange) -> Bool {
+        var isDefault = true
+        textStorage.enumerateAttributes(in: range, options: .longestEffectiveRangeNotRequired) { attributes, _, stop in
+            if let font = attributes[Attr.font] as? PlatformFont, !font.isEqual(Theme.editorFont) {
+                isDefault = false
+            }
+            if let color = attributes[Attr.foregroundColor] as? PlatformColor, !color.isEqual(Theme.textColor) {
+                isDefault = false
+            }
+            if attributes[Attr.backgroundColor] != nil || attributes[Attr.strikethroughStyle] != nil {
+                isDefault = false
+            }
+            if !isDefault {
+                stop.pointee = true
+            }
+        }
+        return isDefault
+    }
+
+    private func resetPlainTextStyle(_ textStorage: PlatformTextStorage, range: NSRange) {
+        resetBaseTypography(textStorage, range: range)
+        textStorage.addAttribute(Attr.foregroundColor, value: Theme.textColor, range: range)
+        textStorage.removeAttribute(Attr.backgroundColor, range: range)
+        textStorage.removeAttribute(Attr.strikethroughStyle, range: range)
+    }
+
+    private func resetBaseTypography(_ textStorage: PlatformTextStorage, range: NSRange) {
+        let paragraph = PlatformParagraphStyle()
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
+        textStorage.addAttributes([
+            Attr.font: Theme.editorFont,
+            Attr.paragraphStyle: paragraph,
+            Attr.baselineOffset: Theme.editorBaselineOffset
+        ], range: range)
     }
 }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -810,7 +810,13 @@ public final class MarkdownSyntaxHighlighter: NSObject {
     }
 
     private static func mayContainMarkdownSyntax(_ text: String) -> Bool {
-        if text.range(of: #"[#*_`\[\]!>=$|<~]"#, options: .regularExpression) != nil {
+        if text.range(of: #"[#*_`\[\]!>$|<~]"#, options: .regularExpression) != nil {
+            return true
+        }
+        // `=` is too noisy for the cheap regex above (matches `key=value` in
+        // ordinary prose); only `==highlight==` is markdown, so check for
+        // the doubled form explicitly.
+        if text.contains("==") {
             return true
         }
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewChunker.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewChunker.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Splits a markdown document into render-friendly chunks for the lazy
+/// preview pipeline. Splits only at safe boundaries (blank lines / ATX
+/// headings) and refuses to split inside fenced code blocks so a chunk
+/// boundary never lands between an opening and closing fence.
+public enum PreviewChunker {
+    public struct Chunk: Equatable, Sendable {
+        public let markdown: String
+        public let startLine: Int
+
+        public init(markdown: String, startLine: Int) {
+            self.markdown = markdown
+            self.startLine = startLine
+        }
+    }
+
+    public static func chunks(
+        from markdown: String,
+        targetCharacters: Int = 90_000,
+        hardLimitCharacters: Int = 140_000
+    ) -> [Chunk] {
+        precondition(targetCharacters > 0, "targetCharacters must be positive")
+        precondition(hardLimitCharacters >= targetCharacters, "hardLimit must be ≥ target")
+
+        var chunks: [Chunk] = []
+        var chunkStart = markdown.startIndex
+        var currentStartLine = 1
+        var currentLine = 1
+        var currentCount = 0
+        var lineStart = markdown.startIndex
+        // Track whether the *next* line will start inside a fenced code
+        // block. Toggled when we cross a ``` or ~~~ fence line.
+        var insideFence = false
+
+        while lineStart < markdown.endIndex {
+            let lineEnd = markdown[lineStart...].firstIndex(of: "\n") ?? markdown.endIndex
+            let nextLineStart = lineEnd < markdown.endIndex ? markdown.index(after: lineEnd) : markdown.endIndex
+            if currentCount == 0 {
+                chunkStart = lineStart
+                currentStartLine = currentLine
+            }
+            currentCount += markdown.distance(from: lineStart, to: nextLineStart)
+
+            let line = markdown[lineStart..<lineEnd]
+            let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+            let isFenceLine = trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~")
+            if isFenceLine {
+                insideFence.toggle()
+            }
+
+            // Safe boundary: ATX heading or blank line, *but* never split
+            // while we're inside a fenced code block — a chunk boundary
+            // there orphans the closing fence and breaks the renderer for
+            // both halves.
+            let isBlank = line.allSatisfy { $0 == " " || $0 == "\t" || $0 == "\r" }
+            let isAtxHeading = line.first == "#"
+            let canSplit = !insideFence && (isAtxHeading || isBlank)
+
+            // Hard limit only kicks in when we're outside a fence; if we
+            // hit the hard limit *inside* a fence, defer the split to the
+            // next line that closes it so the chunk stays self-contained.
+            let mustSplit = !insideFence && currentCount >= hardLimitCharacters
+            if mustSplit || (currentCount >= targetCharacters && canSplit) {
+                chunks.append(Chunk(
+                    markdown: String(markdown[chunkStart..<nextLineStart]),
+                    startLine: currentStartLine
+                ))
+                currentCount = 0
+            }
+
+            lineStart = nextLineStart
+            currentLine += 1
+        }
+
+        if currentCount > 0 {
+            chunks.append(Chunk(
+                markdown: String(markdown[chunkStart..<markdown.endIndex]),
+                startLine: currentStartLine
+            ))
+        }
+
+        return chunks
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Vault/VaultIndex.swift
@@ -718,14 +718,18 @@ public final class VaultIndex: @unchecked Sendable {
         }
     }
 
-    public func searchFilesGrouped(query: String) -> [SearchFileGroup] {
-        searchFilesGrouped(parsed: SearchQueryParser.parse(query))
+    public func searchFilesGrouped(query: String, maxExcerptsPerFile: Int = 100) -> [SearchFileGroup] {
+        searchFilesGrouped(parsed: SearchQueryParser.parse(query), maxExcerptsPerFile: maxExcerptsPerFile)
     }
 
-    public func searchFilesGrouped(parsed: ParsedSearchQuery) -> [SearchFileGroup] {
+    public func searchFilesGrouped(
+        parsed: ParsedSearchQuery,
+        maxExcerptsPerFile: Int = 100
+    ) -> [SearchFileGroup] {
         let trimmed = parsed.ftsQuery.trimmingCharacters(in: .whitespaces)
         var ftsTerms: [String] = []
         var searchTerms: [String] = [] // plain terms for line matching
+        let excerptLimit = max(1, maxExcerptsPerFile)
 
         if !trimmed.isEmpty {
             let quoteRegex = try! NSRegularExpression(pattern: #""([^"]+)""#)
@@ -822,7 +826,7 @@ public final class VaultIndex: @unchecked Sendable {
                                     .replacingOccurrences(of: ">>", with: ""),
                                 highlightedContextLine: highlightedLine
                             ))
-                            if excerpts.count >= 5 { break }
+                            if excerpts.count >= excerptLimit { break }
                         }
                     }
 

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownRendererSourcePosTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownRendererSourcePosTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import ClearlyCore
+
+final class MarkdownRendererSourcePosTests: XCTestCase {
+    func testSourceLineOffsetShiftsDataSourceLine() {
+        let md = "# Heading\n\npara\n"
+        let html0 = MarkdownRenderer.renderHTML(md)
+        let html5 = MarkdownRenderer.renderHTML(md, sourceLineOffset: 5)
+
+        XCTAssertTrue(html0.contains("data-sourcepos=\"1:1-1:9\""), html0)
+        XCTAssertTrue(html5.contains("data-sourcepos=\"6:1-6:9\""), html5)
+    }
+
+    func testFrontmatterAndExplicitOffsetCombine() {
+        let md = """
+---
+title: hi
+---
+
+# Heading
+"""
+        let html = MarkdownRenderer.renderHTML(md, sourceLineOffset: 10)
+        // frontmatter is 3 lines → body line 2 of 2 is heading. With
+        // 3 + 10 = 13 offset added to cmark's body sourcepos line 2,
+        // heading lands on line 15.
+        XCTAssertTrue(html.contains("data-sourcepos=\"15:1-15:9\""), html)
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewChunkerTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewChunkerTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import ClearlyCore
+
+final class PreviewChunkerTests: XCTestCase {
+    func testShortDocumentProducesSingleChunk() {
+        let md = "# Title\n\npara\n"
+        let chunks = PreviewChunker.chunks(from: md, targetCharacters: 1000, hardLimitCharacters: 2000)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks.first?.startLine, 1)
+        XCTAssertEqual(chunks.first?.markdown, md)
+    }
+
+    func testSplitsOnHeading() {
+        // Pad so the first heading's body exceeds the target, forcing a
+        // split at the next heading.
+        let body = String(repeating: "lorem ipsum dolor sit amet\n", count: 20)
+        let md = "# A\n\n\(body)\n## B\n\nmore\n"
+        let chunks = PreviewChunker.chunks(from: md, targetCharacters: 100, hardLimitCharacters: 1_000_000)
+        XCTAssertGreaterThanOrEqual(chunks.count, 2)
+        // Concatenated chunks reproduce the original.
+        XCTAssertEqual(chunks.map(\.markdown).joined(), md)
+    }
+
+    func testNeverSplitsInsideFencedCodeBlock() {
+        // Fenced block large enough that targetCharacters is exceeded
+        // mid-fence. Chunker must defer the split until after the closing
+        // fence so neither half has a dangling ```.
+        let inside = String(repeating: "let x = 1\n", count: 200)
+        let md = "# Heading\n\n```swift\n\(inside)```\n\n## Next\n\nmore\n"
+        let chunks = PreviewChunker.chunks(from: md, targetCharacters: 200, hardLimitCharacters: 800)
+
+        for chunk in chunks {
+            // Each chunk should have an even number of fence lines (every
+            // opening fence has a closing fence).
+            let fences = chunk.markdown.components(separatedBy: "\n").filter {
+                let t = $0.drop { $0 == " " || $0 == "\t" }
+                return t.hasPrefix("```") || t.hasPrefix("~~~")
+            }
+            XCTAssertEqual(fences.count % 2, 0, "chunk has unbalanced fences:\n\(chunk.markdown)")
+        }
+        XCTAssertEqual(chunks.map(\.markdown).joined(), md)
+    }
+
+    func testStartLineMatchesOriginalLineNumbers() {
+        let md = "# A\n\npara\n\n## B\n\nmore\n\n## C\n\ntail\n"
+        let chunks = PreviewChunker.chunks(from: md, targetCharacters: 8, hardLimitCharacters: 1_000_000)
+        XCTAssertEqual(chunks.first?.startLine, 1)
+        // Every subsequent chunk's startLine must match the line count of
+        // the prior chunks combined plus 1.
+        var lineCursor = 1
+        for chunk in chunks {
+            XCTAssertEqual(chunk.startLine, lineCursor)
+            lineCursor += chunk.markdown.filter { $0 == "\n" }.count
+        }
+    }
+
+    func testTildeFencesAlsoTreatedAsCodeBlocks() {
+        let inside = String(repeating: "x\n", count: 100)
+        let md = "para\n~~~\n\(inside)~~~\n\nafter\n"
+        let chunks = PreviewChunker.chunks(from: md, targetCharacters: 50, hardLimitCharacters: 500)
+        for chunk in chunks {
+            let fences = chunk.markdown.components(separatedBy: "\n").filter { $0.hasPrefix("~~~") }
+            XCTAssertEqual(fences.count % 2, 0)
+        }
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/TextMatcherTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/TextMatcherTests.swift
@@ -56,4 +56,14 @@ final class TextMatcherTests: XCTestCase {
             NSRange(location: 18, length: 4),
         ])
     }
+
+    func testLargeRepeatedQueryCountsEveryMatch() throws {
+        let text = (1...20)
+            .map { "Chapter \($0)\nThe story continues." }
+            .joined(separator: "\n")
+
+        let matches = try TextMatcher.matches(of: "chapter", in: text)
+
+        XCTAssertEqual(matches.count, 20)
+    }
 }

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/VaultIndexLimitsTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/VaultIndexLimitsTests.swift
@@ -57,6 +57,35 @@ final class VaultIndexLimitsTests: XCTestCase {
         XCTAssertEqual(index.searchFiles(query: "needle").count, 0)
     }
 
+    func testGroupedSearchReturnsMoreThanFiveExcerptsForLargeBooks() throws {
+        let index = try VaultIndex(locationURL: tempVault)
+        let body = (1...20)
+            .map { "Chapter \($0)\nThe story continues." }
+            .joined(separator: "\n")
+        _ = try writeNote("book.md", body: body)
+        index.indexAllFiles()
+
+        let group = try XCTUnwrap(index.searchFilesGrouped(query: "chapter").first { $0.file.path == "book.md" })
+
+        XCTAssertEqual(group.excerpts.count, 20)
+        XCTAssertTrue(group.excerpts.first?.contextLine.contains("Chapter 1") == true)
+        XCTAssertTrue(group.excerpts.last?.contextLine.contains("Chapter 20") == true)
+    }
+
+    func testGroupedSearchHonorsExplicitExcerptLimit() throws {
+        let index = try VaultIndex(locationURL: tempVault)
+        let body = (1...20)
+            .map { "Chapter \($0)\nThe story continues." }
+            .joined(separator: "\n")
+        _ = try writeNote("book.md", body: body)
+        index.indexAllFiles()
+
+        let group = try XCTUnwrap(index.searchFilesGrouped(query: "chapter", maxExcerptsPerFile: 1).first { $0.file.path == "book.md" })
+
+        XCTAssertEqual(group.excerpts.count, 1)
+        XCTAssertTrue(group.excerpts[0].contextLine.contains("Chapter 1"))
+    }
+
     private func writeNote(_ name: String, body: String) throws -> URL {
         let url = tempVault.appendingPathComponent(name)
         try body.write(to: url, atomically: true, encoding: .utf8)

--- a/project.yml
+++ b/project.yml
@@ -127,6 +127,22 @@ targets:
         buildPhase: resources
     dependencies:
       - package: ClearlyCore
+    postCompileScripts:
+      - script: |
+          if [ "${CONFIGURATION}" != "Debug" ] || [ "${EFFECTIVE_PLATFORM_NAME}" != "-iphonesimulator" ]; then
+            exit 0
+          fi
+
+          FIXTURE_SOURCE="${SRCROOT}/simfixture"
+          FIXTURE_DEST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimFixtureVault"
+          rm -rf "$FIXTURE_DEST"
+
+          if [ -d "$FIXTURE_SOURCE" ] && [ -n "$(find "$FIXTURE_SOURCE" -mindepth 1 -maxdepth 1 | head -n 1)" ]; then
+            mkdir -p "$(dirname "$FIXTURE_DEST")"
+            ditto "$FIXTURE_SOURCE" "$FIXTURE_DEST"
+          fi
+        name: "Copy iOS Simulator Fixture Vault"
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly

--- a/project.yml
+++ b/project.yml
@@ -129,19 +129,19 @@ targets:
       - package: ClearlyCore
     postCompileScripts:
       - script: |
-          if [ "${CONFIGURATION}" != "Debug" ] || [ "${EFFECTIVE_PLATFORM_NAME}" != "-iphonesimulator" ]; then
+          if [ "${CONFIGURATION}" != "Debug" ]; then
             exit 0
           fi
 
-          FIXTURE_SOURCE="${SRCROOT}/simfixture"
-          FIXTURE_DEST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimFixtureVault"
+          FIXTURE_SOURCE="${SRCROOT}/debugfixture"
+          FIXTURE_DEST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugFixtureVault"
           rm -rf "$FIXTURE_DEST"
 
           if [ -d "$FIXTURE_SOURCE" ] && [ -n "$(find "$FIXTURE_SOURCE" -mindepth 1 -maxdepth 1 | head -n 1)" ]; then
             mkdir -p "$(dirname "$FIXTURE_DEST")"
             ditto "$FIXTURE_SOURCE" "$FIXTURE_DEST"
           fi
-        name: "Copy iOS Simulator Fixture Vault"
+        name: "Copy iOS Debug Fixture Vault"
         basedOnDependencyAnalysis: false
     settings:
       base:

--- a/scripts/setup-debugfixture.sh
+++ b/scripts/setup-debugfixture.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Populate debugfixture/ for Debug iOS builds. The app copies this folder into
+# the bundle as DebugFixtureVault and mounts it as a writable vault at launch.
+#
+# Usage:
+#   ./scripts/setup-debugfixture.sh walden  # one large-ish public-domain book
+#   ./scripts/setup-debugfixture.sh all     # full markdown collection stress test
+#   ./scripts/setup-debugfixture.sh clean   # remove generated fixture contents
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST="${DEBUGFIXTURE_DIR:-$REPO_ROOT/debugfixture}"
+
+SOURCE_REPO="mlschmitt/classic-books-markdown"
+SOURCE_BRANCH="main"
+RAW_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_BRANCH"
+ZIP_URL="https://github.com/$SOURCE_REPO/archive/refs/heads/$SOURCE_BRANCH.zip"
+WALDEN_PATH="Henry David Thoreau/Walden.md"
+
+usage() {
+  sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+reset_fixture() {
+  rm -rf "$DEST"
+  mkdir -p "$DEST"
+}
+
+download_walden() {
+  reset_fixture
+  mkdir -p "$DEST/$(dirname "$WALDEN_PATH")"
+  curl -fsSL "$RAW_BASE/${WALDEN_PATH// /%20}" -o "$DEST/$WALDEN_PATH"
+}
+
+download_all() {
+  reset_fixture
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  local zip="$tmp/classic-books-markdown.zip"
+  curl -fsSL "$ZIP_URL" -o "$zip"
+  ditto -x -k "$zip" "$tmp"
+
+  local source_root="$tmp/classic-books-markdown-$SOURCE_BRANCH"
+  if [ ! -d "$source_root" ]; then
+    echo "Expected archive root not found: $source_root" >&2
+    exit 1
+  fi
+
+  while IFS= read -r -d '' file; do
+    local rel="${file#$source_root/}"
+    mkdir -p "$DEST/$(dirname "$rel")"
+    cp "$file" "$DEST/$rel"
+  done < <(find "$source_root" -type f -name '*.md' -print0)
+}
+
+print_summary() {
+  local count
+  count="$(find "$DEST" -type f -name '*.md' | wc -l | tr -d ' ')"
+  echo "Prepared $count markdown file(s) in $DEST"
+}
+
+case "${1:-}" in
+  walden)
+    download_walden
+    print_summary
+    ;;
+  all)
+    download_all
+    print_summary
+    ;;
+  clean)
+    rm -rf "$DEST"
+    echo "Removed $DEST"
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    echo "Unknown mode: $1" >&2
+    echo >&2
+    usage >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
Fixes #347
Improves #199

## Summary
- Move large document reads and large preview rendering off the main thread so opening/editing remains responsive.
- Render large Mac previews as lazy chunks and avoid preloading hidden preview WebViews for large markdown, while preserving crossfade/preload behavior for markdown under 100 KB.
- Extend the large-preview async rendering path to iOS so book-sized markdown renders HTML off the main actor before loading the `WKWebView`.
- Replace the worst preview-rendering hotspot from profiling: repeated full-string protected-region restoration during wiki-link post-processing. The sampled beachball was dominated by repeated whole-HTML scans/copies in that restoration loop, not WebKit.
- Optimize large-preview chunk planning to avoid repeated string concatenation while scanning book-sized markdown.
- Fix large-book vault search truncation:
  - grouped content search now returns up to 100 excerpts per file by default instead of stopping at 5;
  - Mac and iOS quick switchers explicitly request one excerpt per file to keep top-level search responsive;
  - regression coverage verifies a 20-chapter book can return all 20 matching excerpts.
- Improve large-vault search performance on both Mac and iOS:
  - Quick switcher / top-level vault search now debounces query changes, cancels stale searches, and computes filename/tag/FTS content results off the main actor.
  - Content search is still preserved via `VaultIndex.searchFilesGrouped`.
- Improve in-document find performance on both Mac and iOS:
  - Find scans now run off the main actor with stale-result protection.
  - Large result sets still count all matches, but only paint a bounded set of visible/nearby highlights instead of repainting every match in huge documents on each keystroke.
- Improve macOS large-document editor typing performance:
  - remove routine per-keystroke diagnostic logging from editor/highlighter hot paths;
  - cache and incrementally update line-number gutter line starts;
  - skip hidden gutter work entirely;
  - disable AppKit text checking, spell/grammar/autocorrect, and TextKit background layout in large editor mode;
  - debounce expensive SwiftUI/document binding commits longer for large documents;
  - defer/coalesce syntax highlighting while typing in large documents so highlighting no longer runs inside `ClearlyTextView.keyDown`.
- Add a visible macOS Large Document Mode indicator in the bottom editor/status area. Clicking it explains that spelling/grammar/autocorrect are disabled and that highlighting/counts/outline/preview/save-state updates may refresh after a short delay for performance.
- Add Debug fixture tooling for stress testing:
  - `debugfixture/` is gitignored.
  - Debug iOS builds copy `debugfixture/` into the app as `DebugFixtureVault` and mount it as a writable local vault at launch.
  - `scripts/setup-debugfixture.sh walden` downloads Walden.
  - `scripts/setup-debugfixture.sh all` downloads the full `mlschmitt/classic-books-markdown` collection.
  - `scripts/setup-debugfixture.sh clean` removes the fixture.

## Performance notes
- Main large-file test case: about 1.43 MB, 7,681 lines, and 152 headings.
- Additional stress fixtures:
  - Walden at about 582k characters for large-book search and editor typing profiling;
  - 757 markdown files / 326 MB from `mlschmitt/classic-books-markdown`.
- Small-file transition behavior is kept for files at or below 100 KB.
- After the renderer fix, the initial large-preview path shifted from multi-second main-thread beachballs to background chunk planning plus first-chunk rendering; the measured first usable preview path was about 1.35 seconds before the later chunk-planning optimization.
- The largest remaining measured stage before range-based chunk planning was chunk planning at about 950 ms; first-chunk rendering was about 233 ms, with later lazy chunks around 156 ms.
- Final macOS manual typing profile against Walden showed `MarkdownSyntaxHighlighter.highlightAround` no longer appears inside the `ClearlyTextView.keyDown` stack after deferred large-document highlighting.

## Validation
- `swift test --package-path Packages/ClearlyCore --filter 'VaultIndexLimitsTests|TextMatcherTests'`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all xcodebuild -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all xcodebuild -scheme Clearly-iOS -configuration Debug -derivedDataPath ./.build/DerivedData -destination 'id=1B137074-9C9B-42B6-93D1-3E55CC0E8ADC' CODE_SIGNING_ALLOWED=NO build`
- `swift test --package-path Packages/ClearlyCore --filter TextMatcherTests`
- `swift test --package-path Packages/ClearlyCore --filter VaultIndexSearchTests` (no matching tests in this checkout; command succeeds with 0 selected tests)
- `./scripts/setup-debugfixture.sh walden` into a temp fixture: 1 markdown file, 582,398 bytes.
- `./scripts/setup-debugfixture.sh all` into a temp fixture and real `debugfixture/`: 757 markdown files, 326 MB.
- iPhone 17 Pro iOS 26.4 simulator with full `DebugFixtureVault`:
  - top-level search for `walden` returned filename and content matches responsively;
  - opened `Walden.md` from search;
  - in-document find for `pond` returned `1 of 233` responsively;
  - large preview opened and scrolled with `axe`;
  - editing typed into Walden and persisted to the simulator app-container file.
- macOS automated/manual verification:
  - isolated Walden typing probes inserted text at the bottom and near the middle of the document;
  - final user-typing sample confirmed the large-document highlighter work is off the keypress path;
  - Large Document Mode indicator was present in the accessibility/UI tree for Walden.
- Manual testing in both Mac and iOS apps with large markdown files and the full debug fixture collection.

## Screenshot

Large document mode warning:
<img width="3112" height="2324" alt="Screenshot 2026-05-07 at 12 24 24 PM" src="https://github.com/user-attachments/assets/2191625a-95e3-4e89-9eaa-47e4de1f7c46" />

