### PR TITLE
[mac] Add more chat CLI runners

### DIFF
--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -667,6 +667,9 @@ private struct ChatSettingsTab: View {
     @AppStorage("vaultChatRunner") private var runner = "auto"
     @State private var claudePath: String?
     @State private var codexPath: String?
+    @State private var copilotPath: String?
+    @State private var geminiPath: String?
+    @State private var openCodePath: String?
 
     var body: some View {
         Form {
@@ -675,8 +678,11 @@ private struct ChatSettingsTab: View {
                     Text("Auto").tag("auto")
                     Text("Claude Code").tag("claude")
                     Text("Codex").tag("codex")
+                    Text("Copilot").tag("copilot")
+                    Text("Gemini").tag("gemini")
+                    Text("opencode").tag("opencode")
                 }
-                Text("Auto picks Claude Code if installed, otherwise Codex. Vault chat runs read-only against your notes.")
+                Text("Auto picks Claude Code if installed, then Codex, Copilot, Gemini, and opencode. Vault chat runs read-only against your notes.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -691,6 +697,21 @@ private struct ChatSettingsTab: View {
                     name: "Codex CLI",
                     path: codexPath,
                     installURL: URL(string: "https://developers.openai.com/codex/cli")!
+                )
+                detectionRow(
+                    name: "GitHub Copilot CLI",
+                    path: copilotPath,
+                    installURL: URL(string: "https://github.com/github/copilot-cli")!
+                )
+                detectionRow(
+                    name: "Gemini CLI",
+                    path: geminiPath,
+                    installURL: URL(string: "https://github.com/google-gemini/gemini-cli")!
+                )
+                detectionRow(
+                    name: "opencode",
+                    path: openCodePath,
+                    installURL: URL(string: "https://opencode.ai")!
                 )
             }
         }
@@ -729,5 +750,8 @@ private struct ChatSettingsTab: View {
     private func refresh() {
         claudePath = AgentDiscovery.findClaude()?.url.path
         codexPath = AgentDiscovery.findCodex()?.url.path
+        copilotPath = AgentDiscovery.findCopilot()?.url.path
+        geminiPath = AgentDiscovery.findGemini()?.url.path
+        openCodePath = AgentDiscovery.findOpenCode()?.url.path
     }
 }

--- a/Clearly/VaultChat/AgentDiscovery.swift
+++ b/Clearly/VaultChat/AgentDiscovery.swift
@@ -18,6 +18,9 @@ enum AgentDiscovery {
         enum Kind: Equatable {
             case claude
             case codex
+            case copilot
+            case gemini
+            case opencode
         }
     }
 
@@ -37,6 +40,36 @@ enum AgentDiscovery {
         }
         if let url = lookupOnPath("codex") {
             return CLI(kind: .codex, url: url)
+        }
+        return nil
+    }
+
+    static func findCopilot() -> CLI? {
+        if let url = firstExisting(at: copilotCandidatePaths) {
+            return CLI(kind: .copilot, url: url)
+        }
+        if let url = lookupOnPath("copilot") {
+            return CLI(kind: .copilot, url: url)
+        }
+        return nil
+    }
+
+    static func findGemini() -> CLI? {
+        if let url = firstExisting(at: geminiCandidatePaths) {
+            return CLI(kind: .gemini, url: url)
+        }
+        if let url = lookupOnPath("gemini") {
+            return CLI(kind: .gemini, url: url)
+        }
+        return nil
+    }
+
+    static func findOpenCode() -> CLI? {
+        if let url = firstExisting(at: openCodeCandidatePaths) {
+            return CLI(kind: .opencode, url: url)
+        }
+        if let url = lookupOnPath("opencode") {
+            return CLI(kind: .opencode, url: url)
         }
         return nil
     }
@@ -66,6 +99,48 @@ enum AgentDiscovery {
             "/opt/homebrew/bin/codex",
         ]
         if let nvmPath = nvmBinaryPath(for: "codex", home: home) {
+            paths.append(nvmPath)
+        }
+        return paths
+    }
+
+    private static var copilotCandidatePaths: [String] {
+        let home = realUserHome() ?? NSHomeDirectory()
+        var paths = [
+            "\(home)/.copilot/bin/copilot",
+            "\(home)/.local/bin/copilot",
+            "/usr/local/bin/copilot",
+            "/opt/homebrew/bin/copilot",
+        ]
+        if let nvmPath = nvmBinaryPath(for: "copilot", home: home) {
+            paths.append(nvmPath)
+        }
+        return paths
+    }
+
+    private static var geminiCandidatePaths: [String] {
+        let home = realUserHome() ?? NSHomeDirectory()
+        var paths = [
+            "\(home)/.gemini/bin/gemini",
+            "\(home)/.local/bin/gemini",
+            "/usr/local/bin/gemini",
+            "/opt/homebrew/bin/gemini",
+        ]
+        if let nvmPath = nvmBinaryPath(for: "gemini", home: home) {
+            paths.append(nvmPath)
+        }
+        return paths
+    }
+
+    private static var openCodeCandidatePaths: [String] {
+        let home = realUserHome() ?? NSHomeDirectory()
+        var paths = [
+            "\(home)/.opencode/bin/opencode",
+            "\(home)/.local/bin/opencode",
+            "/usr/local/bin/opencode",
+            "/opt/homebrew/bin/opencode",
+        ]
+        if let nvmPath = nvmBinaryPath(for: "opencode", home: home) {
             paths.append(nvmPath)
         }
         return paths

--- a/Clearly/VaultChat/AgentWarmer.swift
+++ b/Clearly/VaultChat/AgentWarmer.swift
@@ -29,9 +29,10 @@ enum AgentWarmer {
         lastWarmedAt = Date()
     }
 
-    /// Fire a background warmup call unless one is already in flight and the
-    /// cache is inside TTL. Returns immediately.
+    /// Fire a background Claude warmup call unless one is already in flight and
+    /// the cache is inside TTL. Returns immediately.
     static func warmIfNeeded(runner: AgentRunner) {
+        guard runner is ClaudeCLIAgentRunner else { return }
         if isWarm { return }
         if inFlight != nil { return }
 

--- a/Clearly/VaultChat/CopilotCLIAgentRunner.swift
+++ b/Clearly/VaultChat/CopilotCLIAgentRunner.swift
@@ -1,0 +1,125 @@
+import Foundation
+import ClearlyCore
+
+/// Spawns the user's locally-installed `copilot` CLI to answer a prompt.
+/// Like the Claude and Codex runners, this uses the user's existing CLI auth;
+/// Clearly never reads or stores Copilot credentials.
+///
+/// Invocation:
+///   copilot -s --no-color --log-level none --disable-builtin-mcps \
+///           --no-custom-instructions --no-auto-update --no-remote \
+///           --stream off --available-tools "" [--model <m>] -p <prompt>
+///
+/// Chat handles retrieval in-process via `VaultChatRetriever`, so Copilot runs
+/// without tools and only answers over the prompt's inlined context.
+struct CopilotCLIAgentRunner: AgentRunner {
+    let binaryURL: URL
+    let environment: [String: String]
+    let workingDirectoryOverride: URL?
+
+    init(
+        binaryURL: URL,
+        workingDirectory: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.binaryURL = binaryURL
+        self.workingDirectoryOverride = workingDirectory
+        self.environment = environment
+    }
+
+    func run(prompt: String, model: String?) async throws -> AgentResult {
+        let arguments = Self.buildArguments(prompt: prompt, model: model)
+        let (stdoutData, stderrText, status) = try await spawn(arguments: arguments)
+
+        DiagnosticLog.log("copilot RUN: status=\(status) promptLen=\(prompt.count) stdoutLen=\(stdoutData.count) stderrLen=\(stderrText.count)")
+        guard status == 0 else {
+            throw AgentError.transport("copilot exited with status \(status). stderr: \(stderrText.prefix(512))")
+        }
+
+        let text = String(data: stdoutData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !text.isEmpty else {
+            throw AgentError.invalidResponse("copilot returned empty result")
+        }
+        return AgentResult(
+            text: text,
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "copilot-cli"
+        )
+    }
+
+    // MARK: - Argument layout
+
+    static func buildArguments(prompt: String, model: String?) -> [String] {
+        var args: [String] = [
+            "--silent",
+            "--no-color",
+            "--log-level", "none",
+            "--disable-builtin-mcps",
+            "--no-custom-instructions",
+            "--no-auto-update",
+            "--no-remote",
+            "--stream", "off",
+            "--available-tools", "",
+        ]
+        if let model, !model.isEmpty {
+            args.append(contentsOf: ["--model", model])
+        }
+        args.append(contentsOf: ["--prompt", prompt])
+        return args
+    }
+
+    // MARK: - Process plumbing
+
+    private func spawn(arguments: [String]) async throws -> (Data, String, Int32) {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = binaryURL
+            process.arguments = arguments
+            process.currentDirectoryURL = workingDirectoryOverride ?? Self.stableWorkingDirectory()
+            process.environment = ClaudeCLIAgentRunner.environmentForSubprocess(
+                base: environment,
+                currentDirectory: process.currentDirectoryURL,
+                binaryURL: binaryURL
+            )
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            let capture = ProcessCaptureState()
+            process.terminationHandler = { _ in
+                capture.finish(status: process.terminationStatus, continuation: continuation)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                capture.fail(AgentError.transport(String(describing: error)), continuation: continuation)
+                return
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStdout(data, continuation: continuation)
+            }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stderr.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStderr(data, continuation: continuation)
+            }
+        }
+    }
+
+    private static func stableWorkingDirectory() -> URL? {
+        guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = caches.appendingPathComponent("wiki-agent", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+}

--- a/Clearly/VaultChat/GeminiCLIAgentRunner.swift
+++ b/Clearly/VaultChat/GeminiCLIAgentRunner.swift
@@ -1,0 +1,129 @@
+import Foundation
+import ClearlyCore
+
+/// Spawns the user's locally-installed `gemini` CLI to answer a prompt. This
+/// reuses the user's existing Gemini CLI auth; Clearly never reads or stores
+/// credentials.
+///
+/// Invocation:
+///   gemini --skip-trust --approval-mode plan --output-format text \
+///          [--model <m>] --prompt ""
+///
+/// The actual prompt is fed on stdin so long retrieved-note context doesn't hit
+/// ARG_MAX. Chat handles retrieval in-process via `VaultChatRetriever`, and
+/// `approval-mode plan` keeps the CLI read-only if the model asks for tools.
+struct GeminiCLIAgentRunner: AgentRunner {
+    let binaryURL: URL
+    let environment: [String: String]
+    let workingDirectoryOverride: URL?
+
+    init(
+        binaryURL: URL,
+        workingDirectory: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.binaryURL = binaryURL
+        self.workingDirectoryOverride = workingDirectory
+        self.environment = environment
+    }
+
+    func run(prompt: String, model: String?) async throws -> AgentResult {
+        let arguments = Self.buildArguments(model: model)
+        let (stdoutData, stderrText, status) = try await spawn(prompt: prompt, arguments: arguments)
+
+        DiagnosticLog.log("gemini RUN: status=\(status) promptLen=\(prompt.count) stdoutLen=\(stdoutData.count) stderrLen=\(stderrText.count)")
+        guard status == 0 else {
+            throw AgentError.transport("gemini exited with status \(status). stderr: \(stderrText.prefix(512))")
+        }
+
+        let text = String(data: stdoutData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !text.isEmpty else {
+            throw AgentError.invalidResponse("gemini returned empty result")
+        }
+        return AgentResult(
+            text: text,
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "gemini-cli"
+        )
+    }
+
+    // MARK: - Argument layout
+
+    static func buildArguments(model: String?) -> [String] {
+        var args: [String] = [
+            "--skip-trust",
+            "--approval-mode", "plan",
+            "--output-format", "text",
+        ]
+        if let model, !model.isEmpty {
+            args.append(contentsOf: ["--model", model])
+        }
+        args.append(contentsOf: ["--prompt", ""])
+        return args
+    }
+
+    // MARK: - Process plumbing
+
+    private func spawn(prompt: String, arguments: [String]) async throws -> (Data, String, Int32) {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = binaryURL
+            process.arguments = arguments
+            process.currentDirectoryURL = workingDirectoryOverride ?? Self.stableWorkingDirectory()
+            process.environment = ClaudeCLIAgentRunner.environmentForSubprocess(
+                base: environment,
+                currentDirectory: process.currentDirectoryURL,
+                binaryURL: binaryURL
+            )
+
+            let stdin = Pipe()
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardInput = stdin
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            let capture = ProcessCaptureState()
+            process.terminationHandler = { _ in
+                capture.finish(status: process.terminationStatus, continuation: continuation)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                capture.fail(AgentError.transport(String(describing: error)), continuation: continuation)
+                return
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStdout(data, continuation: continuation)
+            }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stderr.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStderr(data, continuation: continuation)
+            }
+
+            let writer = stdin.fileHandleForWriting
+            DispatchQueue.global(qos: .userInitiated).async {
+                if let data = prompt.data(using: .utf8) {
+                    try? writer.write(contentsOf: data)
+                }
+                try? writer.close()
+            }
+        }
+    }
+
+    private static func stableWorkingDirectory() -> URL? {
+        guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = caches.appendingPathComponent("wiki-agent", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+}

--- a/Clearly/VaultChat/OpenCodeCLIAgentRunner.swift
+++ b/Clearly/VaultChat/OpenCodeCLIAgentRunner.swift
@@ -1,0 +1,189 @@
+import Foundation
+import ClearlyCore
+
+/// Spawns the user's locally-installed `opencode` CLI to answer a prompt. This
+/// reuses the user's existing opencode provider auth; Clearly never reads or
+/// stores credentials.
+///
+/// Invocation:
+///   opencode --pure run --format json --title "Clearly Chat" [--model <m>]
+///
+/// The prompt is fed on stdin to avoid ARG_MAX with long retrieved-note
+/// context. Chat handles retrieval in-process via `VaultChatRetriever`; the
+/// stable cache-directory cwd keeps opencode away from the user's vault files.
+struct OpenCodeCLIAgentRunner: AgentRunner {
+    let binaryURL: URL
+    let environment: [String: String]
+    let workingDirectoryOverride: URL?
+
+    init(
+        binaryURL: URL,
+        workingDirectory: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.binaryURL = binaryURL
+        self.workingDirectoryOverride = workingDirectory
+        self.environment = environment
+    }
+
+    func run(prompt: String, model: String?) async throws -> AgentResult {
+        let arguments = Self.buildArguments(model: model)
+        let (stdoutData, stderrText, status) = try await spawn(prompt: prompt, arguments: arguments)
+
+        DiagnosticLog.log("opencode RUN: status=\(status) promptLen=\(prompt.count) stdoutLen=\(stdoutData.count) stderrLen=\(stderrText.count)")
+        guard status == 0 else {
+            throw AgentError.transport("opencode exited with status \(status). stderr: \(stderrText.prefix(512))")
+        }
+
+        let decoded = try Self.decode(data: stdoutData)
+        return AgentResult(
+            text: decoded.text,
+            inputTokens: decoded.inputTokens,
+            outputTokens: decoded.outputTokens,
+            model: "opencode-cli"
+        )
+    }
+
+    // MARK: - Argument layout
+
+    static func buildArguments(model: String?) -> [String] {
+        var args: [String] = [
+            "--pure",
+            "run",
+            "--format", "json",
+            "--title", "Clearly Chat",
+        ]
+        if let model, !model.isEmpty {
+            args.append(contentsOf: ["--model", model])
+        }
+        return args
+    }
+
+    // MARK: - Process plumbing
+
+    private func spawn(prompt: String, arguments: [String]) async throws -> (Data, String, Int32) {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = binaryURL
+            process.arguments = arguments
+            process.currentDirectoryURL = workingDirectoryOverride ?? Self.stableWorkingDirectory()
+            process.environment = ClaudeCLIAgentRunner.environmentForSubprocess(
+                base: environment,
+                currentDirectory: process.currentDirectoryURL,
+                binaryURL: binaryURL
+            )
+
+            let stdin = Pipe()
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardInput = stdin
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            let capture = ProcessCaptureState()
+            process.terminationHandler = { _ in
+                capture.finish(status: process.terminationStatus, continuation: continuation)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                capture.fail(AgentError.transport(String(describing: error)), continuation: continuation)
+                return
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStdout(data, continuation: continuation)
+            }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let data = stderr.fileHandleForReading.readDataToEndOfFile()
+                capture.finishStderr(data, continuation: continuation)
+            }
+
+            let writer = stdin.fileHandleForWriting
+            DispatchQueue.global(qos: .userInitiated).async {
+                if let data = prompt.data(using: .utf8) {
+                    try? writer.write(contentsOf: data)
+                }
+                try? writer.close()
+            }
+        }
+    }
+
+    private static func stableWorkingDirectory() -> URL? {
+        guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = caches.appendingPathComponent("wiki-agent", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
+    // MARK: - Response decoding
+
+    struct DecodedResponse: Equatable {
+        let text: String
+        let inputTokens: Int
+        let outputTokens: Int
+    }
+
+    static func decode(data: Data) throws -> DecodedResponse {
+        struct Event: Decodable {
+            struct Part: Decodable {
+                struct Tokens: Decodable {
+                    struct Cache: Decodable {
+                        let read: Int?
+                        let write: Int?
+                    }
+
+                    let input: Int?
+                    let output: Int?
+                    let total: Int?
+                    let cache: Cache?
+                }
+
+                let text: String?
+                let tokens: Tokens?
+            }
+
+            let type: String?
+            let part: Part?
+        }
+
+        guard let raw = String(data: data, encoding: .utf8) else {
+            throw AgentError.invalidResponse("opencode returned non-utf8 output")
+        }
+
+        let decoder = JSONDecoder()
+        var textParts: [String] = []
+        var inputTokens = 0
+        var outputTokens = 0
+        var sawJSON = false
+
+        for line in raw.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, let bytes = trimmed.data(using: .utf8) else { continue }
+            guard let event = try? decoder.decode(Event.self, from: bytes) else { continue }
+            sawJSON = true
+            if event.type == "text", let text = event.part?.text {
+                textParts.append(text)
+            }
+            if event.type == "step_finish", let tokens = event.part?.tokens {
+                inputTokens = tokens.input ?? max(0, (tokens.total ?? 0) - (tokens.output ?? 0))
+                outputTokens = tokens.output ?? 0
+            }
+        }
+
+        guard sawJSON else {
+            throw AgentError.invalidResponse("opencode JSONL decode failure; raw: \(raw.prefix(512))")
+        }
+        let text = textParts.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw AgentError.invalidResponse("opencode returned empty result")
+        }
+        return DecodedResponse(text: text, inputTokens: inputTokens, outputTokens: outputTokens)
+    }
+}

--- a/Clearly/VaultChat/ProcessCaptureState.swift
+++ b/Clearly/VaultChat/ProcessCaptureState.swift
@@ -2,9 +2,8 @@ import Foundation
 
 /// Coordinates the three async readers (stdout, stderr, termination) of a
 /// `Process` subprocess and resumes a single continuation exactly once when
-/// all three have completed. Used by both `ClaudeCLIAgentRunner` and
-/// `CodexCLIAgentRunner` — the streaming/teardown shape is identical, only
-/// the post-process parsing differs.
+/// all three have completed. Used by the local CLI agent runners — the
+/// streaming/teardown shape is identical, only the post-process parsing differs.
 final class ProcessCaptureState: @unchecked Sendable {
     private let lock = NSLock()
     private var stdoutData: Data?

--- a/Clearly/VaultChat/VaultChatCoordinator.swift
+++ b/Clearly/VaultChat/VaultChatCoordinator.swift
@@ -46,7 +46,7 @@ enum VaultChatCoordinator {
             return
         }
         guard let runner = resolveCompletionRunner() else {
-            presentError("Install Claude Code or Codex CLI to use Chat. https://docs.claude.com/claude-code · https://developers.openai.com/codex/cli")
+            presentError("Install Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI, or opencode to use Chat. https://docs.claude.com/claude-code · https://developers.openai.com/codex/cli · https://github.com/github/copilot-cli · https://github.com/google-gemini/gemini-cli · https://opencode.ai")
             return
         }
         guard let vaultIndex = workspace.vaultIndex(for: location) else {
@@ -148,16 +148,40 @@ enum VaultChatCoordinator {
         let makeCodex: (AgentDiscovery.CLI) -> AgentRunner = { cli in
             CodexCLIAgentRunner(binaryURL: cli.url)
         }
+        let makeCopilot: (AgentDiscovery.CLI) -> AgentRunner = { cli in
+            CopilotCLIAgentRunner(binaryURL: cli.url)
+        }
+        let makeGemini: (AgentDiscovery.CLI) -> AgentRunner = { cli in
+            GeminiCLIAgentRunner(binaryURL: cli.url)
+        }
+        let makeOpenCode: (AgentDiscovery.CLI) -> AgentRunner = { cli in
+            OpenCodeCLIAgentRunner(binaryURL: cli.url)
+        }
         switch pref {
         case "claude":
             return AgentDiscovery.findClaude().map(makeClaude)
         case "codex":
             return AgentDiscovery.findCodex().map(makeCodex)
+        case "copilot":
+            return AgentDiscovery.findCopilot().map(makeCopilot)
+        case "gemini":
+            return AgentDiscovery.findGemini().map(makeGemini)
+        case "opencode":
+            return AgentDiscovery.findOpenCode().map(makeOpenCode)
         default:
             if let claude = AgentDiscovery.findClaude() {
                 return makeClaude(claude)
             }
-            return AgentDiscovery.findCodex().map(makeCodex)
+            if let codex = AgentDiscovery.findCodex() {
+                return makeCodex(codex)
+            }
+            if let copilot = AgentDiscovery.findCopilot() {
+                return makeCopilot(copilot)
+            }
+            if let gemini = AgentDiscovery.findGemini() {
+                return makeGemini(gemini)
+            }
+            return AgentDiscovery.findOpenCode().map(makeOpenCode)
         }
     }
 

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Chat/AgentRunner.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Chat/AgentRunner.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The single entry point to an LLM agent. Implemented by the local CLI
-/// runners (Claude Code, Codex). V1 is request / response; streaming +
+/// runners (Claude Code, Codex, Copilot, Gemini, opencode). V1 is request / response; streaming +
 /// multi-turn tool use come later.
 public protocol AgentRunner: Sendable {
     /// Run a prompt and return the assistant's raw text plus token accounting.


### PR DESCRIPTION
## Summary
- Add chat runner support for GitHub Copilot CLI, Gemini CLI, and opencode
- Surface detection and explicit runner selection for the new CLIs in Chat settings
- Keep non-Claude runners out of Claude-specific prompt-cache warmups

## Validation
- `swift test --package-path Packages/ClearlyCore`
- `xcodebuild -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- manually test multiple rounds with copilot, gemini and opencode
