### PR TITLE
[mac] fix: allow scratchpad window to be resized

### DIFF
--- a/Clearly/ScratchpadManager.swift
+++ b/Clearly/ScratchpadManager.swift
@@ -161,8 +161,7 @@ final class ScratchpadManager {
             .environment(store)
             .environment(deleteUndo)
         let controller = NSHostingController(rootView: rootView)
-        controller.view.translatesAutoresizingMaskIntoConstraints = false
-        controller.preferredContentSize = Self.defaultScratchpadContentSize
+        controller.sizingOptions = .minSize
 
         let win = ScratchpadPanel(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 560),
@@ -178,7 +177,8 @@ final class ScratchpadManager {
         win.becomesKeyOnlyIfNeeded = false
         win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         win.isReleasedWhenClosed = false
-        win.minSize = NSSize(width: 360, height: 280)
+        win.minSize = NSSize(width: 420, height: 320)
+        win.contentMinSize = NSSize(width: 420, height: 320)
         win.titleVisibility = .hidden
         win.titlebarSeparatorStyle = .none
         win.titlebarAppearsTransparent = true
@@ -190,14 +190,14 @@ final class ScratchpadManager {
 
         window = win
 
-        win.setFrameAutosaveName("ClearlyScratchpadWindow")
+        win.setFrameAutosaveName("ClearlyScratchpadWindow_v2")
         positionTopRightIfUnsaved(win)
     }
 
     private static let defaultScratchpadContentSize = NSSize(width: 480, height: 560)
 
     private func positionTopRightIfUnsaved(_ win: NSPanel) {
-        if win.setFrameUsingName("ClearlyScratchpadWindow") { return }
+        if win.setFrameUsingName("ClearlyScratchpadWindow_v2") { return }
         win.setContentSize(Self.defaultScratchpadContentSize)
         guard let screen = NSScreen.main else { return }
         let visible = screen.visibleFrame

--- a/Clearly/ScratchpadShellView.swift
+++ b/Clearly/ScratchpadShellView.swift
@@ -47,7 +47,7 @@ struct ScratchpadShellView: View {
             .accessibilityHidden(true)
         }
         .ignoresSafeArea(.container, edges: .top)
-        .frame(minWidth: 360, minHeight: 280)
+        .frame(minWidth: 420, minHeight: 320)
         .onAppear(perform: syncText)
         .onChange(of: manager.currentNoteID) { _, _ in syncText() }
     }


### PR DESCRIPTION
## Summary
- The scratchpad panel had `.resizable` in its styleMask but couldn't actually be resized. `NSHostingController` defaults its `sizingOptions` to `[.minSize, .intrinsicContentSize, .maxSize]` on macOS 13+, so the hosting view pinned the window to SwiftUI's intrinsic size via a `.maxSize` Auto Layout constraint. `preferredContentSize` and `translatesAutoresizingMaskIntoConstraints = false` were earlier workarounds for the same machinery — they kept the panel from collapsing on first show, but locked it at its initial size.
- Set `sizingOptions = .minSize` and drop the workarounds. The SwiftUI minimum still propagates as a constraint, but `.intrinsicContentSize` / `.maxSize` no longer fight user resize.
- Bumped the minimum from 360×280 to **420×320** so the centered "New Scratchpad" title can't overlap the traffic lights or the new-note button. Mirrored on `win.minSize`, `win.contentMinSize`, and the SwiftUI shell's `.frame(minWidth:minHeight:)`.
- Bumped the frame autosave key to `ClearlyScratchpadWindow_v2` so any stale sub-minimum frame saved by earlier builds is discarded — first launch picks up the default 480×560.

## Test plan
- [ ] ⌃⌥⌘N opens the scratchpad at 480×560 in the top-right.
- [ ] Drag any edge or corner — the window resizes smoothly.
- [ ] Drag inward — the window stops at 420×320 and won't go smaller.
- [ ] Resize to a new size, close the scratchpad, reopen — the new frame persists.
- [ ] At the minimum width, the "New Scratchpad" title is fully visible and clear of the traffic lights and the new-note button.