### PR TITLE
[mac] fix: launcher 'New Document' crash in menubar mode (#377)

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -187,6 +187,18 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             NSApp.setActivationPolicy(.accessory)
             return .terminateCancel
         }
+        // Launcher-dismiss fires both terminate methods. By this point
+        // NSDocumentController has added the user-picked doc to `.documents`,
+        // but its SwiftUI scene is still constructing. Falling through to
+        // `closeAllDocuments` would tear that brand-new doc down mid-build
+        // and crash the app (#377). Bail without touching it; the natural
+        // `didBecomeMain` → `updateActivationPolicy` flow clears the flag
+        // once the doc registers, so the next Cmd+Q hits the normal path.
+        if isDocumentPanelPresented {
+            DiagnosticLog.log("appShouldTerminate: panel-in-flight with new doc, cancel without closing")
+            NSApp.setActivationPolicy(.accessory)
+            return .terminateCancel
+        }
         NSDocumentController.shared.closeAllDocuments(
             withDelegate: self,
             didCloseAllSelector: #selector(menubarOnlyDidCloseAllDocuments(_:didCloseAll:contextInfo:)),


### PR DESCRIPTION
## Summary
- Fixes [#377](https://github.com/Shpigford/clearly/issues/377): clicking **New Document** in the launcher panel on a fresh launch crashes the app.
- PR #375 already covered the *menubar-off* branch with the `isDocumentPanelPresented` defer. The default (menubar-on) branch in `applicationShouldTerminate` still fell through to `closeAllDocuments`, which tore down the just-added doc while its SwiftUI scene was mid-build — that's the crash users on 3.2.0 are hitting.
- Adds the same `isDocumentPanelPresented` guard to the menubar-on path: when the launcher just dismissed and `NSDocumentController.documents` already contains the new doc, return `.terminateCancel` without touching the documents collection. `updateActivationPolicy()` clears the flag the moment the new window becomes main, so subsequent Cmd+Q still hits the normal close-all-then-menubar path.

## Why the crash happened
NSDocumentController's "New Document" path is:
1. `addDocument(newDoc)` → `documents.count` goes from 0 → 1
2. launcher panel dismisses
3. SwiftUI scene begins building the window for `newDoc`

The launcher dismiss fires both `applicationShouldTerminate*` methods (per PR #375's notes). In the menubar-on branch, step 1 means `docs.isEmpty == false` by the time `applicationShouldTerminate` runs, so the code calls `closeAllDocuments` on the in-flight new doc and SwiftUI crashes finishing the half-built scene.

## Test plan
- [ ] Default settings (Keep running in menu bar = on, On Launch = Show file picker): launch fresh → click **New Document** in launcher → untitled doc opens, no crash.
- [ ] Same settings: launch fresh → click **Cancel** → app drops to menubar, no crash, no 3s hang.
- [ ] Same settings: open a doc, then Cmd+Q → still drops to menubar (no regression in normal Cmd+Q flow).
- [ ] Keep running in menu bar = off + filePicker (PR #375's case): still works, no regression.
- [ ] Launch with "On Launch: Create new document": untitled opens immediately, no regression.