### PR TITLE
[ios] add QuickLook Preview and Thumbnail extensions for .md files

### DIFF
--- a/Clearly/iOS/Info-iOS.plist
+++ b/Clearly/iOS/Info-iOS.plist
@@ -55,6 +55,10 @@
 					<string>mdwn</string>
 					<string>mdx</string>
 				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>text/markdown</string>
+				</array>
 			</dict>
 		</dict>
 	</array>

--- a/Clearly/iOS/PreviewExtension/ClearlyPreview.entitlements
+++ b/Clearly/iOS/PreviewExtension/ClearlyPreview.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/Clearly/iOS/PreviewExtension/Info.plist
+++ b/Clearly/iOS/PreviewExtension/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>ClearlyPreview</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+				<string>net.ia.markdown</string>
+				<string>com.markdown</string>
+			</array>
+			<key>QLSupportsSearchableItems</key>
+			<false/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.preview</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).PreviewViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/Clearly/iOS/PreviewExtension/PreviewViewController.swift
+++ b/Clearly/iOS/PreviewExtension/PreviewViewController.swift
@@ -1,0 +1,49 @@
+import UIKit
+import ClearlyCore
+import QuickLook
+import WebKit
+
+final class PreviewViewController: UIViewController, QLPreviewingController {
+    private var webView: WKWebView!
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
+        webView = WKWebView(frame: .zero, configuration: config)
+        view = webView
+    }
+
+    func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
+        do {
+            let markdownText = try String(contentsOf: url, encoding: .utf8)
+            let rawBody = MarkdownRenderer.renderHTML(markdownText)
+            let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: url)
+
+            let html = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <style>\(PreviewCSS.css())</style>
+            <style>
+            @media (max-width: 400px) {
+                body { font-size: 14px; padding: 10px 20px 20px; }
+            }
+            </style>
+            </head>
+            <body>\(htmlBody)</body>
+            \(MathSupport.scriptHTML(for: htmlBody))
+            \(TableSupport.scriptHTML(for: htmlBody))
+            \(MermaidSupport.scriptHTML)
+            \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
+            </html>
+            """
+
+            webView.loadHTMLString(html, baseURL: url.deletingLastPathComponent())
+            handler(nil)
+        } catch {
+            handler(error)
+        }
+    }
+}

--- a/Clearly/iOS/ThumbnailExtension/ClearlyThumbnail.entitlements
+++ b/Clearly/iOS/ThumbnailExtension/ClearlyThumbnail.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/Clearly/iOS/ThumbnailExtension/Info.plist
+++ b/Clearly/iOS/ThumbnailExtension/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>ClearlyThumbnail</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+				<string>net.ia.markdown</string>
+				<string>com.markdown</string>
+			</array>
+			<key>QLThumbnailMinimumDimension</key>
+			<integer>64</integer>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.thumbnail</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ThumbnailProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/Clearly/iOS/ThumbnailExtension/ThumbnailProvider.swift
+++ b/Clearly/iOS/ThumbnailExtension/ThumbnailProvider.swift
@@ -1,0 +1,83 @@
+import UIKit
+import QuickLookThumbnailing
+
+final class ThumbnailProvider: QLThumbnailProvider {
+
+    override func provideThumbnail(
+        for request: QLFileThumbnailRequest,
+        _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
+    ) {
+        let sample = readSample(at: request.fileURL)
+        let (heading, body) = split(sample: sample)
+        let size = request.maximumSize
+
+        let reply = QLThumbnailReply(contextSize: size) { [weak self] in
+            self?.draw(heading: heading, body: body, size: size)
+            return true
+        }
+        handler(reply, nil)
+    }
+
+    private func readSample(at url: URL) -> String {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return "" }
+        defer { try? handle.close() }
+        let data = (try? handle.read(upToCount: 4096)) ?? Data()
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func split(sample: String) -> (heading: String?, body: String) {
+        let lines = sample.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
+        var heading: String?
+        var bodyLines: [String] = []
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if heading == nil, trimmed.hasPrefix("#") {
+                heading = trimmed.drop(while: { $0 == "#" || $0 == " " }).description
+                continue
+            }
+            if !trimmed.isEmpty {
+                bodyLines.append(trimmed)
+            }
+            if bodyLines.count >= 12 { break }
+        }
+
+        return (heading, bodyLines.joined(separator: "\n"))
+    }
+
+    private func draw(heading: String?, body: String, size: CGSize) {
+        let bg = UIColor.white
+        let fg = UIColor(white: 0.13, alpha: 1.0)
+        let dim = UIColor(white: 0.40, alpha: 1.0)
+
+        bg.setFill()
+        UIRectFill(CGRect(origin: .zero, size: size))
+
+        // Below ~64pt, text rendering is illegible; leave a clean blank canvas
+        // (system folds in the generic doc badge).
+        guard size.width >= 64 else { return }
+
+        let inset = max(6, size.width * 0.08)
+        var cursorY = inset
+
+        let headingFontSize = max(11, min(size.width * 0.10, 22))
+        let bodyFontSize = max(8, min(size.width * 0.055, 12))
+
+        if let heading, !heading.isEmpty {
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: headingFontSize, weight: .semibold),
+                .foregroundColor: fg
+            ]
+            let rect = CGRect(x: inset, y: cursorY, width: size.width - inset * 2, height: headingFontSize * 2.2)
+            (heading as NSString).draw(with: rect, options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine], attributes: attrs, context: nil)
+            cursorY += headingFontSize * 1.8
+        }
+
+        let bodyAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.monospacedSystemFont(ofSize: bodyFontSize, weight: .regular),
+            .foregroundColor: dim
+        ]
+        let bodyRect = CGRect(x: inset, y: cursorY, width: size.width - inset * 2, height: size.height - cursorY - inset)
+        (body as NSString).draw(with: bodyRect, options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine], attributes: bodyAttrs, context: nil)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -84,6 +84,9 @@ targets:
     platform: iOS
     sources:
       - path: Clearly/iOS
+        excludes:
+          - "PreviewExtension/**"
+          - "ThumbnailExtension/**"
       - path: Clearly/MarkdownDocument.swift
       - path: Clearly/AppIcon.icon
       - path: Shared/Resources/mermaid.min.js
@@ -103,6 +106,10 @@ targets:
         buildPhase: resources
     dependencies:
       - package: ClearlyCore
+      - target: ClearlyPreview-iOS
+        embed: true
+      - target: ClearlyThumbnail-iOS
+        embed: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly
@@ -165,6 +172,76 @@ targets:
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.quicklook
+          CODE_SIGN_STYLE: Automatic
+        Release:
+          CODE_SIGN_STYLE: Automatic
+
+  ClearlyPreview-iOS:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: Clearly/iOS/PreviewExtension
+      - path: Shared/Resources/mermaid.min.js
+        buildPhase: resources
+      - path: Shared/Resources/svg-pan-zoom.min.js
+        buildPhase: resources
+      - path: Shared/Resources/katex.min.js
+        buildPhase: resources
+      - path: Shared/Resources/katex.min.css
+        buildPhase: resources
+      - path: Shared/Resources/fonts
+        buildPhase: resources
+        type: folder
+      - path: Shared/Resources/highlight.min.js
+        buildPhase: resources
+      - path: Shared/Resources/highlight-theme.css
+        buildPhase: resources
+    dependencies:
+      - package: ClearlyCore
+      - package: cmark-gfm
+        product: cmark
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.preview
+        PRODUCT_NAME: ClearlyPreview
+        MARKETING_VERSION: "1.4.0"
+        CURRENT_PROJECT_VERSION: "1"
+        SWIFT_VERSION: "5.9"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SUPPORTS_MACCATALYST: NO
+        GENERATE_INFOPLIST_FILE: NO
+        CODE_SIGN_ENTITLEMENTS: Clearly/iOS/PreviewExtension/ClearlyPreview.entitlements
+        INFOPLIST_FILE: Clearly/iOS/PreviewExtension/Info.plist
+        DEVELOPMENT_TEAM: W33JZPPPFN
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.preview
+          CODE_SIGN_STYLE: Automatic
+        Release:
+          CODE_SIGN_STYLE: Automatic
+
+  ClearlyThumbnail-iOS:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: Clearly/iOS/ThumbnailExtension
+    dependencies: []
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.thumbnail
+        PRODUCT_NAME: ClearlyThumbnail
+        MARKETING_VERSION: "1.4.0"
+        CURRENT_PROJECT_VERSION: "1"
+        SWIFT_VERSION: "5.9"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SUPPORTS_MACCATALYST: NO
+        GENERATE_INFOPLIST_FILE: NO
+        CODE_SIGN_ENTITLEMENTS: Clearly/iOS/ThumbnailExtension/ClearlyThumbnail.entitlements
+        INFOPLIST_FILE: Clearly/iOS/ThumbnailExtension/Info.plist
+        DEVELOPMENT_TEAM: W33JZPPPFN
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sabotage.clearly.dev.thumbnail
           CODE_SIGN_STYLE: Automatic
         Release:
           CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- Adds a Quick Look **Preview** extension so tapping a `.md` in Files renders the same WebKit-based view the in-app reader uses (math, mermaid, syntax highlighting, etc.) instead of raw text.
- Adds a Quick Look **Thumbnail** extension that draws the first heading and body lines in Files' icon view, with a `QLThumbnailMinimumDimension=64` floor and a UIKit-only renderer to stay under the QuickLook XPC memory ceiling.
- Declares `public.mime-type: text/markdown` on the exported UTI so Mail/Safari MIME sniffing routes `.md` content to Clearly. Wires both new app-extension targets into `project.yml` (mirroring the macOS `ClearlyQuickLook` setup, sharing `ClearlyCore.MarkdownRenderer` and the preview HTML scaffold).

## Test plan

- [ ] `xcodegen generate && xcodebuild -scheme Clearly-iOS build` succeeds
- [ ] Install on a simulator/device, tap a `.md` in Files.app → rendered preview appears
- [ ] Files.app icon view → `.md` shows heading + body thumbnail
- [ ] Open With → Clearly still listed for `.md` and `.markdown` files
- [ ] Tapping a `.md` from Files.app hands off to Clearly and opens the file in the editor