### PR TITLE
[mac] fix: scratchpad shortcut steals focus from previous app

### DIFF
--- a/Clearly/ScratchpadManager.swift
+++ b/Clearly/ScratchpadManager.swift
@@ -4,6 +4,11 @@ import UniformTypeIdentifiers
 import KeyboardShortcuts
 import ClearlyCore
 
+private final class ScratchpadPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
 @MainActor
 @Observable
 final class ScratchpadManager {
@@ -14,7 +19,7 @@ final class ScratchpadManager {
     var historyPopoverShown: Bool = false
 
     private let store = ScratchpadStore.shared
-    private var window: NSWindow?
+    private var window: ScratchpadPanel?
     private var windowDelegate: WindowDelegate?
 
     var isWindowVisible: Bool { window?.isVisible == true }
@@ -46,9 +51,8 @@ final class ScratchpadManager {
         if let id = currentNoteID, let note = store.notes.first(where: { $0.id == id }) {
             store.touchOpened(note)
         }
-        ClearlyAppDelegate.shared?.ensureRegularAndActivate()
         window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.orderFrontRegardless()
     }
 
     func createAndShowNew() {
@@ -56,9 +60,8 @@ final class ScratchpadManager {
         store.flushPendingWrites()
         let note = store.create()
         select(note: note)
-        ClearlyAppDelegate.shared?.ensureRegularAndActivate()
         window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        window?.orderFrontRegardless()
     }
 
     func select(note: ScratchpadNote) {
@@ -159,14 +162,23 @@ final class ScratchpadManager {
             .environment(deleteUndo)
         let controller = NSHostingController(rootView: rootView)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
+        controller.preferredContentSize = Self.defaultScratchpadContentSize
 
-        let win = NSWindow(contentViewController: controller)
-        win.styleMask = [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView]
+        let win = ScratchpadPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 560),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable,
+                        .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        win.contentViewController = controller
         win.title = " "
         win.level = .floating
+        win.isFloatingPanel = true
+        win.becomesKeyOnlyIfNeeded = false
+        win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         win.isReleasedWhenClosed = false
         win.minSize = NSSize(width: 360, height: 280)
-        win.setContentSize(NSSize(width: 480, height: 560))
         win.titleVisibility = .hidden
         win.titlebarSeparatorStyle = .none
         win.titlebarAppearsTransparent = true
@@ -182,8 +194,11 @@ final class ScratchpadManager {
         positionTopRightIfUnsaved(win)
     }
 
-    private func positionTopRightIfUnsaved(_ win: NSWindow) {
-        guard !win.setFrameUsingName("ClearlyScratchpadWindow") else { return }
+    private static let defaultScratchpadContentSize = NSSize(width: 480, height: 560)
+
+    private func positionTopRightIfUnsaved(_ win: NSPanel) {
+        if win.setFrameUsingName("ClearlyScratchpadWindow") { return }
+        win.setContentSize(Self.defaultScratchpadContentSize)
         guard let screen = NSScreen.main else { return }
         let visible = screen.visibleFrame
         let size = win.frame.size

--- a/Clearly/ScratchpadMenuBar.swift
+++ b/Clearly/ScratchpadMenuBar.swift
@@ -8,16 +8,12 @@ struct ScratchpadMenuBar: View {
 
     var body: some View {
         Button("Open Scratchpad") {
-            performMenuBarAction {
-                manager.showOrFocus()
-            }
+            manager.showOrFocus()
         }
         .keyboardShortcut(for: .newScratchpad)
 
         Button("New Scratchpad") {
-            performMenuBarAction {
-                manager.createAndShowNew()
-            }
+            manager.createAndShowNew()
         }
 
         if !store.notes.isEmpty {
@@ -26,10 +22,8 @@ struct ScratchpadMenuBar: View {
             Menu("Recent Scratchpads") {
                 ForEach(store.notes.prefix(8)) { note in
                     Button(note.title.isEmpty ? ScratchpadNote.titlePlaceholder : note.title) {
-                        performMenuBarAction {
-                            manager.select(note: note)
-                            manager.showOrFocus()
-                        }
+                        manager.select(note: note)
+                        manager.showOrFocus()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Convert the floating scratchpad to a non-activating `NSPanel` so the global ⌃⌥⌘N shortcut brings it up focused and typable without switching the foreground app (Spotlight-style), instead of the prior fully-activating `NSWindow` that lost the focus race from the Carbon hotkey callback.
- Set `.nonactivatingPanel` in the panel's init style mask (it has no effect when assigned after construction) and use `NSHostingController.preferredContentSize` so the SwiftUI shell doesn't collapse the panel below 480×560.
- Drop the `setActivationPolicy(.regular)` / `NSApp.activate(ignoringOtherApps:)` calls and the 200 ms `asyncAfter` menu-bar workarounds from the scratchpad-open paths — they were papering over the same activation race and are no longer needed. The save-as-document path still activates the app fully, since handing off to a real document window legitimately wants `.regular` policy.

## Test plan
- [ ] Press ⌃⌥⌘N from Finder, Mail, and a browser — scratchpad appears focused, previous app's menu bar stays visible.
- [ ] Press ⌃⌥⌘N over a fullscreen app (Safari fullscreen) — panel overlays it.
- [ ] Menu bar → Open Scratchpad / New Scratchpad / Recent Scratchpads all behave the same as the shortcut.
- [ ] Type characters immediately after the panel appears — no need to click first.
- [ ] Save scratchpad as `.md` document — Clearly takes over (dock icon appears, regular doc window opens).
- [ ] Menu bar → New Document and Open Document still activate Clearly normally.
- [ ] Close scratchpad — focus returns to previous app cleanly, no dock-icon residue.