### PR TITLE
[shared] fix: render wikilinks and stop their pipes from splitting tables (#371)

### DIFF
--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -13,7 +13,8 @@ public enum MarkdownRenderer {
 
         let rawBody = frontmatter?.body ?? markdown
         let (body, codeFilenames) = extractCodeFilenames(rawBody)
-        let protectedBody = protectEscapedMathDelimiters(in: body)
+        let mathProtected = protectEscapedMathDelimiters(in: body)
+        let protectedBody = protectWikilinkPipes(in: mathProtected)
         let len = protectedBody.utf8.count
         let options = Int32(CMARK_OPT_UNSAFE | CMARK_OPT_FOOTNOTES | CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_SOURCEPOS | CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES)
         var html: String
@@ -30,6 +31,7 @@ public enum MarkdownRenderer {
         }
         html = processMath(html)
         html = restoreEscapedMathDelimiters(in: html)
+        html = processWikilinks(html)
         html = processHighlightMarks(html)
         html = processSuperSub(html)
         html = processEmoji(html)
@@ -289,6 +291,159 @@ public enum MarkdownRenderer {
         }
         result += ns.substring(from: lastEnd)
         return result
+    }
+
+    // MARK: - Wikilinks [[Target|Alias]]
+
+    /// Pre-cmark: swap pipes inside `[[...]]` for a private-use token so
+    /// cmark-gfm's table parser doesn't split rows on them. Skips lines
+    /// inside fenced code blocks and matches inside inline code spans.
+    private static func protectWikilinkPipes(in markdown: String) -> String {
+        guard markdown.contains("[[") else { return markdown }
+        let lines = markdown.components(separatedBy: "\n")
+        var out: [String] = []
+        out.reserveCapacity(lines.count)
+
+        var inFence = false
+        var fenceMarker: Character = "`"
+        var fenceLen = 0
+
+        for line in lines {
+            if let fence = fenceBoundary(in: line) {
+                if inFence {
+                    if fence.marker == fenceMarker, fence.length >= fenceLen {
+                        inFence = false
+                    }
+                } else {
+                    inFence = true
+                    fenceMarker = fence.marker
+                    fenceLen = fence.length
+                }
+                out.append(line)
+                continue
+            }
+            if inFence {
+                out.append(line)
+                continue
+            }
+            out.append(protectWikilinkPipesOnLine(line))
+        }
+        return out.joined(separator: "\n")
+    }
+
+    private static func fenceBoundary(in line: String) -> (marker: Character, length: Int)? {
+        let leading = line.prefix(while: { $0 == " " })
+        if leading.count > 3 { return nil }
+        let rest = line.dropFirst(leading.count)
+        guard let first = rest.first, first == "`" || first == "~" else { return nil }
+        var count = 0
+        for ch in rest {
+            if ch == first { count += 1 } else { break }
+        }
+        if count < 3 { return nil }
+        return (first, count)
+    }
+
+    private static let wikilinkRawPattern = #"\[\[([^\]\n]+)\]\]"#
+
+    private static func protectWikilinkPipesOnLine(_ line: String) -> String {
+        guard line.contains("[[") else { return line }
+        guard let regex = try? NSRegularExpression(pattern: wikilinkRawPattern) else { return line }
+        let ns = line as NSString
+        let matches = regex.matches(in: line, range: NSRange(location: 0, length: ns.length))
+        if matches.isEmpty { return line }
+
+        var result = ""
+        var cursor = 0
+        for match in matches {
+            let prefix = ns.substring(with: NSRange(location: cursor, length: match.range.location - cursor))
+            result += prefix
+            let inCode = hasOddUnescapedBackticks(in: ns.substring(with: NSRange(location: 0, length: match.range.location)))
+            let matched = ns.substring(with: match.range)
+            if inCode {
+                result += matched
+            } else {
+                var swapped = matched.replacingOccurrences(of: "\\|", with: WikilinkSupport.pipeToken)
+                swapped = swapped.replacingOccurrences(of: "|", with: WikilinkSupport.pipeToken)
+                result += swapped
+            }
+            cursor = match.range.location + match.range.length
+        }
+        result += ns.substring(from: cursor)
+        return result
+    }
+
+    private static func hasOddUnescapedBackticks(in s: String) -> Bool {
+        var count = 0
+        var prev: Character? = nil
+        for ch in s {
+            if ch == "`", prev != "\\" {
+                count += 1
+            }
+            prev = ch
+        }
+        return count % 2 != 0
+    }
+
+    /// Post-cmark: rewrite `[[Target(#Heading)?(<token>Alias)?]]` into
+    /// `<a class="wiki-link" ...>display</a>`. Then restore any remaining
+    /// `pipeToken` characters (defensive: should not occur for well-formed
+    /// wikilinks the pre-pass identified).
+    private static func processWikilinks(_ html: String) -> String {
+        let hasToken = html.contains(WikilinkSupport.pipeToken)
+        if !html.contains("[[") && !hasToken {
+            return html
+        }
+        let (protectedHTML, segments) = protectCodeRegions(in: html)
+        guard let regex = try? NSRegularExpression(pattern: WikilinkSupport.renderPattern) else {
+            let restored = protectedHTML.replacingOccurrences(of: WikilinkSupport.pipeToken, with: "|")
+            return restoreProtectedSegments(in: restored, segments: segments)
+        }
+        let ns = protectedHTML as NSString
+        var result = ""
+        var cursor = 0
+        for match in regex.matches(in: protectedHTML, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: cursor, length: match.range.location - cursor))
+            let target = ns.substring(with: match.range(at: 1))
+            let heading: String? = {
+                let r = match.range(at: 2)
+                return r.location == NSNotFound ? nil : ns.substring(with: r)
+            }()
+            let alias: String? = {
+                let r = match.range(at: 3)
+                return r.location == NSNotFound ? nil : ns.substring(with: r)
+            }()
+            let display: String
+            if let alias {
+                display = alias
+            } else if let heading {
+                display = "\(target)#\(heading)"
+            } else {
+                display = target
+            }
+            var attrs = "class=\"wiki-link\" href=\"#\" data-wiki-target=\"\(wikilinkAttrEscape(target))\""
+            if let heading {
+                attrs += " data-wiki-heading=\"\(wikilinkAttrEscape(heading))\""
+            }
+            if let alias {
+                attrs += " data-wiki-alias=\"\(wikilinkAttrEscape(alias))\""
+            }
+            result += "<a \(attrs)>\(display)</a>"
+            cursor = match.range.location + match.range.length
+        }
+        result += ns.substring(from: cursor)
+        // Restore code regions first so the defensive token cleanup catches any
+        // pipe-tokens that leaked into protected segments (e.g. multi-backtick
+        // inline code that the line-scanner's naive backtick toggle missed).
+        let restored = restoreProtectedSegments(in: result, segments: segments)
+        return restored.replacingOccurrences(of: WikilinkSupport.pipeToken, with: "|")
+    }
+
+    private static func wikilinkAttrEscape(_ s: String) -> String {
+        // The input text is already HTML-escaped by cmark for text content
+        // (& → &amp;, < → &lt;, > → &gt;). Only " needs additional escaping
+        // for use inside an attribute value.
+        s.replacingOccurrences(of: "\"", with: "&quot;")
     }
 
     // MARK: - Highlight/Mark ==text==

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/WikilinkSupport.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/WikilinkSupport.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public enum WikilinkSupport {
+    /// Private-use codepoint that the pre-cmark pass swaps in for any
+    /// `|` (or `\|`) found inside a `[[...]]` wikilink. Hides the pipe
+    /// from cmark-gfm's table parser so wikilinks survive intact inside
+    /// table cells. The post-cmark pass either consumes it as the alias
+    /// separator or restores it to a literal `|`.
+    public static let pipeToken = "\u{E110}"
+
+    /// Matches a complete wikilink after the pre-pass has run, so the
+    /// alias separator is always `pipeToken` (never a literal pipe).
+    /// Groups: 1 = target, 2 = optional heading after `#`, 3 = optional alias.
+    public static let renderPattern: String = {
+        let t = pipeToken
+        // [[target(#heading)?(<token>alias)?]]
+        return "\\[\\[([^\\]\\n#\(t)]+)(?:#([^\\]\\n\(t)]+))?(?:\(t)([^\\]\\n]+))?\\]\\]"
+    }()
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownWikilinkTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownWikilinkTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import ClearlyCore
+
+final class MarkdownWikilinkTests: XCTestCase {
+    // MARK: - Basic rendering
+
+    func testPlainWikilink() {
+        let html = MarkdownRenderer.renderHTML("See [[Marcus Aurelius]] for more.")
+        let expected = "<a class=\"wiki-link\" href=\"#\" data-wiki-target=\"Marcus Aurelius\">Marcus Aurelius</a>"
+        XCTAssertTrue(html.contains(expected), html)
+    }
+
+    func testWikilinkWithAlias() {
+        let html = MarkdownRenderer.renderHTML("[[Marcus Aurelius Antoninus|Marcus Aurelius]]")
+        XCTAssertTrue(html.contains(#"data-wiki-target="Marcus Aurelius Antoninus""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Marcus Aurelius""#), html)
+        XCTAssertTrue(html.contains(">Marcus Aurelius</a>"), html)
+        XCTAssertFalse(html.contains("[[Marcus"), "raw wikilink text leaked through: \(html)")
+    }
+
+    func testWikilinkWithHeading() {
+        let html = MarkdownRenderer.renderHTML("[[Page#Section]]")
+        XCTAssertTrue(html.contains(#"data-wiki-target="Page""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-heading="Section""#), html)
+        XCTAssertTrue(html.contains(">Page#Section</a>"), html)
+    }
+
+    func testWikilinkWithHeadingAndAlias() {
+        let html = MarkdownRenderer.renderHTML("[[Page#Section|Alias]]")
+        XCTAssertTrue(html.contains(#"data-wiki-target="Page""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-heading="Section""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Alias""#), html)
+        XCTAssertTrue(html.contains(">Alias</a>"), html)
+    }
+
+    func testEscapedPipeFormRenders() {
+        // Obsidian convention: \| as alias separator.
+        let html = MarkdownRenderer.renderHTML(#"[[Page\|Alias]]"#)
+        XCTAssertTrue(html.contains(#"data-wiki-target="Page""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Alias""#), html)
+        XCTAssertTrue(html.contains(">Alias</a>"), html)
+    }
+
+    // MARK: - Issue #371: tables
+
+    func testWikilinkInsideTableCellDoesNotSplitRow() {
+        let md = """
+        | Quote | Author | Movement |
+        | - | - | - |
+        | A quote. | [[Marcus Aurelius Antoninus|Marcus Aurelius]] | [[Stoicism]] |
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        // Two wikilinks rendered.
+        XCTAssertTrue(html.contains(#"data-wiki-target="Marcus Aurelius Antoninus""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-target="Stoicism""#), html)
+        // Header row defined three columns; data row should also have three <td>.
+        let tdCount = html.components(separatedBy: "<td").count - 1
+        XCTAssertEqual(tdCount, 3, "expected exactly 3 <td> cells in the data row; html=\(html)")
+        // No leaked literal wikilink fragments.
+        XCTAssertFalse(html.contains("[[Marcus"), html)
+        XCTAssertFalse(html.contains("Aurelius]]"), html)
+    }
+
+    func testEscapedPipeInsideTableCellRenders() {
+        let md = """
+        | Author |
+        | - |
+        | [[Marcus Aurelius Antoninus\\|Marcus Aurelius]] |
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Marcus Aurelius""#), html)
+        XCTAssertTrue(html.contains(">Marcus Aurelius</a>"), html)
+    }
+
+    // MARK: - Code skipping
+
+    func testWikilinkInsideFencedCodeStaysLiteral() {
+        let md = """
+        ```
+        [[Page|Alias]]
+        ```
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertFalse(html.contains("wiki-link"), html)
+        XCTAssertTrue(html.contains("[[Page|Alias]]"), html)
+    }
+
+    func testWikilinkInsideInlineCodeStaysLiteral() {
+        let html = MarkdownRenderer.renderHTML("Type `[[Page|Alias]]` to link.")
+        XCTAssertFalse(html.contains("wiki-link"), html)
+        XCTAssertTrue(html.contains("[[Page|Alias]]"), html)
+    }
+
+    func testWikilinkOutsideInlineCodeStillRenders() {
+        let html = MarkdownRenderer.renderHTML("`code` and then [[RealLink|Click]].")
+        XCTAssertTrue(html.contains(#"data-wiki-target="RealLink""#), html)
+    }
+
+    // MARK: - Edge cases
+
+    func testTextPipeOutsideWikilinkIsUntouched() {
+        let html = MarkdownRenderer.renderHTML("a | b | c")
+        XCTAssertFalse(html.contains("wiki-link"), html)
+        XCTAssertTrue(html.contains("a | b | c"), html)
+    }
+
+    func testUnclosedWikilinkLeftAlone() {
+        // No matching ]] anywhere on the line.
+        let html = MarkdownRenderer.renderHTML("Type [[ to begin a link.")
+        XCTAssertFalse(html.contains("wiki-link"), html)
+    }
+
+    func testWikilinkDoesNotSpanLines() {
+        let md = "First line has [[an unclosed\nopener and second line has it ]] closed."
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertFalse(html.contains("wiki-link"), html)
+    }
+
+    func testMultipleWikilinksInOneParagraph() {
+        let html = MarkdownRenderer.renderHTML("[[A]] and [[B|bee]] and [[C#H]].")
+        XCTAssertTrue(html.contains(#"data-wiki-target="A""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-target="B""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-target="C""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="bee""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-heading="H""#), html)
+    }
+
+    func testQuoteInTargetIsEscapedInAttribute() {
+        let html = MarkdownRenderer.renderHTML(#"[[Say "Hi"|wave]]"#)
+        XCTAssertTrue(html.contains(#"data-wiki-target="Say &quot;Hi&quot;""#), html)
+        XCTAssertTrue(html.contains(">wave</a>"), html)
+    }
+
+    func testWikilinkInsideHeadingProducesTOCLink() {
+        let md = """
+        [TOC]
+
+        # [[Some Page]]
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        // Heading still becomes a wiki-link
+        XCTAssertTrue(html.contains(#"data-wiki-target="Some Page""#), html)
+        // TOC nav block is present and references the slug derived from text
+        XCTAssertTrue(html.contains("<nav class=\"toc\">"), html)
+        XCTAssertTrue(html.contains("some-page"), html)
+    }
+
+    // MARK: - Unicode token cleanup
+
+    func testNoPrivateUseTokenLeaks() {
+        let html = MarkdownRenderer.renderHTML("[[A|B]] and plain | pipe.")
+        XCTAssertFalse(html.contains("\u{E110}"), "private-use token leaked to output: \(html)")
+    }
+
+    // Multi-backtick inline code is a known limitation of the naive code-span
+    // detector; assert we at least clean up any leaked private-use char so the
+    // visible output is never garbled, even if the wikilink stays literal.
+    func testMultiBacktickCodeDoesNotLeakToken() {
+        let html = MarkdownRenderer.renderHTML("Use ``[[Page|Alias]]`` here.")
+        XCTAssertFalse(html.contains("\u{E110}"), "private-use token leaked: \(html)")
+    }
+
+    func testBareTokenInSourceIsRestored() {
+        let html = MarkdownRenderer.renderHTML("Lorem \u{E110} ipsum.")
+        XCTAssertFalse(html.contains("\u{E110}"), "private-use token leaked: \(html)")
+    }
+
+    func testCRLFLineEndingsTableStillWorks() {
+        // CRLF source: ensure pre-pass line-scan doesn't break with \r tails.
+        let md = "| A | B |\r\n| - | - |\r\n| [[Page|Alias]] | x |\r\n"
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertTrue(html.contains(#"data-wiki-target="Page""#), html)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Alias""#), html)
+        let tdCount = html.components(separatedBy: "<td").count - 1
+        XCTAssertEqual(tdCount, 2, "expected 2 cells; html=\(html)")
+    }
+
+    func testIndentedFenceIsRespected() {
+        // 2-space-indented fence still opens a code block in CommonMark.
+        let md = """
+          ```
+          [[Page|Alias]]
+          ```
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertFalse(html.contains("wiki-link"), html)
+    }
+
+    func testTildeFenceIsRespected() {
+        let md = """
+        ~~~
+        [[Page|Alias]]
+        ~~~
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertFalse(html.contains("wiki-link"), html)
+    }
+
+    func testBackslashEscapesInsideTableCell() {
+        // Reporter said `[[Foo\|Bar]]` in a cell stops the table breaking but
+        // doesn't render. Both must work now.
+        let md = """
+        | Author |
+        | - |
+        | [[Marcus Aurelius Antoninus\\|Marcus Aurelius]] |
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertTrue(html.contains(#"data-wiki-alias="Marcus Aurelius""#), html)
+        // Single-row data should be one <td>.
+        let dataRow = html.components(separatedBy: "<tbody>").last ?? ""
+        let tdCount = dataRow.components(separatedBy: "<td").count - 1
+        XCTAssertEqual(tdCount, 1, "expected 1 cell; html=\(html)")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #371.

- **Tables**: `[[Target|Alias]]` inside a table cell no longer splits the row — the pipe is hidden from cmark-gfm's table parser via a private-use token before parsing.
- **Wikilinks now actually render** in preview. They were advertised in `getting-started.md` and styled by the existing `.wiki-link` CSS, but no code ever generated the `<a>` tag. They do now.

## How

Two passes, mirroring the existing math-escape pattern in `MarkdownRenderer.swift`:

1. **Pre-cmark** (`protectWikilinkPipes`): walk the source line-by-line, skip fenced code, skip inline code spans, and rewrite `|` (and `\|`) inside any `[[...]]` to `U+E110`. cmark-gfm now sees no pipe inside wikilinks, so tables stay intact.
2. **Post-cmark** (`processWikilinks`): match `[[Target(#Heading)?(<token>Alias)?]]` in the rendered HTML, emit `<a class="wiki-link" href="#" data-wiki-target=… [data-wiki-heading=…] [data-wiki-alias=…]>display</a>`. Display = alias if present, else `Target#Heading`, else `Target`. `protectCodeRegions`/`restoreProtectedSegments` keep `<code>`/`<pre>` content out of the rewrite.

`href="#"` is intentional — a real vault router/file resolver doesn't exist yet, and `data-wiki-*` attributes are the forward-compatible carrier for when it does.

A defensive `U+E110 → |` cleanup runs **after** `restoreProtectedSegments`, so any token that leaked into a code segment (e.g. multi-backtick inline code that the naive backtick scanner misclassifies) is restored to a visible pipe instead of an invisible private-use char.

## Reviewer notes

- Touches `ClearlyCore` only — Mac preview, iOS preview, QuickLook, and PDF export all share `MarkdownRenderer.renderHTML` and pick up the fix for free.
- CSS, palette entries, and TOC slug derivation were already wired for `.wiki-link`; this just lights them up.
- `MarkdownStats.stripWikiLinks` (word-count path) is unchanged.
- Known limitation: wikilinks inside multi-backtick inline code (e.g. `` ``[[A|B]]`` ``) stay literal rather than rendering — same end-state as today, but the defensive cleanup ensures the visible pipe is preserved. Filing a fully CommonMark-correct code-span detector wasn't worth it for this case.

## Test plan

- [x] `swift test --package-path Packages/ClearlyCore` — 94/94 green (23 new tests in `MarkdownWikilinkTests`)
- [x] Mac Debug build (`-derivedDataPath ./.build/DerivedData`) — succeeds
- [x] iOS Debug build (`-derivedDataPath ./.build/DerivedData-iOS`) — succeeds
- [x] Visual check in `Clearly Dev` against the issue's exact reproduction — table renders three cells, wikilinks styled as links, code blocks/spans stay literal

New tests cover plain wikilinks, alias, heading, heading+alias, the `\|` escape form, the #371 table case, multiple wikilinks in one paragraph, inline+fenced code skipping, CRLF line endings, indented and tilde fences, the multi-backtick leak guard, attribute-quote escaping, unclosed/multi-line `[[...`, and TOC interaction.