### PR TITLE
[mac] fix: double-click in Preview no longer switches to Edit mode

### DIFF
--- a/Clearly/AppShellSupport.swift
+++ b/Clearly/AppShellSupport.swift
@@ -5,7 +5,6 @@ import ClearlyCore
 /// for cross-pane jumps (click a heading / find-result in one pane and
 /// scroll the other to the same line).
 extension Notification.Name {
-    static let scrollEditorToLine = Notification.Name("ClearlyScrollEditorToLine")
     static let scrollPreviewToLine = Notification.Name("ClearlyScrollPreviewToLine")
     static let flushEditorBuffer = Notification.Name("ClearlyFlushEditorBuffer")
     static let highlightTextInEditor = Notification.Name("ClearlyHighlightTextInEditor")

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -161,14 +161,6 @@ struct ContentView: View {
                 onTaskToggle: { line, checked in
                     toggleTask(line: line, checked: checked)
                 },
-                onJumpToSource: { line in
-                    NotificationCenter.default.post(
-                        name: .scrollEditorToLine,
-                        object: nil,
-                        userInfo: ["line": line]
-                    )
-                    viewMode = .edit
-                },
                 contentWidthEm: contentWidthEm
             )
             .opacity(viewMode == .preview ? 1 : 0)

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -136,14 +136,6 @@ struct EditorView: NSViewRepresentable {
             object: scrollView.contentView
         )
 
-        // Observe click-to-source from preview
-        NotificationCenter.default.addObserver(
-            context.coordinator,
-            selector: #selector(Coordinator.handleScrollToLine(_:)),
-            name: .scrollEditorToLine,
-            object: nil
-        )
-
         NotificationCenter.default.addObserver(
             context.coordinator,
             selector: #selector(Coordinator.flushEditorBuffer(_:)),
@@ -444,28 +436,6 @@ struct EditorView: NSViewRepresentable {
             }
 
             parent.statusBarState?.updateSelection(range, in: textView.string)
-        }
-
-        @objc func handleScrollToLine(_ notification: Notification) {
-            guard let line = notification.userInfo?["line"] as? Int,
-                  let textView,
-                  line > 0 else { return }
-            let text = textView.string
-            let lines = (text as NSString).components(separatedBy: "\n")
-            let targetLine = min(line, lines.count)
-            var charOffset = 0
-            for i in 0..<(targetLine - 1) {
-                charOffset += (lines[i] as NSString).length + 1 // +1 for \n
-            }
-            let nsText = text as NSString
-            let range = NSRange(location: min(charOffset, nsText.length), length: 0)
-            textView.scrollRangeToVisible(range)
-            // Briefly highlight the line
-            if targetLine - 1 < lines.count {
-                let lineLen = (lines[targetLine - 1] as NSString).length
-                let highlightRange = NSRange(location: min(charOffset, nsText.length), length: min(lineLen, nsText.length - charOffset))
-                textView.showFindIndicator(for: highlightRange)
-            }
         }
 
         @objc func handleHighlightText(_ notification: Notification) {

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -30,7 +30,6 @@ struct PreviewView: NSViewRepresentable {
     var findState: FindState?
     var outlineState: OutlineState?
     var onTaskToggle: ((Int, Bool) -> Void)?
-    var onJumpToSource: ((Int) -> Void)?
     var contentWidthEm: CGFloat? = nil
     var extraTopInset: CGFloat = 0
     @AppStorage("hideFrontmatterInPreview") private var hideFrontmatterInPreview = false
@@ -59,7 +58,6 @@ struct PreviewView: NSViewRepresentable {
         config.userContentController.add(context.coordinator, name: "taskToggle")
         config.userContentController.add(context.coordinator, name: "foldToggle")
         config.userContentController.add(context.coordinator, name: "selectionCapture")
-        config.userContentController.add(context.coordinator, name: "jumpToSource")
         config.userContentController.addUserScript(PreviewUserScripts.codeBlockChromeScript())
         let webView = DraggableWKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
@@ -70,7 +68,6 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.findState = findState
         context.coordinator.outlineState = outlineState
         context.coordinator.onTaskToggle = onTaskToggle
-        context.coordinator.onJumpToSource = onJumpToSource
         let coordinator = context.coordinator
         findState?.previewNavigateToNext = { [weak coordinator] in
             coordinator?.navigateToNextMatch()
@@ -144,7 +141,6 @@ struct PreviewView: NSViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "taskToggle")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "foldToggle")
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "selectionCapture")
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "jumpToSource")
     }
 
     private func loadHTML(in webView: WKWebView, context: Context) {
@@ -314,20 +310,6 @@ struct PreviewView: NSViewRepresentable {
                 if (popover) { popover.remove(); popover = null; }
             });
         });
-        // Double-click any element to jump to its source line in the editor.
-        document.addEventListener('dblclick', function(e) {
-            var t = e.target;
-            if (!t || t.nodeType !== 1) return;
-            // Skip elements that own a different dblclick interaction or that
-            // belong to popovers/lightboxes appended to <body>.
-            if (t.closest('.mermaid-wrapper, .lightbox-overlay, .mermaid-lightbox-overlay, .footnote-popover, summary, input, button, .copy-button, .code-copy, .table-sort-button')) return;
-            var node = t.closest('[data-sourcepos]');
-            if (!node) return;
-            var sp = node.getAttribute('data-sourcepos') || '';
-            var m = /^(\\d+):/.exec(sp);
-            if (!m) return;
-            window.webkit.messageHandlers.jumpToSource.postMessage({ line: parseInt(m[1], 10) });
-        });
         </script>
         \(MathSupport.scriptHTML(for: htmlBody))
         \(TableSupport.scriptHTML(for: htmlBody))
@@ -349,7 +331,6 @@ struct PreviewView: NSViewRepresentable {
         var findState: FindState?
         var outlineState: OutlineState?
         var onTaskToggle: ((Int, Bool) -> Void)?
-        var onJumpToSource: ((Int) -> Void)?
         var skipNextReload = false
         var isLoadingContent = false
         var pendingScrollLine: Int?
@@ -791,15 +772,6 @@ struct PreviewView: NSViewRepresentable {
                let body = message.body as? [String: Any],
                let text = body["text"] as? String {
                 SelectionBridge.setSelection(text, for: self.positionSyncID)
-                return
-            }
-
-            if message.name == "jumpToSource",
-               let body = message.body as? [String: Any],
-               let line = (body["line"] as? NSNumber)?.intValue {
-                DispatchQueue.main.async { [weak self] in
-                    self?.onJumpToSource?(line)
-                }
                 return
             }
 


### PR DESCRIPTION
## Summary

Fixes #366. Double-clicking any rendered text in Preview mode was kicking the user back into the editor — including when they were just trying to select a word.

Root cause: a JS `dblclick` listener on the WKWebView posted a `jumpToSource` message to a Swift handler that both scrolled the editor and set `viewMode = .edit`. Since virtually every rendered element carries a `data-sourcepos`, every word-select triggered it.

This PR removes the entire jump-to-source thread end-to-end — no producer, no consumer, no notification. Double-click in Preview now does what `WKWebView` does natively (select the word) and stays in Preview.

## Changes

- Drop the JS `dblclick` listener from the preview HTML
- Remove `jumpToSource` WKScriptMessageHandler registration, dispatch, and cleanup
- Remove `onJumpToSource` from `PreviewView` and its `Coordinator`
- Remove the `onJumpToSource:` closure passed by `ContentView`
- Remove the now-orphaned `scrollEditorToLine` notification declaration, the `EditorView` observer, and `handleScrollToLine` (their only producer was the closure above)

Net: -67 lines, no new code.

iOS is unaffected — it never had this listener.

## Test plan

- [ ] Open a markdown file (or Help → Sample Document)
- [ ] Switch to Preview mode
- [ ] Double-click on a paragraph, heading, list item, table cell, blockquote — each should select the word and remain in Preview
- [ ] Confirm task-checkbox toggle in preview still works (separate handler)
- [ ] Confirm outline → preview scroll still works
- [ ] Confirm find/replace in preview still works