### PR TITLE
[shared] feat: soft-wrap continuation indent via frontmatter

### DIFF
--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -55,13 +55,14 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
 
         let rawBody = MarkdownRenderer.renderHTML(markdown)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: documentURL)
+        let softWrapIndent = MarkdownSyntaxHighlighter.indentValues(from: markdown)
         // Both paths use forExport: false so @media print rules (including page-break) apply
         let html = """
         <!DOCTYPE html>
         <html>
         <head>
         <meta charset="utf-8">
-        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, forExport: false))</style>
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, forExport: false, softWrapIndent: softWrapIndent))</style>
         </head>
         <body>\(htmlBody)</body>
         \(MathSupport.scriptHTML(for: htmlBody))

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -148,6 +148,7 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.isLoadingContent = true
         let rawBody = MarkdownRenderer.renderHTML(markdown, includeFrontmatter: !hideFrontmatterInPreview)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
+        let softWrapIndent = MarkdownSyntaxHighlighter.indentValues(from: markdown)
         let scrollJS = """
         // Track scroll fraction for position sync between editor and preview.
         var _scrollTicking = false;
@@ -178,7 +179,7 @@ struct PreviewView: NSViewRepresentable {
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: bodyMaxWidthCSS))
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: bodyMaxWidthCSS, softWrapIndent: softWrapIndent))
         mark.clearly-find { background-color: rgba(255, 230, 0, 0.4); border-radius: 2px; padding: 0 1px; }
         mark.clearly-mode-highlight { background: rgba(255, 210, 50, 0.5); border-radius: 3px; padding: 0 1px; transition: background 1.5s ease; }
         mark.clearly-mode-highlight.fade { background: transparent; }

--- a/Clearly/iOS/PreviewExtension/PreviewViewController.swift
+++ b/Clearly/iOS/PreviewExtension/PreviewViewController.swift
@@ -18,6 +18,7 @@ final class PreviewViewController: UIViewController, QLPreviewingController {
             let markdownText = try String(contentsOf: url, encoding: .utf8)
             let rawBody = MarkdownRenderer.renderHTML(markdownText)
             let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: url)
+            let softWrapIndent = MarkdownSyntaxHighlighter.indentValues(from: markdownText)
 
             let html = """
             <!DOCTYPE html>
@@ -25,7 +26,7 @@ final class PreviewViewController: UIViewController, QLPreviewingController {
             <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <style>\(PreviewCSS.css())</style>
+            <style>\(PreviewCSS.css(softWrapIndent: softWrapIndent))</style>
             <style>
             @media (max-width: 400px) {
                 body { font-size: 14px; padding: 10px 20px 20px; }

--- a/Clearly/iOS/PreviewView_iOS.swift
+++ b/Clearly/iOS/PreviewView_iOS.swift
@@ -96,6 +96,7 @@ struct PreviewView_iOS: UIViewRepresentable {
         context.coordinator.lastContentKey = contentKey
         let rawBody = MarkdownRenderer.renderHTML(markdown, includeFrontmatter: !hideFrontmatter)
         let htmlBody = LocalImageSupport.resolveImageSources(in: rawBody, relativeTo: fileURL)
+        let softWrapIndent = MarkdownSyntaxHighlighter.indentValues(from: markdown)
 
         let html = """
         <!DOCTYPE html>
@@ -103,7 +104,7 @@ struct PreviewView_iOS: UIViewRepresentable {
         <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: "100%"))
+        <style>\(PreviewCSS.css(fontSize: fontSize, fontFamily: fontFamily, bodyMaxWidth: "100%", softWrapIndent: softWrapIndent))
         body {
             padding-top: max(16px, env(safe-area-inset-top));
             padding-right: max(20px, env(safe-area-inset-right));

--- a/ClearlyQuickLook/PreviewProvider.swift
+++ b/ClearlyQuickLook/PreviewProvider.swift
@@ -15,6 +15,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
         do {
             let markdownText = try String(contentsOf: url, encoding: .utf8)
             let htmlBody = MarkdownRenderer.renderHTML(markdownText)
+            let softWrapIndent = MarkdownSyntaxHighlighter.indentValues(from: markdownText)
 
             let html = """
             <!DOCTYPE html>
@@ -22,7 +23,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
             <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <style>\(PreviewCSS.css())</style>
+            <style>\(PreviewCSS.css(softWrapIndent: softWrapIndent))</style>
             <style>
             @media (max-width: 400px) {
                 body { font-size: 14px; padding: 10px 20px 20px; }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -58,16 +58,26 @@ public enum MarkdownRenderer {
     private static func frontmatterHTML(from block: FrontmatterSupport.Block) -> String {
         let sourcepos = "1:1-\(block.lineCount):1"
 
-        if block.fields.isEmpty {
-            if block.rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                return "<div class=\"frontmatter-anchor\" data-sourcepos=\"\(sourcepos)\"></div>\n"
+        // Layout-directive keys (wrapIndent/firstLineIndent) drive rendering and
+        // are not content metadata, so omit them from the preview's block.
+        let visibleFields = block.fields.filter {
+            !MarkdownSyntaxHighlighter.layoutFrontmatterKeys.contains($0.key)
+        }
+
+        if visibleFields.isEmpty {
+            // Fall back to the raw <pre> only when nothing parsed as fields at all.
+            // A block whose only keys were layout directives renders as a silent
+            // anchor (no visible box, but the sourcepos mapping is preserved).
+            if block.fields.isEmpty,
+               !block.rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let escapedRaw = escapeHTML(block.rawText)
+                return "<div class=\"frontmatter\" data-sourcepos=\"\(sourcepos)\"><pre>\(escapedRaw)</pre></div>\n"
             }
-            let escapedRaw = escapeHTML(block.rawText)
-            return "<div class=\"frontmatter\" data-sourcepos=\"\(sourcepos)\"><pre>\(escapedRaw)</pre></div>\n"
+            return "<div class=\"frontmatter-anchor\" data-sourcepos=\"\(sourcepos)\"></div>\n"
         }
 
         var rows = ""
-        for field in block.fields {
+        for field in visibleFields {
             rows += "<div class=\"frontmatter-row\"><dt>\(escapeHTML(field.key))</dt><dd>\(escapeHTML(field.value))</dd></div>"
         }
         return "<div class=\"frontmatter\" data-sourcepos=\"\(sourcepos)\"><dl>\(rows)</dl></div>\n"

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownSyntaxHighlighter.swift
@@ -1,8 +1,61 @@
+import CoreText
 import Foundation
 import os
 import QuartzCore
 
 private typealias Attr = PlatformTextAttributes
+
+/// A soft-wrap indent length parsed from frontmatter (`wrapIndent` / `firstLineIndent`).
+/// Carries an explicit CSS-style unit so the editor and the preview stay in sync:
+/// the editor resolves it to points, the preview emits it verbatim as CSS.
+public struct IndentLength: Equatable, Sendable {
+    public enum Unit: String, Sendable {
+        case em, ch, px, pt
+    }
+
+    public let value: CGFloat
+    public let unit: Unit
+
+    public init(value: CGFloat, unit: Unit) {
+        self.value = value
+        self.unit = unit
+    }
+
+    /// Parse a frontmatter value like `2em`, `2ch`, `20px`, `20pt`, or a bare
+    /// number (defaults to `em`). Returns `nil` for empty, negative, or
+    /// unparseable input.
+    public static func parse(_ raw: String) -> IndentLength? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return nil }
+        var unit: Unit = .em
+        var numberPart = trimmed
+        for candidate in [Unit.em, .ch, .px, .pt] where trimmed.hasSuffix(candidate.rawValue) {
+            unit = candidate
+            numberPart = String(trimmed.dropLast(candidate.rawValue.count))
+            break
+        }
+        guard let value = Double(numberPart.trimmingCharacters(in: .whitespaces)), value >= 0 else {
+            return nil
+        }
+        return IndentLength(value: CGFloat(value), unit: unit)
+    }
+
+    /// Resolve to points for the editor's `NSParagraphStyle`. `em` scales with the
+    /// editor font size, `ch` with the monospaced character advance; `px`/`pt` are
+    /// already absolute.
+    public func points(fontSize: CGFloat, characterWidth: CGFloat) -> CGFloat {
+        switch unit {
+        case .em: return value * fontSize
+        case .ch: return value * characterWidth
+        case .px, .pt: return value
+        }
+    }
+
+    /// The CSS length string, e.g. `2em`, `-4px`. Whole numbers drop the `.0`.
+    public var css: String {
+        "\(String(format: "%g", Double(value)))\(unit.rawValue)"
+    }
+}
 
 public final class MarkdownSyntaxHighlighter: NSObject {
 
@@ -16,6 +69,153 @@ public final class MarkdownSyntaxHighlighter: NSObject {
     /// Set by `highlightAround` when a block delimiter is detected.
     /// The caller should schedule a deferred `highlightAll` instead of running it synchronously.
     public var needsFullHighlight = false
+
+    // MARK: - Soft-wrap indent (frontmatter `wrapIndent` / `firstLineIndent`)
+
+    /// Frontmatter key for the soft-wrapped continuation-line indent.
+    public static let wrapIndentKey = "wrapIndent"
+    /// Frontmatter key for the first-line indent.
+    public static let firstLineIndentKey = "firstLineIndent"
+    /// Layout-directive frontmatter keys: consumed for rendering, not content
+    /// metadata. The preview hides these from its frontmatter block.
+    public static let layoutFrontmatterKeys: Set<String> = [wrapIndentKey, firstLineIndentKey]
+
+    /// Resolved indent for the current document, or `nil` when the feature is off.
+    /// `head` maps to `headIndent` (soft-wrapped continuation lines); `firstLine`
+    /// maps to `firstLineHeadIndent` (first line of each hard-break-bounded paragraph).
+    private var cachedIndent: (head: IndentLength, firstLine: IndentLength)?
+    /// Last-recorded UTF-16 length of the frontmatter region (may be stale after an
+    /// edit, until the next refresh), used to decide whether an incremental edit
+    /// could have changed the indent config.
+    private var cachedFrontmatterLength: Int = 0
+
+    /// Whether a non-zero indent is active for the current document.
+    private var isIndentActive: Bool {
+        guard let indent = cachedIndent else { return false }
+        return indent.head.value > 0 || indent.firstLine.value > 0
+    }
+
+    /// Parse soft-wrap indent settings from a document's YAML frontmatter.
+    /// Returns `nil` (feature off) when there is no frontmatter, neither
+    /// `wrapIndent` nor `firstLineIndent` is present, or both keys are
+    /// unparseable. Each value may carry an explicit unit (`em`, `ch`, `px`,
+    /// `pt`); a bare number defaults to `em`.
+    public static func indentValues(from text: String) -> (head: IndentLength, firstLine: IndentLength)? {
+        guard let block = FrontmatterSupport.extract(from: text) else { return nil }
+        return indentValues(fromFields: block.fields)
+    }
+
+    private static func indentValues(fromFields fields: [FrontmatterSupport.Field]) -> (head: IndentLength, firstLine: IndentLength)? {
+        var head: IndentLength?
+        var firstLine: IndentLength?
+        for field in fields {
+            switch field.key {
+            case Self.wrapIndentKey:
+                if let parsed = IndentLength.parse(field.value) { head = parsed }
+            case Self.firstLineIndentKey:
+                if let parsed = IndentLength.parse(field.value) { firstLine = parsed }
+            default:
+                break
+            }
+        }
+        if head == nil && firstLine == nil { return nil }
+        let zero = IndentLength(value: 0, unit: .em)
+        return (head ?? zero, firstLine ?? zero)
+    }
+
+    /// Re-read the indent config from `text`. When `markNeedsFullHighlight` is true
+    /// and the resolved values changed, request a deferred full re-highlight so the
+    /// whole document picks up the new indent (an incremental pass only restyles the
+    /// edited paragraph).
+    private func refreshIndentCache(from text: String, markNeedsFullHighlight: Bool) {
+        let old = cachedIndent
+        if let block = FrontmatterSupport.extract(from: text) {
+            // Always record the frontmatter span — even when no indent keys are
+            // present yet — so that adding the keys later counts as an in-region
+            // edit and triggers a re-highlight without needing to reopen the file.
+            cachedFrontmatterLength = Self.frontmatterRegionLength(of: text, block: block)
+            cachedIndent = Self.indentValues(fromFields: block.fields)
+        } else if case let structuralLength = Self.structuralFrontmatterRegionLength(of: text), structuralLength > 0 {
+            // A leading `--- ... ---` block still exists but a line doesn't parse as
+            // a field yet (e.g. a key that's been typed but has no colon yet). Keep
+            // the last-known indent and the region length so a transient unparseable
+            // state doesn't drop the body indent, and so edits stay in-region long
+            // enough to refresh once the line becomes valid again.
+            cachedFrontmatterLength = structuralLength
+        } else {
+            cachedIndent = nil
+            cachedFrontmatterLength = 0
+        }
+        if markNeedsFullHighlight && Self.indentChanged(old, cachedIndent) {
+            needsFullHighlight = true
+        }
+    }
+
+    /// Tuples can't be `Equatable`, so compare the optional indent pair by hand.
+    private static func indentChanged(
+        _ lhs: (head: IndentLength, firstLine: IndentLength)?,
+        _ rhs: (head: IndentLength, firstLine: IndentLength)?
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): return false
+        case let (a?, b?): return a.head != b.head || a.firstLine != b.firstLine
+        default: return true
+        }
+    }
+
+    /// UTF-16 length of the leading frontmatter region (including delimiters),
+    /// or 0 when there is no frontmatter. Used to decide whether an incremental
+    /// edit could have changed the indent config. Computed independently of which
+    /// keys are present, so adding indent keys to existing frontmatter still
+    /// registers as an in-region edit.
+    static func frontmatterRegionLength(of text: String) -> Int {
+        guard let block = FrontmatterSupport.extract(from: text) else { return 0 }
+        return frontmatterRegionLength(of: text, block: block)
+    }
+
+    private static func frontmatterRegionLength(of text: String, block: FrontmatterSupport.Block) -> Int {
+        max(0, (text as NSString).length - (block.body as NSString).length)
+    }
+
+    /// UTF-16 length of the leading `--- ... ---` block detected by delimiters alone,
+    /// ignoring whether the body parses as fields. 0 when there's no such block.
+    /// Used to keep the indent cache alive while a frontmatter line is mid-edit and
+    /// `FrontmatterSupport.extract` transiently fails.
+    static func structuralFrontmatterRegionLength(of text: String) -> Int {
+        guard let regex = frontmatterBlockRegex else { return 0 }
+        let ns = text as NSString
+        return regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length))?.range.length ?? 0
+    }
+
+    /// The editor paragraph style: line height (always) plus soft-wrap indent when active.
+    /// `headIndent` indents soft-wrapped continuation lines; `firstLineHeadIndent`
+    /// indents the first line of each (hard-break-bounded) paragraph.
+    private func indentParagraphStyle() -> PlatformParagraphStyle {
+        let paragraph = PlatformParagraphStyle()
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
+        if let indent = cachedIndent, isIndentActive {
+            let fontSize = Theme.editorFontSize
+            let charWidth = Self.characterWidth(of: Theme.editorFont)
+            paragraph.headIndent = indent.head.points(fontSize: fontSize, characterWidth: charWidth)
+            paragraph.firstLineHeadIndent = indent.firstLine.points(fontSize: fontSize, characterWidth: charWidth)
+        }
+        return paragraph
+    }
+
+    /// Advance width of one character in `font`. The editor font is monospaced,
+    /// so a single space measures the column width used for indent math.
+    private static func characterWidth(of font: PlatformFont) -> CGFloat {
+        let ctFont = font as CTFont
+        var character: UniChar = 0x20 // space
+        var glyph = CGGlyph(0)
+        guard CTFontGetGlyphsForCharacters(ctFont, &character, &glyph, 1) else {
+            return font.pointSize * 0.6
+        }
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(ctFont, .horizontal, &glyph, &advance, 1)
+        return advance.width > 0 ? advance.width : font.pointSize * 0.6
+    }
 
     // MARK: - Regex Patterns
 
@@ -174,10 +374,11 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         let fullRange = NSRange(location: 0, length: textStorage.length)
         let text = textStorage.string
 
+        // Refresh soft-wrap indent config from frontmatter before styling the document.
+        refreshIndentCache(from: text, markNeedsFullHighlight: false)
+
         // Reset to default style
-        let paragraph = PlatformParagraphStyle()
-        paragraph.minimumLineHeight = Theme.editorLineHeight
-        paragraph.maximumLineHeight = Theme.editorLineHeight
+        let paragraph = indentParagraphStyle()
 
         textStorage.addAttributes([
             Attr.font: Theme.editorFont,
@@ -360,8 +561,12 @@ public final class MarkdownSyntaxHighlighter: NSObject {
                     textStorage.addAttribute(Attr.foregroundColor, value: Theme.htmlTagColor, range: match.range)
 
                 case .frontmatter:
-                    let matchedText = (text as NSString).substring(with: match.range)
-                    guard FrontmatterSupport.extract(from: matchedText) != nil else { return }
+                    // The block regex is anchored at the document start and requires
+                    // `--- ... ---`, so a match is structurally frontmatter even when a
+                    // line is mid-edit and doesn't yet parse as a field. Color the region
+                    // regardless; the field-level key coloring below is best-effort.
+                    // (Gating this on a full parse made the whole block lose its
+                    // highlight while a new field line was being typed.)
                     protectedRanges.append(ProtectedRange(range: match.range, kind: .frontmatter))
                     let nsText = text as NSString
                     // Base color for the whole block
@@ -422,8 +627,9 @@ public final class MarkdownSyntaxHighlighter: NSObject {
 
         Self.frontmatterBlockRegex?.enumerateMatches(in: text, range: fullRange) { match, _, _ in
             guard let match else { return }
-            let matchedText = nsText.substring(with: match.range)
-            guard FrontmatterSupport.extract(from: matchedText) != nil else { return }
+            // Treat any document-leading `--- ... ---` block as frontmatter for
+            // protection, without requiring a full field parse — otherwise a
+            // half-typed field line would drop the block's protected status.
             protectedRanges.append(ProtectedRange(range: match.range, kind: .frontmatter))
         }
 
@@ -466,6 +672,15 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         let postEditRange = NSRange(location: safeLocation, length: safeLength)
         let paragraphRange = nsText.paragraphRange(for: postEditRange)
 
+        // If the edit could lie inside the frontmatter region, re-read the indent
+        // config. A changed value flips `needsFullHighlight` so the whole document
+        // restyles; edits in the body reuse the cached values for free.
+        // `cachedFrontmatterLength` reflects the pre-edit text, so allow a little
+        // slack past it to catch edits that land right at the old boundary.
+        if editedRange.location <= cachedFrontmatterLength + 8 {
+            refreshIndentCache(from: text, markNeedsFullHighlight: true)
+        }
+
         // A "paragraph" here is a `\n`-bounded run. A file with no newlines (binary blob,
         // pasted log dump) is one paragraph the size of the whole file — running the regex
         // pipeline over multi-MB input is the catastrophic case. Bail; the file-size cap on
@@ -507,14 +722,16 @@ public final class MarkdownSyntaxHighlighter: NSObject {
         }
 
         if needsFontReset {
-            let paragraph = PlatformParagraphStyle()
-            paragraph.minimumLineHeight = Theme.editorLineHeight
-            paragraph.maximumLineHeight = Theme.editorLineHeight
             textStorage.addAttributes([
                 Attr.font: Theme.editorFont,
-                Attr.paragraphStyle: paragraph,
+                Attr.paragraphStyle: indentParagraphStyle(),
                 Attr.baselineOffset: Theme.editorBaselineOffset
             ], range: paragraphRange)
+        } else if isIndentActive {
+            // Soft-wrap indent is active. Typing only stamps the line-height typing
+            // attributes onto new characters, so re-apply the indent paragraph style
+            // here to keep plain paragraphs aligned.
+            textStorage.addAttribute(Attr.paragraphStyle, value: indentParagraphStyle(), range: paragraphRange)
         }
         textStorage.addAttribute(Attr.foregroundColor, value: Theme.textColor, range: paragraphRange)
         textStorage.removeAttribute(Attr.backgroundColor, range: paragraphRange)

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/PreviewCSS.swift
@@ -306,7 +306,8 @@ public enum PreviewCSS {
         bodyMaxWidth: String = "61em",
         light: PreviewPalette = .light,
         dark: PreviewPalette = .dark,
-        print: PreviewPalette = .print
+        print: PreviewPalette = .print,
+        softWrapIndent: (head: IndentLength, firstLine: IndentLength)? = nil
     ) -> String {
         let bodyFontFamily: String
         let headingFontFamily: String
@@ -377,6 +378,31 @@ public enum PreviewCSS {
             display: block;
         }
         """ : ""
+
+        // Soft-wrap hanging indent (frontmatter wrapIndent / firstLineIndent).
+        // Only top-level paragraphs: lists, blockquotes, code, tables, and the
+        // frontmatter table have their own layout and must not be reflowed.
+        // `body > p` out-specifies the base `p` rule and is emitted after the
+        // `@media print` block, so it also wins inside the print/export contexts;
+        // keep it last if you move it. Empty string when the document opts out.
+        let softWrapIndentBlock: String
+        if let softWrapIndent {
+            let head = softWrapIndent.head
+            let firstLine = softWrapIndent.firstLine
+            // text-indent = firstLine - head (a negative offset pulls the first line flush).
+            // Same unit → fold to a single value; mixed units → defer to CSS calc().
+            let textIndent = head.unit == firstLine.unit
+                ? IndentLength(value: firstLine.value - head.value, unit: head.unit).css
+                : "calc(\(firstLine.css) - \(head.css))"
+            softWrapIndentBlock = """
+            body > p {
+                padding-left: \(head.css);
+                text-indent: \(textIndent);
+            }
+            """
+        } else {
+            softWrapIndentBlock = ""
+        }
 
         return """
         \(baseRoot)
@@ -1269,6 +1295,7 @@ public enum PreviewCSS {
             }
         }
         \(exportStructural)
+        \(softWrapIndentBlock)
         """
     }
 

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownFrontmatterTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownFrontmatterTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import ClearlyCore
+
+/// Rendering of the frontmatter block in the preview, in particular that
+/// layout-directive keys (`wrapIndent` / `firstLineIndent`) are hidden.
+final class MarkdownFrontmatterTests: XCTestCase {
+
+    func testContentFieldsAreRendered() {
+        let md = """
+        ---
+        title: Notes
+        author: Me
+        ---
+        body
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertTrue(html.contains("<dl>"), "content frontmatter should render a definition list")
+        XCTAssertTrue(html.contains("<dt>title</dt><dd>Notes</dd>"))
+        XCTAssertTrue(html.contains("<dt>author</dt><dd>Me</dd>"))
+    }
+
+    func testLayoutKeysAreHiddenButContentKeysRemain() {
+        let md = """
+        ---
+        title: Notes
+        wrapIndent: 2em
+        firstLineIndent: 0
+        ---
+        body
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertTrue(html.contains("<dt>title</dt><dd>Notes</dd>"), "content key should still render")
+        XCTAssertFalse(html.contains("wrapIndent"), "layout key wrapIndent should be hidden from preview")
+        XCTAssertFalse(html.contains("firstLineIndent"), "layout key firstLineIndent should be hidden from preview")
+    }
+
+    /// When the frontmatter contains ONLY layout directives, the preview must not
+    /// render a visible frontmatter block — just the silent anchor that keeps the
+    /// source-position mapping intact.
+    func testOnlyLayoutKeysRendersNoFrontmatterBlock() {
+        let md = """
+        ---
+        wrapIndent: 11
+        firstLineIndent: 0
+        ---
+        body
+        """
+        let html = MarkdownRenderer.renderHTML(md)
+        XCTAssertFalse(html.contains("<dl>"), "no definition list when all keys are layout directives")
+        XCTAssertFalse(html.contains("frontmatter-row"), "no rows when all keys are hidden")
+        XCTAssertFalse(html.contains("wrapIndent"), "layout key must not leak into output")
+        XCTAssertTrue(html.contains("class=\"frontmatter-anchor\""), "should emit the silent anchor")
+    }
+
+    func testNoFrontmatterEmitsNoFrontmatterMarkup() {
+        let html = MarkdownRenderer.renderHTML("# Title\n\nbody")
+        XCTAssertFalse(html.contains("class=\"frontmatter"), "plain document should not emit a frontmatter block")
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewCSSTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/PreviewCSSTests.swift
@@ -146,4 +146,49 @@ final class PreviewCSSTests: XCTestCase {
     // Asset-catalog resolution is exercised at runtime by the app + QuickLook targets; `swift test`
     // from the CLI can't load Bundle.module xcassets, so we verify asset-driven hex resolution via
     // Xcode test bundles rather than SPM.
+
+    // MARK: - Soft-wrap hanging indent
+
+    func testSoftWrapIndentOmittedByDefault() {
+        let sheet = PreviewCSS.css()
+        XCTAssertFalse(sheet.contains("body > p {"))
+    }
+
+    func testSoftWrapIndentEmitsHangingIndentRule() {
+        let sheet = PreviewCSS.css(softWrapIndent: (head: IndentLength(value: 4, unit: .em),
+                                                    firstLine: IndentLength(value: 0, unit: .em)))
+        XCTAssertTrue(sheet.contains("body > p {"))
+        XCTAssertTrue(sheet.contains("padding-left: 4em;"))
+        // firstLine - head = 0 - 4 = -4 → first line pulled flush, wrapped lines indented.
+        XCTAssertTrue(sheet.contains("text-indent: -4em;"))
+    }
+
+    func testSoftWrapIndentHonorsFirstLineIndent() {
+        let sheet = PreviewCSS.css(softWrapIndent: (head: IndentLength(value: 4, unit: .em),
+                                                    firstLine: IndentLength(value: 2, unit: .em)))
+        XCTAssertTrue(sheet.contains("padding-left: 4em;"))
+        // firstLine - head = 2 - 4 = -2
+        XCTAssertTrue(sheet.contains("text-indent: -2em;"))
+    }
+
+    func testSoftWrapIndentEmitsAbsoluteUnit() {
+        let sheet = PreviewCSS.css(softWrapIndent: (head: IndentLength(value: 24, unit: .px),
+                                                    firstLine: IndentLength(value: 0, unit: .px)))
+        XCTAssertTrue(sheet.contains("padding-left: 24px;"))
+        XCTAssertTrue(sheet.contains("text-indent: -24px;"))
+    }
+
+    func testSoftWrapIndentMixedUnitsUseCalc() {
+        let sheet = PreviewCSS.css(softWrapIndent: (head: IndentLength(value: 4, unit: .em),
+                                                    firstLine: IndentLength(value: 2, unit: .ch)))
+        XCTAssertTrue(sheet.contains("padding-left: 4em;"))
+        XCTAssertTrue(sheet.contains("text-indent: calc(2ch - 4em);"))
+    }
+
+    func testSoftWrapIndentDropsTrailingZeroForWholeNumbers() {
+        let sheet = PreviewCSS.css(softWrapIndent: (head: IndentLength(value: 2.5, unit: .em),
+                                                    firstLine: IndentLength(value: 0, unit: .em)))
+        XCTAssertTrue(sheet.contains("padding-left: 2.5em;"))
+        XCTAssertFalse(sheet.contains("padding-left: 2.50000")) // no float noise
+    }
 }

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/SoftWrapIndentTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/SoftWrapIndentTests.swift
@@ -1,0 +1,212 @@
+import Testing
+import Foundation
+@testable import ClearlyCore
+
+/// Tests for `MarkdownSyntaxHighlighter.indentValues(from:)` — the frontmatter
+/// parsing that drives soft-wrap continuation indent.
+struct SoftWrapIndentTests {
+
+    @Test func noFrontmatterReturnsNil() {
+        #expect(MarkdownSyntaxHighlighter.indentValues(from: "# Hello\n\nplain body") == nil)
+    }
+
+    @Test func frontmatterWithoutIndentKeysReturnsNil() {
+        let doc = """
+        ---
+        title: Notes
+        author: Me
+        ---
+        body
+        """
+        #expect(MarkdownSyntaxHighlighter.indentValues(from: doc) == nil)
+    }
+
+    @Test func wrapIndentOnly() {
+        let doc = """
+        ---
+        wrapIndent: 4
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 4)
+        #expect(values?.head.unit == .em) // bare number defaults to em
+        #expect(values?.firstLine.value == 0)
+    }
+
+    @Test func firstLineIndentOnly() {
+        let doc = """
+        ---
+        firstLineIndent: 2
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 0)
+        #expect(values?.firstLine.value == 2)
+    }
+
+    @Test func bothIndentsTogether() {
+        let doc = """
+        ---
+        title: Notes
+        wrapIndent: 4
+        firstLineIndent: 1
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 4)
+        #expect(values?.firstLine.value == 1)
+    }
+
+    @Test func zeroIsAValidExplicitValue() {
+        let doc = """
+        ---
+        wrapIndent: 0
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 0)
+        #expect(values?.firstLine.value == 0)
+    }
+
+    @Test func negativeValueIsIgnored() {
+        let doc = """
+        ---
+        wrapIndent: -3
+        ---
+        body
+        """
+        // wrapIndent rejected as negative; no other key → feature off.
+        #expect(MarkdownSyntaxHighlighter.indentValues(from: doc) == nil)
+    }
+
+    @Test func nonNumericValueIsIgnored() {
+        let doc = """
+        ---
+        wrapIndent: lots
+        firstLineIndent: 3
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        // wrapIndent unparseable → falls back to 0, but only because the valid
+        // firstLineIndent keeps the feature on (both unparseable would return nil).
+        #expect(values?.head.value == 0)
+        #expect(values?.firstLine.value == 3)
+    }
+
+    @Test func fractionalValueIsAccepted() {
+        let doc = """
+        ---
+        wrapIndent: 2.5
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 2.5)
+    }
+
+    // MARK: - Explicit units
+
+    @Test func explicitUnitsAreParsed() {
+        let doc = """
+        ---
+        wrapIndent: 2ch
+        firstLineIndent: 24px
+        ---
+        body
+        """
+        let values = MarkdownSyntaxHighlighter.indentValues(from: doc)
+        #expect(values?.head.value == 2)
+        #expect(values?.head.unit == .ch)
+        #expect(values?.firstLine.value == 24)
+        #expect(values?.firstLine.unit == .px)
+    }
+
+    @Test func emAndPtUnitsAreParsed() {
+        #expect(IndentLength.parse("2em") == IndentLength(value: 2, unit: .em))
+        #expect(IndentLength.parse("12pt") == IndentLength(value: 12, unit: .pt))
+        #expect(IndentLength.parse("3.5ch") == IndentLength(value: 3.5, unit: .ch))
+        #expect(IndentLength.parse("  5  ") == IndentLength(value: 5, unit: .em)) // bare → em
+    }
+
+    @Test func invalidUnitInputReturnsNil() {
+        #expect(IndentLength.parse("") == nil)
+        #expect(IndentLength.parse("abc") == nil)
+        #expect(IndentLength.parse("-2em") == nil) // negative rejected
+    }
+
+    @Test func pointsResolutionPerUnit() {
+        // em scales with font size, ch with character width, px/pt are absolute.
+        #expect(IndentLength(value: 2, unit: .em).points(fontSize: 12, characterWidth: 7) == 24)
+        #expect(IndentLength(value: 2, unit: .ch).points(fontSize: 12, characterWidth: 7) == 14)
+        #expect(IndentLength(value: 20, unit: .px).points(fontSize: 12, characterWidth: 7) == 20)
+        #expect(IndentLength(value: 20, unit: .pt).points(fontSize: 12, characterWidth: 7) == 20)
+    }
+
+    @Test func cssStringDropsTrailingZero() {
+        #expect(IndentLength(value: 4, unit: .em).css == "4em")
+        #expect(IndentLength(value: 2.5, unit: .ch).css == "2.5ch")
+        #expect(IndentLength(value: -4, unit: .px).css == "-4px")
+    }
+
+    // MARK: - Frontmatter region length (live re-highlight gate)
+
+    /// The incremental highlighter only re-reads the indent config when the edit
+    /// falls within `frontmatterRegionLength`. Driving `highlightAll`/`highlightAround`
+    /// end-to-end isn't possible under `swift test` (Theme color assets aren't
+    /// loaded), so the gate is verified at the region-length level instead.
+
+    @Test func regionLengthIsZeroWithoutFrontmatter() {
+        #expect(MarkdownSyntaxHighlighter.frontmatterRegionLength(of: "# Just a body\n\ntext") == 0)
+    }
+
+    /// Regression: the region length must be reported even when the frontmatter
+    /// has no indent keys yet. Before the fix it was left at 0 in that case, so
+    /// adding `wrapIndent` later fell outside the in-region check and the change
+    /// only took effect after reopening the document.
+    @Test func regionLengthCoversFrontmatterWithoutIndentKeys() {
+        let doc = "---\ntitle: x\n---\nbody"
+        let length = MarkdownSyntaxHighlighter.frontmatterRegionLength(of: doc)
+        // Region spans "---\ntitle: x\n---\n" (17 chars); body "body" excluded.
+        #expect(length == (doc as NSString).length - ("body" as NSString).length)
+        #expect(length > 0)
+
+        // The location where one would insert "wrapIndent: 4" (just after the
+        // title line) is inside the region, so the edit would be detected.
+        let insertLocation = 12
+        #expect(insertLocation < length)
+    }
+
+    @Test func regionLengthCoversFrontmatterWithIndentKeys() {
+        let doc = "---\nwrapIndent: 4\n---\nbody text here"
+        let length = MarkdownSyntaxHighlighter.frontmatterRegionLength(of: doc)
+        #expect(length == (doc as NSString).length - ("body text here" as NSString).length)
+    }
+
+    // MARK: - Structural region length (keeps indent alive mid-edit)
+
+    /// Regression: while typing a new field, a line is briefly invalid (a key with
+    /// no colon yet), so `FrontmatterSupport.extract` fails and the field-based
+    /// region length is 0. The structural length (delimiters only) must still be
+    /// non-zero, so the indent cache and the in-region edit gate survive the
+    /// transient state instead of permanently dropping the body indent.
+    @Test func structuralLengthSurvivesHalfTypedField() {
+        let doc = "---\nwrapIndent: 4\ndate\n---\nbody"   // `date` has no colon yet
+        #expect(MarkdownSyntaxHighlighter.frontmatterRegionLength(of: doc) == 0)
+        #expect(MarkdownSyntaxHighlighter.structuralFrontmatterRegionLength(of: doc) > 0)
+    }
+
+    @Test func structuralLengthIsZeroWithoutDelimiters() {
+        #expect(MarkdownSyntaxHighlighter.structuralFrontmatterRegionLength(of: "# Heading\n\nbody") == 0)
+    }
+
+    @Test func structuralLengthMatchesValidFrontmatter() {
+        let doc = "---\nwrapIndent: 4\n---\nbody"
+        // Valid frontmatter: structural length covers the leading `--- ... ---\n` span.
+        #expect(MarkdownSyntaxHighlighter.structuralFrontmatterRegionLength(of: doc) > 0)
+    }
+}


### PR DESCRIPTION
## What

Adds two **opt-in** frontmatter keys that indent soft-wrapped (auto-wrapped) continuation lines while hard line breaks stay flush left:

```yaml
---
wrapIndent: 2em        # indent for soft-wrapped continuation lines
firstLineIndent: 0     # optional indent for the first line of each paragraph
---
```

Values accept explicit CSS units (`em`, `ch`, `px`, `pt`); a bare number defaults to `em`. The editor resolves them to `NSParagraphStyle` points and the preview emits them verbatim as CSS, so the **editor, WKWebView preview, PDF
export, and QuickLook all render the same indent**.

When neither key is present, nothing changes — the default behavior is completely untouched.

<img width="543" height="494" alt="image" src="https://github.com/user-attachments/assets/c7a3ede5-0974-4d8f-a535-455b698c55bb" />

**Also includes a small editor fix:** a leading `--- … ---` block is now recognized structurally, so a half-typed frontmatter field (e.g. a key before its colon) no longer drops the block's syntax highlighting or the live indent — a pre-existing display glitch, surfaced while testing this feature.

## Why

For log / changelog / reference-style notes, a hanging indent makes wrapped lines line up under a leading column (timestamp, key, citation, etc.) and visually distinguishes a *soft wrap* from a deliberate *hard break*. Several editors (and a popular Obsidian CSS snippet, `--wrap-indent`) and Emacs' `visual-wrap-extra-indent` do exactly this. I wanted it for a specific set of my own documents.

## Scope / design notes

I tried to keep this in line with the project's "stay boring" philosophy:

- **No new UI, no settings toggle** — config lives only in per-document   frontmatter, default off.
- **No new infrastructure** — no sidebar, vault, index, or anything like that.   It's purely a paragraph-style/CSS tweak.
- Core logic lives in `ClearlyCore` (shared), so **Mac and iOS** behave   identically, and the same value feeds preview/PDF/QuickLook.
- Added unit tests for parsing, unit resolution, and CSS emission; the full   `ClearlyCore` suite is green (`swift test --package-path Packages/ClearlyCore`).

## A note on stance

This scratches a personal itch for specific documents — I completely understand if niche per-document layout knobs aren't a direction you want for Clearly, and **it's totally fine if this doesn't get merged**. Sharing it in case it's useful.

Either way: thank you for open-sourcing such a clean, genuinely pleasant markdown editor. It's a joy to use, and the codebase was a pleasure to work in.