### PR TITLE
[mac] Add "Default View Mode" setting

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
     @Binding var document: MarkdownDocument
     let fileURL: URL?
 
-    @State private var viewMode: ViewMode = .edit
+    @State private var viewMode: ViewMode
     @StateObject private var outlineState = OutlineState()
     @StateObject private var findState = FindState()
     @StateObject private var jumpToLineState = JumpToLineState()
@@ -26,6 +26,17 @@ struct ContentView: View {
     /// Stable per-window key for ScrollBridge / SelectionBridge. Re-keyed on
     /// document URL change so two windows on different files don't collide.
     @State private var positionSyncID: String = UUID().uuidString
+
+    init(document: Binding<MarkdownDocument>, fileURL: URL?) {
+        self._document = document
+        self.fileURL = fileURL
+        // Never land a blank document in Preview — there'd be nothing to see
+        // and no obvious way to edit.
+        let raw = UserDefaults.standard.string(forKey: "defaultViewMode") ?? "edit"
+        let preferred = ViewMode(rawValue: raw) ?? .edit
+        let isBlank = document.wrappedValue.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        self._viewMode = State(initialValue: (preferred == .preview && isBlank) ? .edit : preferred)
+    }
 
     private var shouldShowBottomToolbar: Bool {
         alwaysShowBottomToolbar || isHoveringBottom

--- a/Clearly/SettingsView.swift
+++ b/Clearly/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
     @AppStorage("keepRunningMenubarOnly") private var keepRunningMenubarOnly = true
     @AppStorage("launchBehavior") private var launchBehavior = "filePicker"
+    @AppStorage("defaultViewMode") private var defaultViewMode = "edit"
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     @Environment(\.dismiss) private var dismiss
@@ -59,6 +60,11 @@ struct SettingsView: View {
                 Text("Open last file").tag("lastFile")
                 Text("Show file picker").tag("filePicker")
                 Text("Do nothing").tag("nothing")
+            }
+
+            Picker("Default View Mode", selection: $defaultViewMode) {
+                Text("Editor").tag("edit")
+                Text("Preview").tag("preview")
             }
 
             HStack {


### PR DESCRIPTION
## Summary
- Adds a **Default View Mode** picker (Editor / Preview) in Settings → General, right under "On Launch", for viewer-first users who don't want to flip the mode pill on every open.
- Default value is **Editor**, so existing users see no change on update.
- Blank documents (empty or whitespace-only) always open in Editor regardless of the preference — Preview on an empty doc is a dead end.

## Test plan
- [ ] Pref = Editor → opening any file lands in Editor (status quo)
- [ ] Pref = Preview → opening a non-empty `.md` lands in Preview
- [ ] Pref = Preview → Cmd-N lands in Editor (blank guard)
- [ ] Pref = Preview → opening an empty-on-disk `.md` lands in Editor
- [ ] Switching modes in one window via the toolbar pill / ⌘1 / ⌘2 does not overwrite the preference for other windows

Fixes #356