### PR TITLE
[mac] Add hover-revealed bottom toolbar with Copy menu and Liquid Glass

### DIFF
--- a/Clearly/BottomToolbar.swift
+++ b/Clearly/BottomToolbar.swift
@@ -1,0 +1,320 @@
+import SwiftUI
+import AppKit
+import ClearlyCore
+
+/// Floating-pill bottom toolbar shown over the document content. Holds the
+/// Edit/Preview segmented control, live word/character count, Copy menu, and
+/// Outline toggle. Replaces the previous top SwiftUI `.toolbar` mode picker
+/// and the inline `StatusBar` view.
+struct BottomToolbar: View {
+    @Binding var viewMode: ViewMode
+    @ObservedObject var statusBarState: StatusBarState
+    @ObservedObject var outlineState: OutlineState
+    let fileURL: URL?
+    let documentText: () -> String
+
+    /// Reserved height for the bottom controls. `ContentView` passes this to
+    /// `EditorView.extraBottomInset` and the preview CSS floor so content
+    /// scrolls clear of the overlay.
+    static let pillHeight: CGFloat = 40
+
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            glassBody
+        } else {
+            legacyBody
+        }
+    }
+
+    @available(macOS 26.0, *)
+    private var glassBody: some View {
+        GlassEffectContainer(spacing: 0) {
+            HStack(spacing: 0) {
+                ModePill(viewMode: $viewMode)
+
+                Spacer(minLength: 12)
+                    .contentShape(Rectangle())
+                    .allowsHitTesting(false)
+
+                countText
+                    .accessibilityLabel("\(statusBarState.counts.totalWords) words, \(statusBarState.counts.totalChars) characters")
+                    .accessibilityAddTraits(.isStaticText)
+
+                Spacer(minLength: 12)
+                    .contentShape(Rectangle())
+                    .allowsHitTesting(false)
+
+                HStack(spacing: 8) {
+                    glassCopyMenu
+                    glassOutlineToggle
+                }
+            }
+            .frame(height: Self.pillHeight)
+        }
+    }
+
+    private var legacyBody: some View {
+        HStack(spacing: 0) {
+            ModePill(viewMode: $viewMode)
+
+            Spacer(minLength: 12)
+                .contentShape(Rectangle())
+                .allowsHitTesting(false)
+
+            countText
+                .accessibilityLabel("\(statusBarState.counts.totalWords) words, \(statusBarState.counts.totalChars) characters")
+                .accessibilityAddTraits(.isStaticText)
+
+            Spacer(minLength: 12)
+                .contentShape(Rectangle())
+                .allowsHitTesting(false)
+
+            HStack(spacing: 2) {
+                copyMenu
+                outlineToggle
+            }
+        }
+        .frame(height: Self.pillHeight)
+    }
+
+    private var countText: some View {
+        let counts = statusBarState.counts
+        let words = counts.hasSelection ? counts.selectionWords : counts.totalWords
+        let chars = counts.hasSelection ? counts.selectionChars : counts.totalChars
+        return Text("\(words.formatted()) words \u{00B7} \(chars.formatted()) characters")
+            .font(.system(size: 11))
+            .tracking(0.3)
+            .foregroundStyle(.tertiary)
+            .monospacedDigit()
+            .lineLimit(1)
+    }
+
+    private var copyMenu: some View {
+        Menu {
+            copyMenuContent
+        } label: {
+            Image(systemName: "doc.on.doc")
+                .font(.system(size: 13, weight: .medium))
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(BottomToolbarIconStyle(isActive: false))
+        .frame(width: 28, height: 28)
+        .help("Copy document")
+        .accessibilityLabel("Copy document")
+    }
+
+    private var outlineToggle: some View {
+        Button {
+            outlineState.isVisible.toggle()
+        } label: {
+            Image(systemName: "list.bullet.indent")
+                .font(.system(size: 13, weight: .medium))
+        }
+        .buttonStyle(BottomToolbarIconStyle(isActive: outlineState.isVisible))
+        .frame(width: 28, height: 28)
+        .help("Toggle outline")
+        .accessibilityLabel("Toggle outline")
+        .accessibilityAddTraits(outlineState.isVisible ? .isSelected : [])
+    }
+
+    @available(macOS 26.0, *)
+    private var glassCopyMenu: some View {
+        Menu {
+            copyMenuContent
+        } label: {
+            Image(systemName: "doc.on.doc")
+                .font(.system(size: 13, weight: .medium))
+                .frame(width: 32, height: 32)
+                .contentShape(Circle())
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .glassEffect(.regular.interactive(), in: .circle)
+        .help("Copy document")
+        .accessibilityLabel("Copy document")
+    }
+
+    @available(macOS 26.0, *)
+    private var glassOutlineToggle: some View {
+        Button {
+            outlineState.isVisible.toggle()
+        } label: {
+            Image(systemName: "list.bullet.indent")
+                .font(.system(size: 13, weight: .medium))
+                .frame(width: 32, height: 32)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .glassEffect(
+            outlineState.isVisible
+                ? .regular.tint(Color.accentColor.opacity(0.35)).interactive()
+                : .regular.interactive(),
+            in: .circle
+        )
+        .help("Toggle outline")
+        .accessibilityLabel("Toggle outline")
+        .accessibilityAddTraits(outlineState.isVisible ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private var copyMenuContent: some View {
+        Button("Copy Markdown")  { CopyActions.copyMarkdown(documentText()) }
+        Button("Copy HTML")      { CopyActions.copyHTML(documentText()) }
+        Button("Copy Rich Text") { CopyActions.copyRichText(documentText()) }
+        Button("Copy Plain Text") { CopyActions.copyPlainText(documentText()) }
+        Divider()
+        Button("Copy File Path") {
+            if let url = fileURL { CopyActions.copyFilePath(url) }
+        }
+        .disabled(fileURL == nil)
+        Button("Copy File Name") {
+            if let url = fileURL { CopyActions.copyFileName(url) }
+        }
+        .disabled(fileURL == nil)
+    }
+}
+
+// MARK: - Edit / Preview segmented pill
+
+private struct ModePill: View {
+    @Binding var viewMode: ViewMode
+
+    @Namespace private var selectionNamespace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            HStack(spacing: 2) {
+                segment(.edit, title: "Edit", systemImage: "pencil")
+                segment(.preview, title: "Preview", systemImage: "eye")
+            }
+            .padding(2)
+            .glassEffect(.regular, in: .capsule)
+        } else {
+            HStack(spacing: 2) {
+                segment(.edit, title: "Edit", systemImage: "pencil")
+                segment(.preview, title: "Preview", systemImage: "eye")
+            }
+            .padding(2)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(Color(NSColor.unemphasizedSelectedContentBackgroundColor))
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func segment(_ mode: ViewMode, title: String, systemImage: String) -> some View {
+        let isSelected = viewMode == mode
+
+        Button {
+            if reduceMotion {
+                viewMode = mode
+            } else {
+                withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+                    viewMode = mode
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .medium))
+                Text(title)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .frame(minHeight: 22)
+            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+            .background {
+                if isSelected {
+                    Capsule(style: .continuous)
+                        .fill(Color(NSColor.controlBackgroundColor))
+                        .shadow(color: .black.opacity(0.06), radius: 1, x: 0, y: 0.5)
+                        .matchedGeometryEffect(id: "selection", in: selectionNamespace)
+                }
+            }
+            .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(title) mode")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Mouse tracker (hover detection without blocking clicks)
+
+/// NSView with an NSTrackingArea that fires `onHover` callbacks but returns
+/// nil from `hitTest` so clicks pass through to whatever is underneath.
+struct BottomHoverTracker: NSViewRepresentable {
+    let onHover: (Bool) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = TrackingView()
+        view.onHover = onHover
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? TrackingView)?.onHover = onHover
+    }
+
+    private final class TrackingView: NSView {
+        var onHover: ((Bool) -> Void)?
+        private var trackingArea: NSTrackingArea?
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let trackingArea {
+                removeTrackingArea(trackingArea)
+            }
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            trackingArea = area
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            onHover?(true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHover?(false)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+    }
+}
+
+// MARK: - Right-side icon button style
+
+private struct BottomToolbarIconStyle: ButtonStyle {
+    let isActive: Bool
+    @State private var isHovering = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 28, height: 28)
+            .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+            .background {
+                let opacity: Double = {
+                    if configuration.isPressed { return 0.16 }
+                    if isActive { return 0.14 }
+                    if isHovering { return 0.08 }
+                    return 0
+                }()
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isActive ? Color.accentColor.opacity(opacity) : Color.primary.opacity(opacity))
+            }
+            .contentShape(Rectangle())
+            .onHover { isHovering = $0 }
+    }
+}

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -240,8 +240,8 @@ struct ClearlyApp: App {
             CommandGroup(after: .toolbar) {
                 ViewModeCommands()
                 OutlineToggleCommand()
-                StatusBarToggleCommand()
                 LineNumbersToggleCommand()
+                BottomToolbarVisibilityCommand()
             }
             CommandGroup(replacing: .textFormatting) {
                 FontSizeCommands()
@@ -384,10 +384,6 @@ private struct OutlineStateKey: FocusedValueKey {
     typealias Value = OutlineState
 }
 
-private struct StatusBarStateKey: FocusedValueKey {
-    typealias Value = StatusBarState
-}
-
 private struct ViewModeKey: FocusedValueKey {
     typealias Value = Binding<ViewMode>
 }
@@ -408,10 +404,6 @@ extension FocusedValues {
     var outlineState: OutlineState? {
         get { self[OutlineStateKey.self] }
         set { self[OutlineStateKey.self] = newValue }
-    }
-    var statusBarState: StatusBarState? {
-        get { self[StatusBarStateKey.self] }
-        set { self[StatusBarStateKey.self] = newValue }
     }
     var viewMode: Binding<ViewMode>? {
         get { self[ViewModeKey.self] }
@@ -474,19 +466,19 @@ struct OutlineToggleCommand: View {
     }
 }
 
-struct StatusBarToggleCommand: View {
-    @FocusedValue(\.statusBarState) var statusBarState
+struct BottomToolbarVisibilityCommand: View {
+    @AppStorage("alwaysShowBottomToolbar") private var alwaysShowBottomToolbar: Bool = false
 
     var body: some View {
         Button {
-            statusBarState?.toggle()
+            alwaysShowBottomToolbar.toggle()
         } label: {
             Label(
-                statusBarState?.isVisible == true ? "Hide Word Counts" : "Show Word Counts",
-                systemImage: "character.textbox"
+                alwaysShowBottomToolbar ? "Hide Toolbar" : "Show Toolbar",
+                systemImage: "rectangle.bottomthird.inset.filled"
             )
         }
-        .disabled(statusBarState == nil)
+        .keyboardShortcut("b", modifiers: [.command, .shift])
     }
 }
 

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import AppKit
 import ClearlyCore
 
-/// Per-document scene root: hosts the editor / preview, find bar, jump-to-line bar,
-/// outline panel, status bar, and the toolbar mode picker. One instance per
-/// `DocumentGroup` window.
+/// Per-document scene root: hosts the editor / preview, find bar, jump-to-line
+/// bar, outline panel, and the floating bottom toolbar (mode picker / counts /
+/// copy / outline). One instance per `DocumentGroup` window.
 struct ContentView: View {
     @Binding var document: MarkdownDocument
     let fileURL: URL?
@@ -19,10 +19,17 @@ struct ContentView: View {
     @AppStorage("previewFontFamily") private var previewFontFamily: String = "sanFrancisco"
     @AppStorage("contentWidth") private var contentWidth: String = "off"
     @AppStorage("showLineNumbers") private var showLineNumbers: Bool = false
+    @AppStorage("alwaysShowBottomToolbar") private var alwaysShowBottomToolbar: Bool = false
+
+    @State private var isHoveringBottom: Bool = false
 
     /// Stable per-window key for ScrollBridge / SelectionBridge. Re-keyed on
     /// document URL change so two windows on different files don't collide.
     @State private var positionSyncID: String = UUID().uuidString
+
+    private var shouldShowBottomToolbar: Bool {
+        alwaysShowBottomToolbar || isHoveringBottom
+    }
 
     private var contentWidthEm: CGFloat? {
         switch contentWidth {
@@ -47,40 +54,52 @@ struct ContentView: View {
             HStack(spacing: 0) {
                 mainPane
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay(alignment: .bottom) {
+                        ZStack(alignment: .bottom) {
+                            BottomHoverTracker { hovering in
+                                withAnimation(.easeInOut(duration: 0.18)) {
+                                    isHoveringBottom = hovering
+                                }
+                            }
+                            .frame(height: 96)
+
+                            if shouldShowBottomToolbar {
+                                LinearGradient(
+                                    stops: [
+                                        .init(color: Theme.backgroundColorSwiftUI.opacity(0), location: 0),
+                                        .init(color: Theme.backgroundColorSwiftUI.opacity(0.7), location: 0.55),
+                                        .init(color: Theme.backgroundColorSwiftUI, location: 1)
+                                    ],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
+                                .frame(height: 96)
+                                .allowsHitTesting(false)
+                                .transition(.opacity)
+
+                                BottomToolbar(
+                                    viewMode: $viewMode,
+                                    statusBarState: statusBarState,
+                                    outlineState: outlineState,
+                                    fileURL: fileURL,
+                                    documentText: { document.text }
+                                )
+                                .padding(.horizontal, 12)
+                                .padding(.bottom, 6)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                            }
+                        }
+                    }
 
                 if outlineState.isVisible {
                     OutlineView(outlineState: outlineState, isEditorVisible: viewMode == .edit)
                         .frame(width: 240)
                 }
             }
-
-            if statusBarState.isVisible {
-                Divider()
-                StatusBar(state: statusBarState)
-            }
         }
         .frame(minWidth: 600, minHeight: 360)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("View", selection: $viewMode) {
-                    Text("Editor").tag(ViewMode.edit)
-                    Text("Preview").tag(ViewMode.preview)
-                }
-                .pickerStyle(.segmented)
-                .frame(width: 160)
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    outlineState.isVisible.toggle()
-                } label: {
-                    Image(systemName: "list.bullet.indent")
-                }
-                .help("Toggle Outline")
-            }
-        }
         .focusedSceneValue(\.findState, findState)
         .focusedSceneValue(\.outlineState, outlineState)
-        .focusedSceneValue(\.statusBarState, statusBarState)
         .focusedSceneValue(\.viewMode, $viewMode)
         .focusedSceneValue(\.exportPDFAction) { exportPDF() }
         .focusedSceneValue(\.printDocumentAction) { printDocument() }
@@ -110,6 +129,7 @@ struct ContentView: View {
                 positionSyncID: positionSyncID,
                 findState: findState,
                 outlineState: outlineState,
+                extraBottomInset: BottomToolbar.pillHeight + 24,
                 showLineNumbers: showLineNumbers,
                 jumpToLineState: jumpToLineState,
                 statusBarState: statusBarState,
@@ -182,33 +202,3 @@ struct ContentView: View {
     }
 }
 
-// MARK: - Status bar
-
-private struct StatusBar: View {
-    @ObservedObject var state: StatusBarState
-
-    var body: some View {
-        HStack(spacing: 16) {
-            if state.counts.hasSelection {
-                Text("\(state.counts.selectionWords) words")
-                Text("\(state.counts.selectionChars) chars")
-            } else {
-                Text("\(state.counts.totalWords) words")
-                Text("\(state.counts.totalChars) chars")
-                Text(readingTime(seconds: state.counts.totalReadingSeconds))
-            }
-        }
-        .font(.system(size: 11))
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .background(.bar)
-    }
-
-    private func readingTime(seconds: Int) -> String {
-        if seconds < 60 { return "\(seconds)s read" }
-        let minutes = (seconds + 30) / 60
-        return "\(minutes) min read"
-    }
-}

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -13,6 +13,7 @@ struct EditorView: NSViewRepresentable {
     var findState: FindState?
     var outlineState: OutlineState?
     var extraTopInset: CGFloat = 0
+    var extraBottomInset: CGFloat = 0
     var showLineNumbers: Bool = false
     var jumpToLineState: JumpToLineState?
     var statusBarState: StatusBarState?
@@ -41,6 +42,9 @@ struct EditorView: NSViewRepresentable {
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
         scrollView.autohidesScrollers = true
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: extraBottomInset, right: 0)
+        scrollView.scrollerInsets = NSEdgeInsets(top: 0, left: 0, bottom: -extraBottomInset, right: 0)
 
         let textView = ClearlyTextView()
         textView.isRichText = false
@@ -236,6 +240,11 @@ struct EditorView: NSViewRepresentable {
         let expectedInset = NSSize(width: horizontalInset, height: Theme.editorInsetTop + extraTopInset)
         if textView.textContainerInset != expectedInset {
             textView.textContainerInset = expectedInset
+        }
+
+        if abs(scrollView.contentInsets.bottom - extraBottomInset) > 0.5 {
+            scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: extraBottomInset, right: 0)
+            scrollView.scrollerInsets = NSEdgeInsets(top: 0, left: 0, bottom: -extraBottomInset, right: 0)
         }
 
         let didChangeDocument = context.coordinator.lastPositionSyncID != positionSyncID

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
@@ -399,7 +399,7 @@ public enum PreviewCSS {
             margin: 0 auto;
             padding-top: max(40px, env(safe-area-inset-top));
             padding-right: max(64px, env(safe-area-inset-right));
-            padding-bottom: max(48px, env(safe-area-inset-bottom));
+            padding-bottom: max(80px, env(safe-area-inset-bottom));
             padding-left: max(64px, env(safe-area-inset-left));
             color: var(--c-text);
             background-color: var(--c-bg);

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/StatusBarState.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/StatusBarState.swift
@@ -1,16 +1,6 @@
 import Foundation
 
 public final class StatusBarState: ObservableObject {
-    public static let userDefaultsKey = "statusBarVisible"
-
-    @Published public var isVisible: Bool {
-        didSet {
-            UserDefaults.standard.set(isVisible, forKey: Self.userDefaultsKey)
-            if isVisible {
-                recomputeAll()
-            }
-        }
-    }
     @Published public private(set) var counts: MarkdownStats.Counts = .empty
 
     private var lastText: String = ""
@@ -18,13 +8,7 @@ public final class StatusBarState: ObservableObject {
     private var cachedTotals: MarkdownStats.Counts = .empty
     private var hasCachedTotals = false
 
-    public init() {
-        self.isVisible = UserDefaults.standard.bool(forKey: Self.userDefaultsKey)
-    }
-
-    public func toggle() {
-        isVisible.toggle()
-    }
+    public init() {}
 
     /// Replace the cached document text and recompute. Selection length is
     /// preserved if it still fits inside the new text; otherwise it collapses.
@@ -35,7 +19,6 @@ public final class StatusBarState: ObservableObject {
         if lastSelection.location + lastSelection.length > nsLength {
             lastSelection = NSRange(location: 0, length: 0)
         }
-        guard isVisible else { return }
         recomputeAll()
     }
 
@@ -45,10 +28,6 @@ public final class StatusBarState: ObservableObject {
     public func updateSelection(_ range: NSRange, in text: String) {
         lastText = text
         lastSelection = range
-        guard isVisible else {
-            hasCachedTotals = false
-            return
-        }
         if hasCachedTotals {
             recomputeSelectionOnly()
         } else {
@@ -60,7 +39,6 @@ public final class StatusBarState: ObservableObject {
     /// document switches or the editor is dismissed.
     public func resetSelection() {
         lastSelection = NSRange(location: 0, length: 0)
-        guard isVisible else { return }
         if hasCachedTotals {
             recomputeSelectionOnly()
         } else {

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/StatusBarStateTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/StatusBarStateTests.swift
@@ -2,50 +2,7 @@ import XCTest
 @testable import ClearlyCore
 
 final class StatusBarStateTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        UserDefaults.standard.removeObject(forKey: StatusBarState.userDefaultsKey)
-    }
-
-    override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: StatusBarState.userDefaultsKey)
-        super.tearDown()
-    }
-
-    func testHiddenUpdatesDoNotPublishCountsUntilShown() {
-        UserDefaults.standard.set(false, forKey: StatusBarState.userDefaultsKey)
-        let state = StatusBarState()
-        let text = "Hello world"
-
-        state.updateText(text)
-        state.updateSelection((text as NSString).range(of: "world"), in: text)
-
-        XCTAssertEqual(state.counts, .empty)
-
-        state.toggle()
-
-        XCTAssertEqual(state.counts.totalWords, 2)
-        XCTAssertEqual(state.counts.selectionWords, 1)
-        XCTAssertTrue(state.counts.hasSelection)
-    }
-
-    func testHiddenTextChangeRecomputesWhenShownAgain() {
-        UserDefaults.standard.set(true, forKey: StatusBarState.userDefaultsKey)
-        let state = StatusBarState()
-
-        state.updateText("one two")
-        XCTAssertEqual(state.counts.totalWords, 2)
-
-        state.toggle()
-        state.updateText("one two three")
-        XCTAssertEqual(state.counts.totalWords, 2)
-
-        state.toggle()
-        XCTAssertEqual(state.counts.totalWords, 3)
-    }
-
     func testSelectionChangesKeepDocumentTotals() {
-        UserDefaults.standard.set(true, forKey: StatusBarState.userDefaultsKey)
         let state = StatusBarState()
         let text = "**Hello** world from Clearly"
 
@@ -60,5 +17,15 @@ final class StatusBarStateTests: XCTestCase {
         state.resetSelection()
         XCTAssertEqual(state.counts.totalWords, 4)
         XCTAssertFalse(state.counts.hasSelection)
+    }
+
+    func testTextChangeAfterTextChangeRefreshesTotals() {
+        let state = StatusBarState()
+
+        state.updateText("one two")
+        XCTAssertEqual(state.counts.totalWords, 2)
+
+        state.updateText("one two three")
+        XCTAssertEqual(state.counts.totalWords, 3)
     }
 }


### PR DESCRIPTION
## Summary

- Restores the Copy menu (Markdown, HTML, Rich Text, Plain Text, File Path, File Name) removed in the recent strip-down, and replaces the top mode picker + inline status bar with a single floating bottom toolbar holding the Edit/Preview segmented control, live word/char count, Copy menu, and Outline toggle.
- The toolbar is hidden by default and fades in on hover; **View → Show Toolbar (⌘⇧B)** makes it always visible (`@AppStorage`-backed). On macOS 26 the controls use native Liquid Glass (`.glassEffect` capsule + circle inside a `GlassEffectContainer`); pre-26 falls back to a custom segmented pill and hover-state icon style.
- Document text fades into the editor background as it scrolls under the toolbar via a theme-aware `LinearGradient`. `EditorView` exposes a new `extraBottomInset` so `NSScrollView` content clears the floating bar; `PreviewCSS` `padding-bottom` floor bumped 48→80px.
- Removes the now-vestigial `isVisible` toggle from `StatusBarState` (counts always recompute) plus the related `StatusBarToggleCommand` and `StatusBarStateKey` focused-value plumbing; rewrites the `StatusBarState` tests to drop the visibility-gating cases.

## Test plan

- [ ] `xcodegen generate && xcodebuild -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData build` succeeds
- [ ] `xcodebuild -scheme Clearly-iOS -destination 'generic/platform=iOS Simulator' -derivedDataPath ./.build/DerivedData build` succeeds (iOS untouched)
- [ ] `swift test --package-path Packages/ClearlyCore` — all green
- [ ] Hover bottom edge → toolbar fades in; move away → fades out
- [ ] ⌘⇧B toggles persistent always-show; menu label flips Show/Hide
- [ ] Copy menu produces correct content for all 6 items; File Path / File Name disable on untitled doc
- [ ] Edit/Preview segmented control + ⌘1 / ⌘2 stay in sync; ⌘⇧O still toggles Outline
- [ ] Editor and Preview scroll cleanly under the floating bar (last line not clipped)