### PR TITLE
[mac] Restore menubar-only mode for Scratchpad workflow

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -17,10 +17,26 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     private var isOpeningSettingsFromMenuBar = false
     private var observers: [Any] = []
 
-    /// Mirrors the `@AppStorage("showMenuBarIcon")` value the SwiftUI side reads.
-    /// Reads via `object(forKey:)` so the unset state resolves to `true`.
-    private var showMenuBarIcon: Bool {
-        (UserDefaults.standard.object(forKey: "showMenuBarIcon") as? Bool) ?? true
+    /// Temporarily set by the menubar "Quit Clearly" item so
+    /// `applicationShouldTerminate` knows to let the process actually exit.
+    /// Any other terminate path (⌘Q, File ▸ Quit) is treated as "drop to
+    /// menubar" when the menubar-only toggle is on.
+    private var allowFullQuit = false
+
+    /// SwiftUI side stores this with `@AppStorage("keepRunningMenubarOnly")`,
+    /// default `true`. Use `object(forKey:)` to distinguish unset (→ true)
+    /// from an explicit `false` the user wrote.
+    private var keepRunningMenubarOnly: Bool {
+        (UserDefaults.standard.object(forKey: "keepRunningMenubarOnly") as? Bool) ?? true
+    }
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // Avoid Dock-icon flash when the user launches with the toggle on.
+        // The `didBecomeMain` observer flips us back to `.regular` once a
+        // document window appears (Finder-open, untitled-on-launch, etc.).
+        if keepRunningMenubarOnly {
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -30,11 +46,22 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 
         let nc = NotificationCenter.default
         observers.append(nc.addObserver(forName: NSWindow.willCloseNotification, object: nil, queue: .main) { [weak self] notification in
+            let window = notification.object as? NSWindow
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                if let window = notification.object as? NSWindow {
-                    self.clearTrackedSettingsWindow(window)
+                if let window { self.clearTrackedSettingsWindow(window) }
+            }
+            // willClose fires while the window is still in NSApp.windows;
+            // defer the policy check until after it's removed.
+            DispatchQueue.main.async {
+                Task { @MainActor [weak self] in
+                    self?.updateActivationPolicy()
                 }
+            }
+        })
+        observers.append(nc.addObserver(forName: NSWindow.didBecomeMainNotification, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateActivationPolicy()
             }
         })
     }
@@ -84,7 +111,54 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        !showMenuBarIcon
+        if keepRunningMenubarOnly {
+            NSApp.setActivationPolicy(.accessory)
+            return false
+        }
+        return true
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if allowFullQuit { return .terminateNow }
+        guard keepRunningMenubarOnly else { return .terminateNow }
+
+        // Drop to menubar instead of terminating. `closeAllDocuments` walks
+        // every NSDocument (including SwiftUI DocumentGroup ones), prompting
+        // for unsaved changes — looping NSApp.windows and calling performClose
+        // does NOT reliably close DocumentGroup windows.
+        let docs = NSDocumentController.shared.documents
+        if docs.isEmpty {
+            NSApp.setActivationPolicy(.accessory)
+            return .terminateCancel
+        }
+        NSDocumentController.shared.closeAllDocuments(
+            withDelegate: self,
+            didCloseAllSelector: #selector(menubarOnlyDidCloseAllDocuments(_:didCloseAll:contextInfo:)),
+            contextInfo: nil
+        )
+        return .terminateLater
+    }
+
+    @objc private func menubarOnlyDidCloseAllDocuments(_ controller: NSDocumentController, didCloseAll: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        // Always reply NO — we're dropping to menubar regardless of whether
+        // all docs closed (user may have cancelled a save).
+        NSApp.reply(toApplicationShouldTerminate: false)
+        if didCloseAll {
+            // All docs closed. Hide Dock immediately; don't go through
+            // `updateActivationPolicy()` because the just-closed windows are
+            // still in `NSApp.windows` for a beat and would read as "doc open".
+            NSApp.setActivationPolicy(.accessory)
+        } else {
+            // User cancelled at least one save — at least one doc window
+            // remains; recompute against the real state.
+            updateActivationPolicy()
+        }
+    }
+
+    func requestFullQuitFromMenuBar() {
+        allowFullQuit = true
+        defer { allowFullQuit = false }
+        NSApp.terminate(nil)
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -94,11 +168,48 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
         observers.removeAll()
     }
 
-    private func hasDocumentWindows() -> Bool {
-        NSApp.windows.contains { window in
-            guard !(window is NSPanel), !window.isSheet, window.level != .floating else { return false }
-            return window.frame.width >= 200 && window.frame.height >= 200 && window !== trackedSettingsWindow
+    /// Drives the Dock icon. Called from window observers and from the
+    /// Settings toggle's `.onChange`. Always `.regular` when the toggle is
+    /// off. When the toggle is on, `.regular` only while a document window
+    /// is on screen.
+    func updateActivationPolicy() {
+        guard keepRunningMenubarOnly else {
+            if NSApp.activationPolicy() != .regular {
+                NSApp.setActivationPolicy(.regular)
+            }
+            return
         }
+        if hasDocumentWindows() {
+            if NSApp.activationPolicy() != .regular {
+                NSApp.setActivationPolicy(.regular)
+            }
+        } else {
+            if NSApp.activationPolicy() != .accessory {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+    }
+
+    /// Surfaces the Dock icon and brings the app forward. Used by the
+    /// menubar dropdown before opening a window — `updateActivationPolicy()`
+    /// will then keep us `.regular` until the window closes.
+    func ensureRegularAndActivate() {
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func hasDocumentWindows() -> Bool {
+        NSApp.windows.contains(where: isDocumentWindow)
+    }
+
+    private func isDocumentWindow(_ window: NSWindow) -> Bool {
+        // `isVisible` filters out windows that have just closed but are still
+        // in `NSApp.windows` waiting to be released — those would otherwise
+        // pin the activation policy to `.regular` for a beat after Cmd+Q.
+        guard window.isVisible, !(window is NSPanel), !window.isSheet, window.level != .floating else { return false }
+        return window.frame.width >= 200 && window.frame.height >= 200 && window !== trackedSettingsWindow
     }
 
     // MARK: - Settings window tracking (menu-bar Settings… coordination)
@@ -192,7 +303,6 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
 struct ClearlyApp: App {
     @NSApplicationDelegateAdaptor(ClearlyAppDelegate.self) var appDelegate
     @AppStorage("themePreference") private var themePreference = "system"
-    @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @State private var scratchpadManager = ScratchpadManager.shared
 
     #if canImport(Sparkle)
@@ -324,7 +434,7 @@ struct ClearlyApp: App {
             #endif
         }
 
-        MenuBarExtra("Scratchpads", image: "ScratchpadMenuBarIcon", isInserted: $showMenuBarIcon) {
+        MenuBarExtra("Scratchpads", image: "ScratchpadMenuBarIcon") {
             ScratchpadMenuBar(manager: scratchpadManager)
         }
     }

--- a/Clearly/ScratchpadManager.swift
+++ b/Clearly/ScratchpadManager.swift
@@ -151,10 +151,7 @@ final class ScratchpadManager {
                 return
             }
 
-            if NSApp.activationPolicy() != .regular {
-                NSApp.setActivationPolicy(.regular)
-            }
-            NSApp.activate(ignoringOtherApps: true)
+            ClearlyAppDelegate.shared?.ensureRegularAndActivate()
             NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in
                 Task { @MainActor in
                     self?.windows[id]?.close()

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -49,18 +49,22 @@ struct ScratchpadMenuBar: View {
         .keyboardShortcut(",", modifiers: [.command])
 
         Button("Quit Clearly") {
-            NSApp.terminate(nil)
+            ClearlyAppDelegate.shared?.requestFullQuitFromMenuBar()
         }
     }
 
     private func performMenuBarAction(_ action: @escaping () -> Void) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            if NSApp.activationPolicy() != .regular {
-                NSApp.setActivationPolicy(.regular)
-            }
-            NSApp.activate(ignoringOtherApps: true)
+            ClearlyAppDelegate.shared?.ensureRegularAndActivate()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 action()
+                // Re-activate after the action so any NSOpenPanel /
+                // NSSavePanel comes to the front. Without this second
+                // activation, transitions from `.accessory` can leave the
+                // panel buried behind other apps' windows.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    NSApp.activate(ignoringOtherApps: true)
+                }
             }
         }
     }
@@ -68,12 +72,12 @@ struct ScratchpadMenuBar: View {
     private func performSettingsMenuBarAction() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             ClearlyAppDelegate.shared?.prepareForMenuBarSettingsActivation()
-            if NSApp.activationPolicy() != .regular {
-                NSApp.setActivationPolicy(.regular)
-            }
-            NSApp.activate(ignoringOtherApps: true)
+            ClearlyAppDelegate.shared?.ensureRegularAndActivate()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 openSettings()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    NSApp.activate(ignoringOtherApps: true)
+                }
             }
         }
     }

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -16,7 +16,7 @@ struct SettingsView: View {
     @AppStorage("themePreference") private var themePreference = "system"
     @AppStorage("contentWidth") private var contentWidth = "off"
     @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
-    @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
+    @AppStorage("keepRunningMenubarOnly") private var keepRunningMenubarOnly = true
     @AppStorage("launchBehavior") private var launchBehavior = "filePicker"
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
@@ -84,7 +84,10 @@ struct SettingsView: View {
             }
 
             Toggle("Hide frontmatter in Preview", isOn: $hideFrontmatterInPreview)
-            Toggle("Show icon in menu bar", isOn: $showMenuBarIcon)
+            Toggle("Keep running in menu bar", isOn: $keepRunningMenubarOnly)
+                .onChange(of: keepRunningMenubarOnly) { _, _ in
+                    ClearlyAppDelegate.shared?.updateActivationPolicy()
+                }
 
             KeyboardShortcuts.Recorder("New Scratchpad:", name: .newScratchpad)
 
@@ -102,6 +105,7 @@ struct SettingsView: View {
                 }
         }
         .formStyle(.grouped)
+        .scrollDisabled(true)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Keep running in menu bar" Settings toggle (default ON) that restores the menubar-only behavior removed in the v3 refactor: when enabled, ⌘Q and closing the last document window drop the app to the menubar instead of quitting. Dock icon hides when no document windows are open and comes back when one opens.
- The existing "Show icon in menu bar" toggle is removed — the scratchpad menubar icon is now always visible while the app runs.
- ⌘Q routes through `NSDocumentController.closeAllDocuments` (handles unsaved-changes prompts) since `performClose` is a silent no-op on SwiftUI `DocumentGroup` windows. Only the menubar dropdown's "Quit Clearly" actually terminates the process.
- Dock visibility is driven by a single `updateActivationPolicy()` helper plus `willClose`/`didBecomeMain` observers; `ensureRegularAndActivate()` consolidates the inline `setActivationPolicy(.regular)` calls that were scattered across `ScratchpadManager` and `ScratchpadMenuBar`. NSOpenPanel / Settings invoked from the menubar now re-activate after presenting so they don't appear behind other apps' windows.

## Test plan
- [ ] Fresh install: launch with no defaults set → toggle reads ON, app boots into `.accessory` with menubar icon visible
- [ ] Toggle ON, open a doc → Dock icon visible while window is open
- [ ] Close last document window (red button) → Dock icon hides, menubar stays
- [ ] ⌘Q with clean doc → window closes, Dock hides, app keeps running
- [ ] ⌘Q with unsaved changes → save sheet appears; Cancel keeps window open and Dock visible; Save/Don't Save closes and drops to menubar
- [ ] Menubar > Open Document → file picker comes to the front above other apps
- [ ] Menubar > Settings → window comes to the front; toggle flip OFF brings Dock back immediately
- [ ] Menubar > Quit Clearly → process actually terminates
- [ ] Scratchpad workflow with toggle ON: New Scratchpad creates floating window without surfacing Dock; Save as Document does surface Dock