### PR TITLE
[shared] fix: dead-key IME composition silently aborted (#367)

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -318,8 +318,21 @@ struct EditorView: NSViewRepresentable {
         // When the user types, textDidChange marks the text view authoritative
         // until the next run loop. While updates are pending, any mismatch is
         // just SwiftUI catching up, not an external change.
+        //
+        // Marked-text composition (e.g. Option+U dead-key on a US keyboard;
+        // CJK IMEs) also makes textView.string diverge from the binding —
+        // setMarkedText inserts the composing character into textStorage but
+        // does NOT fire textDidChange, so pendingBindingUpdates stays 0. The
+        // hasMarkedText check below stops us from overwriting the composing
+        // character with the stale binding value, which would silently abort
+        // the dead-key sequence. The mismatch resolves naturally on the next
+        // textDidChange — either when composition commits (Option+u then o →
+        // "ö" gets inserted normally) or when the user dismisses it.
         let textMismatch = text.count != textView.string.count || textView.string != text
-        if !context.coordinator.isUpdating && context.coordinator.pendingBindingUpdates == 0 && textMismatch {
+        if !context.coordinator.isUpdating
+            && context.coordinator.pendingBindingUpdates == 0
+            && !textView.hasMarkedText()
+            && textMismatch {
             DiagnosticLog.log("updateNSView #\(count): external text change (\(text.count) chars)")
             context.coordinator.isUpdating = true
             let selectedRanges = textView.selectedRanges

--- a/Clearly/iOS/EditorView_iOS.swift
+++ b/Clearly/iOS/EditorView_iOS.swift
@@ -45,6 +45,11 @@ struct EditorView_iOS: UIViewRepresentable {
         context.coordinator.attachOutlineState(outlineState)
         context.coordinator.attachFindState(findState)
         guard context.coordinator.pendingBindingUpdates == 0 else { return }
+        // Don't clobber an in-flight IME composition (CJK, predictive text,
+        // emoji picker). UIKit's marked text mutates the text view's content
+        // without firing textViewDidChange, so without this guard a layout
+        // pass that retriggers updateUIView would wipe the composing range.
+        guard textView.markedTextRange == nil else { return }
         guard text != context.coordinator.lastAppliedText else { return }
         context.coordinator.applyExternalText(text)
     }


### PR DESCRIPTION
## Summary

Fixes [#367](https://github.com/Shpigford/clearly/issues/367) — Option+u (and other dead-key sequences) silently failed to compose German umlauts on the U.S. keyboard layout. Pressing Option+u looked like a no-op; the next vowel was inserted bare.

## Root cause

`NSTextView.setMarkedText(_:selectedRange:replacementRange:)` mutates `textStorage` to insert the composing character (e.g. `¨`) but does **not** fire `NSText.didChangeNotification`. The single-character growth still triggers a SwiftUI layout pass on the `NSViewRepresentable`, which calls `updateNSView`. At that point:

- `text` binding is still the pre-composition value
- `textView.string` has the composing character
- `pendingBindingUpdates == 0` (no `textDidChange` fired, so the fast-typing race protection from #84 doesn't engage)

The textMismatch guard fired and `textView.string = text` wiped the marked `¨`. The next keystroke arrived with no composition active, so `o` just inserted `o`.

Same shape on iOS — UIKit marked text (CJK IMEs, predictive text, emoji picker) mutates content without firing `textViewDidChange`, so `updateUIView` was equally susceptible.

## Change

Guard the binding-driven text replacement with `hasMarkedText()` (Mac) / `markedTextRange == nil` (iOS) so an in-flight composition survives layout passes. Composition resolves normally on the next `textDidChange` once the user commits or dismisses it.

Two lines on each platform — no changes to `ClearlyCore`, the syntax highlighter, or the `textDidChange` flow.

## Test plan

- [x] Build Mac (`xcodebuild -scheme Clearly`)
- [x] Build iOS (`xcodebuild -scheme Clearly-iOS`)
- [x] `swift test --package-path Packages/ClearlyCore` — all suites green
- [x] Manual: Option+u then `o` → `ö` ✓
- [x] Manual: Option+e then `a` → `á` ✓
- [x] Manual: Option+n then `n` → `ñ` ✓
- [x] Manual: Shift+Option+U continues to insert a standalone `¨` (correct — matches TextEdit; the Shift variant is not a dead key on the U.S. layout)
- [x] Regression: fast typing in long documents — cursor doesn't jump (the `pendingBindingUpdates` mechanism from #84 still in place)
- [ ] Manual on iOS Simulator: enable Japanese - Romaji keyboard, type `nihongo` and confirm marked composition resolves to `日本語` rather than committing each Romaji keystroke individually