### PR TITLE
[mac] Add OpenAI-compatible vault chat API settings

### DIFF
--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -664,40 +664,150 @@ private struct SyncSettingsTab: View {
 // MARK: - Chat Settings Tab
 
 private struct ChatSettingsTab: View {
+    @AppStorage(OpenAICompatibleAgentRunner.Keys.backend) private var backend = "cli"
     @AppStorage("vaultChatRunner") private var runner = "auto"
+    @AppStorage(OpenAICompatibleAgentRunner.Keys.baseURL) private var apiBaseURL = OpenAICompatibleAgentRunner.Settings.defaultBaseURLString
+    @AppStorage(OpenAICompatibleAgentRunner.Keys.model) private var apiModel = ""
+    @AppStorage(OpenAICompatibleAgentRunner.Keys.thinkingLevel) private var apiThinkingLevel = OpenAICompatibleAgentRunner.ThinkingLevel.providerDefault.rawValue
     @State private var claudePath: String?
     @State private var codexPath: String?
+    @State private var apiToken = ""
+    @State private var tokenStatus: String?
+    @State private var modelOptions: [String] = []
+    @State private var modelRefreshStatus: String?
+    @State private var isRefreshingModels = false
 
     var body: some View {
         Form {
-            Section("Agent") {
-                Picker("Runner", selection: $runner) {
-                    Text("Auto").tag("auto")
-                    Text("Claude Code").tag("claude")
-                    Text("Codex").tag("codex")
-                }
-                Text("Auto picks Claude Code if installed, otherwise Codex. Vault chat runs read-only against your notes.")
+            Section("Active Chat Backend") {
+                backendToggle
+                Text("CLI uses Claude Code or Codex on your Mac. API uses an OpenAI-compatible chat completions endpoint.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
 
-            Section("Detection") {
-                detectionRow(
-                    name: "Claude Code",
-                    path: claudePath,
-                    installURL: URL(string: "https://docs.claude.com/claude-code")!
-                )
-                detectionRow(
-                    name: "Codex CLI",
-                    path: codexPath,
-                    installURL: URL(string: "https://developers.openai.com/codex/cli")!
-                )
+            if backend == "cli" {
+                Section("Agent") {
+                    Picker("Runner", selection: $runner) {
+                        Text("Auto").tag("auto")
+                        Text("Claude Code").tag("claude")
+                        Text("Codex").tag("codex")
+                    }
+                    Text("Auto picks Claude Code if installed, otherwise Codex. Vault chat runs read-only against your notes.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+
+                Section("Detection") {
+                    detectionRow(
+                        name: "Claude Code",
+                        path: claudePath,
+                        installURL: URL(string: "https://docs.claude.com/claude-code")!
+                    )
+                    detectionRow(
+                        name: "Codex CLI",
+                        path: codexPath,
+                        installURL: URL(string: "https://developers.openai.com/codex/cli")!
+                    )
+                }
+            } else if backend == "api" {
+                Section("API Endpoint") {
+                    TextField("Endpoint URL", text: $apiBaseURL)
+                    SecureField("API token", text: $apiToken)
+                    if let tokenStatus {
+                        Text(tokenStatus)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Text("Use OpenAI's base URL (`https://api.openai.com/v1`) or a local OpenAI-compatible server such as LM Studio (`http://localhost:1234/v1`). Leave the token blank for local servers that do not require auth.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+
+                Section {
+                    Picker("Model", selection: $apiModel) {
+                        ForEach(modelChoices, id: \.self) { model in
+                            Text(modelLabel(for: model)).tag(model)
+                        }
+                    }
+                    Picker("Thinking", selection: $apiThinkingLevel) {
+                        ForEach(OpenAICompatibleAgentRunner.ThinkingLevel.allCases) { level in
+                            Text(level.label).tag(level.rawValue)
+                        }
+                    }
+                    if let modelRefreshStatus {
+                        Text(modelRefreshStatus)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Text("Thinking maps to OpenAI-style `reasoning_effort`. Provider default omits the field for the broadest compatibility.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                } header: {
+                    HStack {
+                        Text("API Model")
+                        Spacer()
+                        Button {
+                            Task { await refreshModels() }
+                        } label: {
+                            if isRefreshingModels {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isRefreshingModels)
+                        .help("Refresh models")
+                        .accessibilityLabel("Refresh models")
+                    }
+                }
             }
         }
         .formStyle(.grouped)
-        .onAppear { refresh() }
+        .onAppear {
+            refresh()
+            loadToken()
+            refreshModelsIfNeeded()
+        }
+        .onChange(of: backend) { _, _ in
+            refreshModelsIfNeeded()
+        }
+        .onChange(of: apiToken) { _, newValue in
+            persistToken(newValue)
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refresh()
+        }
+    }
+
+    private var backendToggle: some View {
+        Picker("Backend", selection: $backend) {
+            Text("CLI").tag("cli")
+            Text("API").tag("api")
+        }
+        .pickerStyle(.segmented)
+        .allowsHitTesting(false)
+        .overlay {
+            HStack(spacing: 0) {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { toggleBackendSelection("cli") }
+                    .accessibilityLabel("CLI")
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { toggleBackendSelection("api") }
+                    .accessibilityLabel("API")
+            }
+        }
+    }
+
+    private func toggleBackendSelection(_ value: String) {
+        if backend == value {
+            backend = value == "cli" ? "api" : "cli"
+        } else {
+            backend = value
         }
     }
 
@@ -729,5 +839,85 @@ private struct ChatSettingsTab: View {
     private func refresh() {
         claudePath = AgentDiscovery.findClaude()?.url.path
         codexPath = AgentDiscovery.findCodex()?.url.path
+    }
+
+    private var modelChoices: [String] {
+        let savedModel = apiModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        var choices = modelOptions
+        if !savedModel.isEmpty, !choices.contains(savedModel) {
+            choices.insert(savedModel, at: 0)
+        }
+        if choices.isEmpty {
+            choices.append("")
+        }
+        return choices
+    }
+
+    private func modelLabel(for model: String) -> String {
+        model.isEmpty ? "No model selected" : model
+    }
+
+    private func loadToken() {
+        do {
+            apiToken = try ChatAPIKeychain.loadToken() ?? ""
+            tokenStatus = nil
+        } catch {
+            tokenStatus = "Token load failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func persistToken(_ token: String) {
+        do {
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            try ChatAPIKeychain.saveToken(trimmed)
+            tokenStatus = nil
+        } catch {
+            tokenStatus = "Token save failed: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func refreshModels() async {
+        isRefreshingModels = true
+        modelRefreshStatus = nil
+        defer { isRefreshingModels = false }
+
+        do {
+            let models = try await OpenAICompatibleAgentRunner.fetchModels(
+                baseURLString: apiBaseURL,
+                token: apiToken
+            )
+            modelOptions = models
+            if apiModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               let first = models.first {
+                apiModel = first
+            }
+            modelRefreshStatus = models.isEmpty ? "No models returned" : nil
+        } catch {
+            modelOptions = []
+            modelRefreshStatus = describeAPIError(error)
+        }
+    }
+
+    private func refreshModelsIfNeeded() {
+        guard backend == "api",
+              !apiBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !isRefreshingModels
+        else { return }
+
+        Task { await refreshModels() }
+    }
+
+    private func describeAPIError(_ error: Error) -> String {
+        switch error {
+        case AgentError.httpError(let status, let body):
+            return "HTTP \(status): \(String(body.prefix(120)))"
+        case AgentError.transport(let message):
+            return "Network error: \(message)"
+        case let localized as LocalizedError:
+            return localized.errorDescription ?? String(describing: error)
+        default:
+            return String(describing: error)
+        }
     }
 }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -664,7 +664,7 @@ private struct SyncSettingsTab: View {
 // MARK: - Chat Settings Tab
 
 private struct ChatSettingsTab: View {
-    @AppStorage(OpenAICompatibleAgentRunner.Keys.backend) private var backend = "cli"
+    @AppStorage(OpenAICompatibleAgentRunner.Keys.backend) private var backend = OpenAICompatibleAgentRunner.Keys.defaultBackend
     @AppStorage("vaultChatRunner") private var runner = "auto"
     @AppStorage(OpenAICompatibleAgentRunner.Keys.baseURL) private var apiBaseURL = OpenAICompatibleAgentRunner.Settings.defaultBaseURLString
     @AppStorage(OpenAICompatibleAgentRunner.Keys.model) private var apiModel = ""

--- a/Clearly/UserDefaultsMigrator.swift
+++ b/Clearly/UserDefaultsMigrator.swift
@@ -60,6 +60,10 @@ enum UserDefaultsMigrator {
         "sidebarPinnedExpanded",
         "sidebarRecentsExpanded",
         "vaultChatRunner",
+        "vaultChatBackend",
+        "vaultChatAPIBaseURL",
+        "vaultChatAPIModel",
+        "vaultChatAPIThinkingLevel",
         "vaultChatPanelWidth",
         // Editor / detail toggles persisted outside @AppStorage
         "continuousSpellCheckingEnabled",

--- a/Clearly/VaultChat/ChatAPIKeychain.swift
+++ b/Clearly/VaultChat/ChatAPIKeychain.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Security
+
+/// Stores the vault chat API bearer token outside UserDefaults. Endpoint and
+/// model preferences are plain settings, but the token is a credential.
+enum ChatAPIKeychain {
+    private static let service = "com.sabotage.clearly.vault-chat-api"
+    private static let account = "openai-compatible"
+
+    static func loadToken() throws -> String? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data,
+                  let token = String(data: data, encoding: .utf8)
+            else {
+                throw KeychainError.unreadableData
+            }
+            return token
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.status(status)
+        }
+    }
+
+    static func saveToken(_ token: String) throws {
+        guard !token.isEmpty else {
+            try deleteToken()
+            return
+        }
+
+        let data = Data(token.utf8)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(baseQuery() as CFDictionary, attributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var add = baseQuery()
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            let addStatus = SecItemAdd(add as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.status(addStatus)
+            }
+        default:
+            throw KeychainError.status(updateStatus)
+        }
+    }
+
+    static func deleteToken() throws {
+        let status = SecItemDelete(baseQuery() as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.status(status)
+        }
+    }
+
+    private static func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    enum KeychainError: LocalizedError, Equatable {
+        case status(OSStatus)
+        case unreadableData
+
+        var errorDescription: String? {
+            switch self {
+            case .status(let status):
+                let message = SecCopyErrorMessageString(status, nil) as String? ?? "OSStatus \(status)"
+                return "Keychain error: \(message)"
+            case .unreadableData:
+                return "Keychain item was not valid UTF-8."
+            }
+        }
+    }
+}

--- a/Clearly/VaultChat/OpenAICompatibleAgentRunner.swift
+++ b/Clearly/VaultChat/OpenAICompatibleAgentRunner.swift
@@ -1,0 +1,351 @@
+import Foundation
+import ClearlyCore
+
+/// Calls an OpenAI-compatible Chat Completions API. This covers OpenAI's
+/// hosted API and local servers such as LM Studio that expose `/v1` endpoints.
+struct OpenAICompatibleAgentRunner: AgentRunner {
+    let settings: Settings
+    let urlSession: URLSession
+
+    init(settings: Settings, urlSession: URLSession = .shared) {
+        self.settings = settings
+        self.urlSession = urlSession
+    }
+
+    func run(prompt: String, model: String?) async throws -> AgentResult {
+        let selectedModel = model?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? settings.model
+        let requestBody = ChatCompletionRequest(
+            model: selectedModel,
+            messages: [.init(role: "user", content: prompt)],
+            reasoning_effort: settings.thinkingLevel.requestValue
+        )
+        var request = URLRequest(url: Self.chatCompletionsEndpoint(for: settings.baseURL))
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        applyAuthorization(to: &request)
+        request.httpBody = try JSONEncoder().encode(requestBody)
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            try Self.validateHTTPResponse(response, data: data)
+            return try Self.decodeChatCompletion(data: data, fallbackModel: selectedModel)
+        } catch let error as AgentError {
+            throw error
+        } catch {
+            throw AgentError.transport(error.localizedDescription)
+        }
+    }
+
+    private func applyAuthorization(to request: inout URLRequest) {
+        let token = settings.token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return }
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    // MARK: - Settings
+
+    struct Settings: Sendable, Equatable {
+        static let defaultBaseURLString = "https://api.openai.com/v1"
+
+        let baseURL: URL
+        let token: String
+        let model: String
+        let thinkingLevel: ThinkingLevel
+
+        static func loadFromUserDefaults(_ defaults: UserDefaults = .standard) throws -> Settings {
+            let baseURLString = defaults.string(forKey: Keys.baseURL) ?? defaultBaseURLString
+            let baseURL = try normalizedBaseURL(from: baseURLString)
+            let model = (defaults.string(forKey: Keys.model) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !model.isEmpty else {
+                throw VaultChatAPIConfigurationError.missingModel
+            }
+            let thinkingRaw = defaults.string(forKey: Keys.thinkingLevel) ?? ThinkingLevel.providerDefault.rawValue
+            let thinkingLevel = ThinkingLevel(rawValue: thinkingRaw) ?? .providerDefault
+            let token = try ChatAPIKeychain.loadToken() ?? ""
+            return Settings(
+                baseURL: baseURL,
+                token: token,
+                model: model,
+                thinkingLevel: thinkingLevel
+            )
+        }
+
+        static func normalizedBaseURL(from rawValue: String) throws -> URL {
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw VaultChatAPIConfigurationError.invalidBaseURL(rawValue)
+            }
+
+            let candidate: String
+            if trimmed.contains("://") {
+                candidate = trimmed
+            } else if trimmed.hasPrefix("localhost") ||
+                        trimmed.hasPrefix("127.0.0.1") ||
+                        trimmed.hasPrefix("0.0.0.0") {
+                candidate = "http://\(trimmed)"
+            } else {
+                candidate = "https://\(trimmed)"
+            }
+
+            guard let url = URL(string: candidate),
+                  let scheme = url.scheme?.lowercased(),
+                  (scheme == "http" || scheme == "https"),
+                  url.host != nil
+            else {
+                throw VaultChatAPIConfigurationError.invalidBaseURL(rawValue)
+            }
+            return url
+        }
+    }
+
+    enum Keys {
+        static let backend = "vaultChatBackend"
+        static let baseURL = "vaultChatAPIBaseURL"
+        static let model = "vaultChatAPIModel"
+        static let thinkingLevel = "vaultChatAPIThinkingLevel"
+    }
+
+    enum ThinkingLevel: String, CaseIterable, Identifiable, Sendable {
+        case providerDefault = "default"
+        case minimal
+        case low
+        case medium
+        case high
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .providerDefault: return "Provider default"
+            case .minimal: return "Minimal"
+            case .low: return "Low"
+            case .medium: return "Medium"
+            case .high: return "High"
+            }
+        }
+
+        var requestValue: String? {
+            self == .providerDefault ? nil : rawValue
+        }
+    }
+
+    // MARK: - Model listing
+
+    static func fetchModels(baseURLString: String, token: String) async throws -> [String] {
+        let baseURL = try Settings.normalizedBaseURL(from: baseURLString)
+        var request = URLRequest(url: modelsEndpoint(for: baseURL))
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedToken.isEmpty {
+            request.setValue("Bearer \(trimmedToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data)
+            let decoded = try JSONDecoder().decode(ModelListResponse.self, from: data)
+            return Array(Set(decoded.data.map(\.id)))
+                .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        } catch let error as AgentError {
+            throw error
+        } catch {
+            throw AgentError.transport(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Endpoint normalization
+
+    private enum Endpoint {
+        case chatCompletions
+        case models
+    }
+
+    private static func chatCompletionsEndpoint(for baseURL: URL) -> URL {
+        endpointURL(for: baseURL, endpoint: .chatCompletions)
+    }
+
+    private static func modelsEndpoint(for baseURL: URL) -> URL {
+        endpointURL(for: baseURL, endpoint: .models)
+    }
+
+    private static func endpointURL(for baseURL: URL, endpoint: Endpoint) -> URL {
+        var url = strippedEndpointURL(baseURL)
+        if pathComponents(url).isEmpty {
+            url.appendPathComponent("v1")
+        }
+        switch endpoint {
+        case .chatCompletions:
+            url.appendPathComponent("chat")
+            url.appendPathComponent("completions")
+        case .models:
+            url.appendPathComponent("models")
+        }
+        return url
+    }
+
+    private static func strippedEndpointURL(_ url: URL) -> URL {
+        var base = url
+        let components = pathComponents(base)
+        if components.suffix(2) == ["chat", "completions"] {
+            base.deleteLastPathComponent()
+            base.deleteLastPathComponent()
+        } else if components.last == "models" {
+            base.deleteLastPathComponent()
+        }
+        return base
+    }
+
+    private static func pathComponents(_ url: URL) -> [String] {
+        url.pathComponents.filter { $0 != "/" }
+    }
+
+    // MARK: - Request / response
+
+    private struct ChatCompletionRequest: Encodable {
+        struct Message: Encodable {
+            let role: String
+            let content: String
+        }
+
+        let model: String
+        let messages: [Message]
+        let reasoning_effort: String?
+    }
+
+    private struct ChatCompletionResponse: Decodable {
+        struct Choice: Decodable {
+            struct Message: Decodable {
+                let content: MessageContent?
+            }
+
+            let message: Message?
+        }
+
+        struct Usage: Decodable {
+            let prompt_tokens: Int?
+            let completion_tokens: Int?
+        }
+
+        let choices: [Choice]
+        let usage: Usage?
+        let model: String?
+    }
+
+    private enum MessageContent: Decodable {
+        struct Part: Decodable {
+            let text: String?
+        }
+
+        case string(String)
+        case parts([Part])
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let string = try? container.decode(String.self) {
+                self = .string(string)
+                return
+            }
+            if let parts = try? container.decode([Part].self) {
+                self = .parts(parts)
+                return
+            }
+            throw DecodingError.typeMismatch(
+                MessageContent.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected string or text parts for message content"
+                )
+            )
+        }
+
+        var text: String {
+            switch self {
+            case .string(let value):
+                return value
+            case .parts(let parts):
+                return parts.compactMap(\.text).joined()
+            }
+        }
+    }
+
+    private struct ModelListResponse: Decodable {
+        struct Model: Decodable {
+            let id: String
+        }
+
+        let data: [Model]
+    }
+
+    private struct APIErrorResponse: Decodable {
+        struct APIError: Decodable {
+            let message: String?
+        }
+
+        let error: APIError?
+    }
+
+    private static func validateHTTPResponse(_ response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw AgentError.invalidResponse("API returned a non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "<non-utf8 response>"
+            let apiMessage = (try? JSONDecoder().decode(APIErrorResponse.self, from: data))
+                .flatMap { $0.error?.message }
+            throw AgentError.httpError(
+                status: http.statusCode,
+                body: String((apiMessage ?? body).prefix(512))
+            )
+        }
+    }
+
+    private static func decodeChatCompletion(data: Data, fallbackModel: String) throws -> AgentResult {
+        let response: ChatCompletionResponse
+        do {
+            response = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+        } catch {
+            let raw = String(data: data, encoding: .utf8) ?? "<non-utf8>"
+            throw AgentError.invalidResponse("API JSON decode failure: \(error); raw: \(raw.prefix(512))")
+        }
+
+        let text = response.choices
+            .compactMap { $0.message?.content?.text }
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !text.isEmpty else {
+            throw AgentError.invalidResponse("API returned an empty assistant message")
+        }
+
+        return AgentResult(
+            text: text,
+            inputTokens: response.usage?.prompt_tokens ?? 0,
+            outputTokens: response.usage?.completion_tokens ?? 0,
+            model: response.model ?? fallbackModel
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}
+
+enum VaultChatAPIConfigurationError: LocalizedError, Equatable {
+    case invalidBaseURL(String)
+    case missingModel
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBaseURL:
+            return "Enter a valid API base URL in Settings > Chat."
+        case .missingModel:
+            return "Choose an API model in Settings > Chat."
+        }
+    }
+}

--- a/Clearly/VaultChat/OpenAICompatibleAgentRunner.swift
+++ b/Clearly/VaultChat/OpenAICompatibleAgentRunner.swift
@@ -102,6 +102,7 @@ struct OpenAICompatibleAgentRunner: AgentRunner {
     }
 
     enum Keys {
+        static let defaultBackend = "cli"
         static let backend = "vaultChatBackend"
         static let baseURL = "vaultChatAPIBaseURL"
         static let model = "vaultChatAPIModel"

--- a/Clearly/VaultChat/VaultChatCoordinator.swift
+++ b/Clearly/VaultChat/VaultChatCoordinator.swift
@@ -45,15 +45,20 @@ enum VaultChatCoordinator {
             presentError("This vault is no longer registered.")
             return
         }
-        guard let runner = resolveCompletionRunner() else {
-            presentError("Install Claude Code or Codex CLI to use Chat. https://docs.claude.com/claude-code · https://developers.openai.com/codex/cli")
+        let runner: AgentRunner
+        do {
+            runner = try resolveCompletionRunner()
+        } catch {
+            presentError(describe(error))
             return
         }
         guard let vaultIndex = workspace.vaultIndex(for: location) else {
             presentError("Vault index isn't loaded yet — give it a moment and try again.")
             return
         }
-        AgentWarmer.warmIfNeeded(runner: runner)
+        if shouldWarmSelectedRunner() {
+            AgentWarmer.warmIfNeeded(runner: runner)
+        }
 
         let userMessage = chat.appendUser(text)
         chat.draft = ""
@@ -87,7 +92,9 @@ enum VaultChatCoordinator {
                 DiagnosticLog.log("Chat: sending (turns=\(chat.messages.count), prompt=\(prompt.count) chars)")
 
                 let result = try await runner.run(prompt: prompt, model: nil)
-                AgentWarmer.markExercised()
+                if shouldWarmSelectedRunner() {
+                    AgentWarmer.markExercised()
+                }
                 DiagnosticLog.log("Chat: reply \(result.text.count) chars, tokens in=\(result.inputTokens) out=\(result.outputTokens)")
 
                 let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -110,7 +117,8 @@ enum VaultChatCoordinator {
     /// AgentWarmer short-circuits while the cache is still warm.
     static func warmForActiveVaultIfPossible(workspace: WorkspaceManager) {
         guard workspace.activeLocation?.url != nil,
-              let runner = resolveCompletionRunner() else {
+              shouldWarmSelectedRunner(),
+              let runner = try? resolveCompletionRunner() else {
             return
         }
         AgentWarmer.warmIfNeeded(runner: runner)
@@ -140,7 +148,11 @@ enum VaultChatCoordinator {
 
     /// Completion-only runner used by Chat (RAG path). No built-in tools —
     /// the agent's only job is to answer over the inlined retrieved context.
-    private static func resolveCompletionRunner() -> AgentRunner? {
+    private static func resolveCompletionRunner() throws -> AgentRunner {
+        if selectedBackend() == "api" {
+            return OpenAICompatibleAgentRunner(settings: try .loadFromUserDefaults())
+        }
+
         let pref = UserDefaults.standard.string(forKey: "vaultChatRunner") ?? "auto"
         let makeClaude: (AgentDiscovery.CLI) -> AgentRunner = { cli in
             ClaudeCLIAgentRunner(binaryURL: cli.url, enabledTools: "")
@@ -150,15 +162,30 @@ enum VaultChatCoordinator {
         }
         switch pref {
         case "claude":
-            return AgentDiscovery.findClaude().map(makeClaude)
+            if let claude = AgentDiscovery.findClaude() {
+                return makeClaude(claude)
+            }
         case "codex":
-            return AgentDiscovery.findCodex().map(makeCodex)
+            if let codex = AgentDiscovery.findCodex() {
+                return makeCodex(codex)
+            }
         default:
             if let claude = AgentDiscovery.findClaude() {
                 return makeClaude(claude)
             }
-            return AgentDiscovery.findCodex().map(makeCodex)
+            if let codex = AgentDiscovery.findCodex() {
+                return makeCodex(codex)
+            }
         }
+        throw ChatConfigurationError.missingCLI
+    }
+
+    private static func selectedBackend() -> String {
+        UserDefaults.standard.string(forKey: OpenAICompatibleAgentRunner.Keys.backend) ?? "cli"
+    }
+
+    private static func shouldWarmSelectedRunner() -> Bool {
+        selectedBackend() != "api"
     }
 
     private static func presentError(_ message: String) {
@@ -173,9 +200,22 @@ enum VaultChatCoordinator {
     private static func describe(_ error: Error) -> String {
         switch error {
         case AgentError.invalidResponse(let m): return "Invalid response: \(m)"
-        case AgentError.httpError(let status, _): return "HTTP \(status) fetching the source URL."
+        case AgentError.httpError(let status, let body): return "HTTP \(status): \(String(body.prefix(240)))"
         case AgentError.transport(let m): return "Network error: \(m)"
+        case let localized as LocalizedError:
+            return localized.errorDescription ?? String(describing: error)
         default: return String(describing: error)
+        }
+    }
+
+    private enum ChatConfigurationError: LocalizedError {
+        case missingCLI
+
+        var errorDescription: String? {
+            switch self {
+            case .missingCLI:
+                return "Install Claude Code or Codex CLI, or switch Chat to API in Settings > Chat."
+            }
         }
     }
 }

--- a/Clearly/VaultChat/VaultChatCoordinator.swift
+++ b/Clearly/VaultChat/VaultChatCoordinator.swift
@@ -181,7 +181,8 @@ enum VaultChatCoordinator {
     }
 
     private static func selectedBackend() -> String {
-        UserDefaults.standard.string(forKey: OpenAICompatibleAgentRunner.Keys.backend) ?? "cli"
+        UserDefaults.standard.string(forKey: OpenAICompatibleAgentRunner.Keys.backend) ??
+            OpenAICompatibleAgentRunner.Keys.defaultBackend
     }
 
     private static func shouldWarmSelectedRunner() -> Bool {


### PR DESCRIPTION
## Summary
- add an OpenAI-compatible API backend for vault chat with configurable endpoint URL, token, model, and thinking level
- update Chat settings with a CLI/API backend toggle, conditional backend settings, automatic model refresh, and Keychain-backed API token persistence
- keep CLI as the default backend for new installs and upgrades without a backend preference

## Validation
- xcodegen generate
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all xcodebuild -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- manually test against my localhost lm-studio server with a chat message and selecting models.

## Screenshot
<img width="1144" height="1440" alt="Screenshot 2026-05-07 at 12 20 19 AM" src="https://github.com/user-attachments/assets/47f966f5-0506-4250-9424-747ce86233d3" />

