### PR TITLE
[mac] fix: keep scratchpad title clear of traffic-light buttons

### DIFF
--- a/Clearly/ScratchpadShellView.swift
+++ b/Clearly/ScratchpadShellView.swift
@@ -127,6 +127,7 @@ struct ScratchpadTitlebarBar: View {
     var body: some View {
         ZStack {
             ScratchpadTitleMenuButton()
+                .padding(.horizontal, 72)
 
             HStack(spacing: 0) {
                 Spacer(minLength: 0)


### PR DESCRIPTION
## Summary
- Scratchpad windows use a custom SwiftUI titlebar (`titleVisibility = .hidden` + `.fullSizeContentView`), so AppKit's built-in title vs. traffic-light layout doesn't apply. The centered title-menu button had no width constraint, so on narrow windows the title text bled into the red/yellow/green controls.
- Added `.padding(.horizontal, 72)` to `ScratchpadTitleMenuButton()` inside `ScratchpadTitlebarBar`, reserving room for the traffic-light cluster (left) and the new-note button (right). The existing `.lineLimit(1)` + `.truncationMode(.tail)` now engages and the title ellipsizes cleanly.

## Test plan
- [x] Build succeeds (`xcodebuild -scheme Clearly -derivedDataPath ./.build/DerivedData build`)
- [x] Long-title scratchpad (e.g. `GOOGLE_CLOUD_PROJECT_ID=granite-496215`) renders truncated with `…`, traffic lights fully visible
- [ ] Resize scratchpad to minimum width (360pt) and confirm title still truncates cleanly without overlapping either side
- [ ] Short title (e.g. `Scratchpad`) stays visually centered