### PR TITLE
[shared] feat: auto-reload open documents on external file changes

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -127,6 +127,20 @@ struct ContentView: View {
             // file's scroll position doesn't inherit the old fraction.
             positionSyncID = UUID().uuidString
         }
+        .watchExternalChanges(fileURL: fileURL, text: $document.text) { url in
+            // Sync SwiftUI's underlying NSDocument's fileModificationDate to
+            // the new on-disk mtime — without this, the next autosave detects
+            // a conflict and shows "could not be autosaved" dialog. We
+            // deliberately do NOT try to suppress the title's "Edited"
+            // decoration: SwiftUI tracks its own FileDocument-vs-disk diff
+            // for that, and the indicator is a useful "doc changed under you"
+            // signal anyway.
+            let target = url.standardizedFileURL
+            guard let doc = NSDocumentController.shared.documents.first(where: { $0.fileURL?.standardizedFileURL == target }) else { return }
+            if let mtime = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date {
+                doc.fileModificationDate = mtime
+            }
+        }
     }
 
     @ViewBuilder

--- a/Clearly/iOS/DocumentDetailBody.swift
+++ b/Clearly/iOS/DocumentDetailBody.swift
@@ -39,6 +39,7 @@ struct DocumentDetailBody: View {
         .onChange(of: document.text) { _, newText in
             outlineState.parseHeadings(from: newText)
         }
+        .watchExternalChanges(fileURL: fileURL, text: $document.text)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/ExternalFileWatcher.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/ExternalFileWatcher.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Watches a single file URL for out-of-process modifications via
+/// `NSFilePresenter` + `NSFileCoordinator`. Survives atomic-rename writes
+/// (the common save-via-temp pattern) because the presenter is keyed on URL,
+/// not file descriptor.
+///
+/// `onExternalChange` is invoked on `presentedItemOperationQueue` (a serial,
+/// non-main queue). Callers that need to touch UI state must hop to main
+/// themselves — keeping the dispatch decision in the caller makes the watcher
+/// trivially testable without driving a run loop.
+public final class ExternalFileWatcher: NSObject, NSFilePresenter, @unchecked Sendable {
+    public var presentedItemURL: URL?
+    public let presentedItemOperationQueue: OperationQueue = {
+        let q = OperationQueue()
+        q.qualityOfService = .userInitiated
+        q.maxConcurrentOperationCount = 1
+        return q
+    }()
+
+    private let onExternalChange: (String) -> Void
+    private var isStopped = false
+
+    public init(url: URL, onExternalChange: @escaping (String) -> Void) {
+        self.presentedItemURL = url
+        self.onExternalChange = onExternalChange
+        super.init()
+        NSFileCoordinator.addFilePresenter(self)
+    }
+
+    public func stop() {
+        guard !isStopped else { return }
+        isStopped = true
+        NSFileCoordinator.removeFilePresenter(self)
+    }
+
+    deinit { stop() }
+
+    public func presentedItemDidChange() {
+        guard let url = presentedItemURL else { return }
+        var diskText: String?
+        var coordErr: NSError?
+        NSFileCoordinator(filePresenter: self).coordinate(
+            readingItemAt: url, options: [], error: &coordErr
+        ) { resolved in
+            #if os(iOS)
+            let scoped = resolved.startAccessingSecurityScopedResource()
+            defer { if scoped { resolved.stopAccessingSecurityScopedResource() } }
+            #endif
+            if let data = try? Data(contentsOf: resolved) {
+                diskText = String(decoding: data, as: UTF8.self)
+            }
+        }
+        guard let text = diskText else { return }
+        guard !isStopped else { return }
+        onExternalChange(text)
+    }
+
+    public func presentedItemDidMove(to newURL: URL) {
+        presentedItemURL = newURL
+    }
+}

--- a/Packages/ClearlyCore/Sources/ClearlyCore/State/WatchExternalChangesModifier.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/State/WatchExternalChangesModifier.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Outcome of comparing on-disk content to the in-memory editor text when an
+/// external write fires.
+public enum ExternalChangeDecision: Equatable {
+    /// Disk content matches the editor already — almost certainly the echo
+    /// from our own save (DocumentGroup autosave). No-op.
+    case ignoreEcho
+    /// The user has typed since the last on-disk version we observed.
+    /// Dropping the external change preserves their unsaved work.
+    case ignoreDirty
+    /// Safe to overwrite the editor with the new disk content.
+    case apply(String)
+}
+
+/// Pure policy function. Echo-detection wins over dirty-detection so that
+/// a save round-trip where the editor and disk agree is always a no-op,
+/// even if `lastKnownDisk` lags.
+public func mergeExternalChange(
+    disk: String,
+    currentText: String,
+    lastKnownDisk: String
+) -> ExternalChangeDecision {
+    if disk == currentText { return .ignoreEcho }
+    if currentText != lastKnownDisk { return .ignoreDirty }
+    return .apply(disk)
+}
+
+/// State machine that pairs `mergeExternalChange` with a baseline that
+/// advances on every observed on-disk content (initial load + each presenter
+/// callback). Baseline does NOT advance on user typing — that's the whole
+/// point of dirty detection. Extracted so the policy is unit-testable without
+/// a SwiftUI host.
+public final class ExternalChangeReducer {
+    private(set) public var lastKnownDisk: String
+
+    public init(initialText: String) {
+        self.lastKnownDisk = initialText
+    }
+
+    /// Returns the new editor text iff the change should be applied. Always
+    /// advances `lastKnownDisk` to the observed disk content.
+    public func observe(disk: String, currentText: String) -> String? {
+        let decision = mergeExternalChange(disk: disk, currentText: currentText, lastKnownDisk: lastKnownDisk)
+        lastKnownDisk = disk
+        if case .apply(let new) = decision { return new }
+        return nil
+    }
+}
+
+public extension View {
+    /// Watch the file at `fileURL` for out-of-process modifications and
+    /// reflect them into `text` when safe (editor not mid-edit).
+    ///
+    /// `onApply` fires immediately after the editor binding is updated with
+    /// new disk content. The Mac app uses this hook to refresh the underlying
+    /// `NSDocument`'s bookkeeping so SwiftUI's autosave doesn't pop a
+    /// "file changed by another application" conflict dialog.
+    func watchExternalChanges(
+        fileURL: URL?,
+        text: Binding<String>,
+        onApply: ((URL) -> Void)? = nil
+    ) -> some View {
+        modifier(WatchExternalChangesModifier(fileURL: fileURL, text: text, onApply: onApply))
+    }
+}
+
+private struct WatchExternalChangesModifier: ViewModifier {
+    let fileURL: URL?
+    @Binding var text: String
+    let onApply: ((URL) -> Void)?
+
+    @State private var watcher: ExternalFileWatcher?
+    @State private var reducer: ExternalChangeReducer?
+    /// Bumped on every `bind()`. `presentedItemDidChange` callbacks captured
+    /// from the OLD watcher can still complete after `removeFilePresenter`
+    /// (Apple's API only guarantees deregistration, not synchronous drain).
+    /// We snapshot this token into each watcher's closure and drop callbacks
+    /// whose token no longer matches the current generation.
+    @State private var bindGeneration: Int = 0
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { bind(to: fileURL) }
+            .onDisappear {
+                watcher?.stop()
+                watcher = nil
+                reducer = nil
+                bindGeneration &+= 1
+            }
+            .onChange(of: fileURL) { _, newURL in
+                bind(to: newURL)
+            }
+    }
+
+    private func bind(to url: URL?) {
+        watcher?.stop()
+        bindGeneration &+= 1
+        guard let url else {
+            watcher = nil
+            reducer = nil
+            return
+        }
+        // FileDocument's init(configuration:) set `text` from disk just before
+        // the view appeared, so `text` is the right baseline at bind time.
+        let reducer = ExternalChangeReducer(initialText: text)
+        self.reducer = reducer
+        let onApply = self.onApply
+        let token = bindGeneration
+        watcher = ExternalFileWatcher(url: url) { diskText in
+            // Watcher invokes on its operation queue; SwiftUI state mutations
+            // must run on main.
+            DispatchQueue.main.async {
+                // Drop callbacks left over from a previous watcher — those
+                // carry the wrong file's content and would clobber the editor.
+                guard token == bindGeneration else { return }
+                if let newText = reducer.observe(disk: diskText, currentText: text) {
+                    text = newText
+                    onApply?(url)
+                }
+            }
+        }
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ExternalFileWatcherTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ExternalFileWatcherTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import ClearlyCore
+
+struct ExternalFileWatcherTests {
+
+    // MARK: - mergeExternalChange policy
+
+    @Test func applyWhenEditorMatchesLastKnownDisk() {
+        let decision = mergeExternalChange(disk: "B", currentText: "A", lastKnownDisk: "A")
+        #expect(decision == .apply("B"))
+    }
+
+    @Test func ignoreEchoWhenDiskMatchesEditor() {
+        let decision = mergeExternalChange(disk: "A", currentText: "A", lastKnownDisk: "B")
+        #expect(decision == .ignoreEcho)
+    }
+
+    @Test func ignoreDirtyWhenEditorDivergedFromLastKnownDisk() {
+        let decision = mergeExternalChange(disk: "B", currentText: "A-typed", lastKnownDisk: "A")
+        #expect(decision == .ignoreDirty)
+    }
+
+    @Test func ignoreEchoWinsOverDirty() {
+        let decision = mergeExternalChange(disk: "X", currentText: "X", lastKnownDisk: "Y")
+        #expect(decision == .ignoreEcho)
+    }
+
+    @Test func applyDeliversFullDiskString() {
+        let decision = mergeExternalChange(
+            disk: "# new heading\n\nbody",
+            currentText: "# old heading\n\nbody",
+            lastKnownDisk: "# old heading\n\nbody"
+        )
+        #expect(decision == .apply("# new heading\n\nbody"))
+    }
+
+    // MARK: - ExternalChangeReducer (the stateful glue used by the modifier)
+
+    @Test func reducerAppliesExternalChangeWhenEditorClean() {
+        let r = ExternalChangeReducer(initialText: "A")
+        #expect(r.observe(disk: "B", currentText: "A") == "B")
+        #expect(r.lastKnownDisk == "B")
+    }
+
+    @Test func reducerIgnoresEchoFromOwnSave() {
+        let r = ExternalChangeReducer(initialText: "A")
+        // User typed "Ab" but DocumentGroup hasn't autosaved yet → currentText="Ab".
+        // Then autosave fires and presenter sees disk="Ab".
+        #expect(r.observe(disk: "Ab", currentText: "Ab") == nil)
+        #expect(r.lastKnownDisk == "Ab")
+    }
+
+    /// Regression test for the bug where baseline advanced on every keystroke,
+    /// making dirty-detection unreachable. The reducer must NOT advance
+    /// `lastKnownDisk` from typing — it advances only from observed disk events.
+    @Test func reducerPreservesUnsavedTypingAgainstExternalWrite() {
+        let r = ExternalChangeReducer(initialText: "A")
+        // User has typed "Ab" — autosave hasn't fired yet, baseline still "A".
+        // An external writer rewrites disk to "X".
+        #expect(r.observe(disk: "X", currentText: "Ab") == nil)
+        // Baseline still advances so we see "X" next time.
+        #expect(r.lastKnownDisk == "X")
+    }
+
+    @Test func reducerAppliesAfterAutosaveCatchesUp() {
+        let r = ExternalChangeReducer(initialText: "A")
+        // Type "Ab", autosave fires → presenter sees disk="Ab" (echo).
+        _ = r.observe(disk: "Ab", currentText: "Ab")
+        // Now external writer rewrites disk to "X". Editor is clean against
+        // the new baseline "Ab", so apply.
+        #expect(r.observe(disk: "X", currentText: "Ab") == "X")
+        #expect(r.lastKnownDisk == "X")
+    }
+
+    @Test func reducerHandlesRapidBackToBackExternalWrites() {
+        let r = ExternalChangeReducer(initialText: "A")
+        #expect(r.observe(disk: "B", currentText: "A") == "B")
+        // Caller updates editor to "B" (we returned it). Next external write
+        // arrives with editor already at "B".
+        #expect(r.observe(disk: "C", currentText: "B") == "C")
+    }
+
+    // MARK: - Presenter integration
+
+    @Test func externalWriteFiresCallback() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("doc.md")
+        try "v1".write(to: url, atomically: true, encoding: .utf8)
+
+        let received = CapturedText()
+        let watcher = ExternalFileWatcher(url: url) { text in
+            received.set(text)
+        }
+        defer { watcher.stop() }
+
+        // Let the presenter register before we issue the foreign write.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let foreign = NSFileCoordinator()
+        var err: NSError?
+        foreign.coordinate(writingItemAt: url, options: .forReplacing, error: &err) { resolved in
+            try? "v2".write(to: resolved, atomically: true, encoding: .utf8)
+        }
+        #expect(err == nil)
+
+        // Poll for the callback (presenter callback runs on its own queue).
+        let deadline = Date(timeIntervalSinceNow: 3.0)
+        while Date() < deadline {
+            if received.value == "v2" { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(received.value == "v2")
+    }
+
+    @Test func stopHaltsCallbacks() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("doc.md")
+        try "v1".write(to: url, atomically: true, encoding: .utf8)
+
+        let received = CapturedText()
+        let watcher = ExternalFileWatcher(url: url) { text in
+            received.set(text)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        watcher.stop()
+
+        let foreign = NSFileCoordinator()
+        var err: NSError?
+        foreign.coordinate(writingItemAt: url, options: .forReplacing, error: &err) { resolved in
+            try? "v2".write(to: resolved, atomically: true, encoding: .utf8)
+        }
+        #expect(err == nil)
+
+        // Wait a moment to be sure no late callback sneaks in.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(received.value == nil)
+    }
+}
+
+/// Thread-safe holder for the most recent callback string. The presenter's
+/// operation queue is non-main, so the test thread reads via the lock.
+private final class CapturedText: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: String?
+
+    var value: String? {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+
+    func set(_ text: String) {
+        lock.lock(); defer { lock.unlock() }
+        _value = text
+    }
+}


### PR DESCRIPTION
## Summary

- Open documents now reflect out-of-process file changes automatically (AI agents editing the file, `vim`/Cursor, iCloud sync, etc.).
- Unsaved typing is preserved: if the user has edited since the last on-disk version we observed, we drop the external change rather than clobber.
- On Mac, NSDocument's `fileModificationDate` is updated after each apply so SwiftUI's autosave doesn't pop the "file changed by another application" conflict dialog.

## How it works

Three pieces in `ClearlyCore`:

- `ExternalFileWatcher` — `NSFilePresenter` keyed on a URL. Survives atomic-rename writes (the Cursor/vim pattern) because it's URL-based, not FD-based.
- `mergeExternalChange` + `ExternalChangeReducer` — pure policy that returns `.ignoreEcho` / `.ignoreDirty` / `.apply(newText)` based on (disk, currentText, lastKnownDisk). Baseline advances only on observed disk events, never on user typing — that's what makes dirty-detection meaningful.
- `.watchExternalChanges(fileURL:text:onApply:)` modifier — glues the above to a SwiftUI view. Holds the watcher/reducer in `@State`, bumps a generation token on each `bind()` so any stale in-flight callback from a previous URL gets dropped instead of writing the wrong file's content into the editor.

Mac wiring in `ContentView` passes an `onApply` callback that finds the matching NSDocument and updates its `fileModificationDate`. The title bar still shows "Edited" after an external write — intentional; it's a useful "doc changed under you" signal and `close` does not prompt (the change count is clean).

iOS wiring is the same modifier with no `onApply`.

## Tests

17 tests, all green. Reducer state-machine tests cover the dirty-detection bug that was caught during adversarial review (baseline must not advance on keystrokes). Watcher integration tests use a foreign `NSFileCoordinator` to write the file and assert the callback fires. Plus a `stop()` test for the deregistration path.

## Test plan

- [x] `swift test --package-path Packages/ClearlyCore` — all 17 + existing pass
- [x] `xcodebuild -scheme Clearly` — Debug build clean
- [x] `xcodebuild -scheme Clearly-iOS -destination 'generic/platform=iOS Simulator'` — clean
- [x] Manual on Mac: open a `.md`, rewrite from terminal — editor updates silently
- [x] Manual on Mac: type unsaved chars, external write — typing preserved
- [x] Manual on Mac: autosave round-trip after external write — no conflict dialog
- [ ] Manual on iOS simulator — not exercised; UIDocument may benefit from similar bookkeeping later