### PR TITLE
Move paragraph # characters into the left gutter

### DIFF
--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -26,6 +26,15 @@ class PersistentTextCheckingTextView: NSTextView {
         let textSystem = MarkdownTextSystem()
         self.init(frame: frame, textContainer: textSystem.textContainer)
         markdownTextSystem = textSystem
+
+        // `NSTextView()` normally starts with a virtually unbounded maximum
+        // height. Supplying our own TextKit stack skips that default and leaves
+        // maxSize equal to the initial frame, which pins a zero-frame editor to
+        // the scroll viewport once it is installed as the document view.
+        maxSize = NSSize(
+            width: frame.width,
+            height: textSystem.textContainer.size.height
+        )
     }
 
     @objc override func toggleContinuousSpellChecking(_ sender: Any?) {

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -20,6 +20,14 @@ enum TextCheckingPreferences {
 }
 
 class PersistentTextCheckingTextView: NSTextView {
+    private var markdownTextSystem: MarkdownTextSystem?
+
+    convenience init(markdownFrame frame: NSRect = .zero) {
+        let textSystem = MarkdownTextSystem()
+        self.init(frame: frame, textContainer: textSystem.textContainer)
+        markdownTextSystem = textSystem
+    }
+
     @objc override func toggleContinuousSpellChecking(_ sender: Any?) {
         super.toggleContinuousSpellChecking(sender)
         TextCheckingPreferences.persist(from: self)

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -25,10 +25,18 @@ struct EditorView: NSViewRepresentable {
         scrollViewWidth: CGFloat, contentWidthEm: CGFloat?,
         fontSize: CGFloat, needsTrafficLightClearance: Bool
     ) -> CGFloat {
-        let minInset = Theme.editorInsetX + (needsTrafficLightClearance ? 20 : 0)
-        guard let emValue = contentWidthEm else { return minInset }
+        let markerGutter = MarkdownHeadingLayout.markerGutterWidth
+        let minContentInset = max(Theme.editorInsetX, markerGutter + 8)
+            + (needsTrafficLightClearance ? 20 : 0)
+        guard let emValue = contentWidthEm else {
+            return max(0, minContentInset - markerGutter)
+        }
         let maxWidthPoints = emValue * fontSize
-        return max(minInset, (scrollViewWidth - maxWidthPoints) / 2.0)
+        let contentInset = max(
+            minContentInset,
+            (scrollViewWidth - maxWidthPoints) / 2.0
+        )
+        return max(0, contentInset - markerGutter)
     }
 
     func makeCoordinator() -> Coordinator {
@@ -46,7 +54,7 @@ struct EditorView: NSViewRepresentable {
         scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: extraBottomInset, right: 0)
         scrollView.scrollerInsets = NSEdgeInsets(top: 0, left: 0, bottom: -extraBottomInset, right: 0)
 
-        let textView = ClearlyTextView()
+        let textView = ClearlyTextView(markdownFrame: .zero)
         textView.isRichText = false
         textView.allowsUndo = true
         textView.usesFindPanel = false
@@ -63,9 +71,7 @@ struct EditorView: NSViewRepresentable {
 
         // Paragraph style with line height — use min/max line height + baselineOffset
         // so text is vertically centered in each line (not top-aligned like lineSpacing)
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.minimumLineHeight = Theme.editorLineHeight
-        paragraph.maximumLineHeight = Theme.editorLineHeight
+        let paragraph = MarkdownHeadingLayout.paragraphStyle()
         textView.defaultParagraphStyle = paragraph
         textView.typingAttributes = [
             .font: Theme.editorFont,
@@ -98,7 +104,7 @@ struct EditorView: NSViewRepresentable {
         // the first updateNSView call handles initial highlighting via the color-scheme check.
         // Note: we do NOT set textStorage.delegate — highlighting is driven explicitly
         // from textDidChange and updateNSView to avoid re-entrant layout manager access.
-        let highlighter = MarkdownSyntaxHighlighter()
+        let highlighter = MarkdownEditorHighlighter()
         context.coordinator.highlighter = highlighter
         textView.string = text
         textView.delegate = context.coordinator
@@ -287,9 +293,7 @@ struct EditorView: NSViewRepresentable {
             context.coordinator.lastFontSize = currentFontSize
             textView.font = Theme.editorFont
 
-            let paragraph = NSMutableParagraphStyle()
-            paragraph.minimumLineHeight = Theme.editorLineHeight
-            paragraph.maximumLineHeight = Theme.editorLineHeight
+            let paragraph = MarkdownHeadingLayout.paragraphStyle()
             textView.typingAttributes = [
                 .font: Theme.editorFont,
                 .foregroundColor: Theme.textColor,
@@ -361,7 +365,7 @@ struct EditorView: NSViewRepresentable {
         var parent: EditorView
         var isUpdating = false
         var isHighlightingInProgress = false
-        var highlighter: MarkdownSyntaxHighlighter?
+        var highlighter: MarkdownEditorHighlighter?
         var lastEditedRange: NSRange?
         var lastReplacementLength: Int = 0
         weak var textView: ClearlyTextView?

--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -39,6 +39,19 @@ struct EditorView: NSViewRepresentable {
         return max(0, contentInset - markerGutter)
     }
 
+    private static func maxScrollOffsetY(for scrollView: NSScrollView) -> CGFloat {
+        let documentHeight = scrollView.documentView?.frame.height ?? 1
+        let viewportHeight = scrollView.contentView.bounds.height
+
+        // NSScrollView's bottom content inset extends the real scroll range so
+        // the final line can move above the floating toolbar. Include that
+        // reserved space in our fraction bridge as well.
+        return max(
+            1,
+            documentHeight - viewportHeight + scrollView.contentInsets.bottom
+        )
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -256,9 +269,7 @@ struct EditorView: NSViewRepresentable {
         if mode == .edit && (context.coordinator.lastMode != .edit || didChangeDocument) {
             findState?.activeMode = .edit
             let fraction = ScrollBridge.fraction(for: positionSyncID)
-            let docHeight = scrollView.documentView?.frame.height ?? 1
-            let viewportHeight = scrollView.contentView.bounds.height
-            let maxScroll = max(1, docHeight - viewportHeight)
+            let maxScroll = Self.maxScrollOffsetY(for: scrollView)
             scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: fraction * maxScroll))
             scrollView.reflectScrolledClipView(scrollView.contentView)
             DispatchQueue.main.async {
@@ -713,9 +724,7 @@ struct EditorView: NSViewRepresentable {
             guard now - lastScrollTime >= 0.016 else { return }
             lastScrollTime = now
 
-            let docHeight = scrollView.documentView?.frame.height ?? 1
-            let viewportHeight = clipView.bounds.height
-            let maxScroll = max(1, docHeight - viewportHeight)
+            let maxScroll = EditorView.maxScrollOffsetY(for: scrollView)
             let fraction = min(max(clipView.bounds.origin.y / maxScroll, 0), 1)
             ScrollBridge.setFraction(fraction, for: parent.positionSyncID)
 

--- a/Clearly/MarkdownHeadingLayout.swift
+++ b/Clearly/MarkdownHeadingLayout.swift
@@ -1,0 +1,256 @@
+import AppKit
+import ClearlyCore
+
+/// Applies the shared syntax highlighter, then adds the Mac editor's
+/// paragraph geometry for hanging ATX heading markers.
+final class MarkdownEditorHighlighter {
+    private let syntaxHighlighter = MarkdownSyntaxHighlighter()
+
+    var needsFullHighlight: Bool {
+        get { syntaxHighlighter.needsFullHighlight }
+        set { syntaxHighlighter.needsFullHighlight = newValue }
+    }
+
+    func highlightAll(_ textStorage: NSTextStorage, caller: String = "") {
+        syntaxHighlighter.highlightAll(textStorage, caller: caller)
+        MarkdownHeadingLayout.apply(
+            to: textStorage,
+            in: NSRange(location: 0, length: textStorage.length),
+            syntaxHighlighter: syntaxHighlighter
+        )
+    }
+
+    func highlightAround(
+        _ textStorage: NSTextStorage,
+        editedRange: NSRange,
+        replacementLength: Int,
+        caller: String = ""
+    ) {
+        syntaxHighlighter.highlightAround(
+            textStorage,
+            editedRange: editedRange,
+            replacementLength: replacementLength,
+            caller: caller
+        )
+        MarkdownHeadingLayout.apply(
+            to: textStorage,
+            in: MarkdownHeadingLayout.affectedParagraphRange(
+                in: textStorage.string,
+                editedRange: editedRange,
+                replacementLength: replacementLength
+            ),
+            syntaxHighlighter: syntaxHighlighter
+        )
+    }
+}
+
+enum MarkdownHeadingLayout {
+    static func markerWidth(for prefix: String) -> CGFloat {
+        (prefix as NSString).size(withAttributes: [.font: Theme.editorFont]).width
+    }
+
+    /// AppKit tab stops are absolute, so the tab grid must be re-anchored at
+    /// the body-text column after introducing the internal marker gutter.
+    static var tabInterval: CGFloat {
+        markerWidth(for: "    ")
+    }
+
+    /// Fits the widest editable prefix (`###### `) and rounds to the tab grid.
+    static var markerGutterWidth: CGFloat {
+        ceil(markerWidth(for: "###### ") / tabInterval) * tabInterval
+    }
+
+    /// The internal gutter is subtracted from the text container's outer inset,
+    /// leaving the visible body-text margin unchanged.
+    static func paragraphStyle() -> NSMutableParagraphStyle {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.minimumLineHeight = Theme.editorLineHeight
+        paragraph.maximumLineHeight = Theme.editorLineHeight
+        paragraph.firstLineHeadIndent = markerGutterWidth
+        paragraph.headIndent = markerGutterWidth
+        paragraph.tailIndent = -markerGutterWidth
+        paragraph.tabStops = []
+        paragraph.defaultTabInterval = tabInterval
+        return paragraph
+    }
+
+    static func containerInset(forContentInset contentInset: CGFloat) -> CGFloat {
+        max(0, max(contentInset, markerGutterWidth + 8) - markerGutterWidth)
+    }
+
+    static func apply(
+        to textStorage: NSTextStorage,
+        in requestedRange: NSRange,
+        syntaxHighlighter: MarkdownSyntaxHighlighter
+    ) {
+        guard textStorage.length > 0 else { return }
+
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        let range = NSIntersectionRange(requestedRange, fullRange)
+        guard range.length > 0 else { return }
+
+        let text = textStorage.string as NSString
+        textStorage.beginEditing()
+        resetParagraphGeometryIfNeeded(in: range, of: textStorage)
+
+        var location = range.location
+        while location < NSMaxRange(range) {
+            let lineRange = text.lineRange(
+                for: NSRange(location: location, length: 0)
+            )
+            let styledLineRange = NSIntersectionRange(lineRange, fullRange)
+            let line = text.substring(with: styledLineRange)
+
+            if !syntaxHighlighter.isInsideProtectedRange(at: lineRange.location),
+               let prefix = ATXHeadingPrefix.parse(in: line) {
+                let prefixString = String(prefix)
+                let prefixRange = NSRange(
+                    location: lineRange.location,
+                    length: prefixString.utf16.count
+                )
+                let headingParagraph = paragraphStyle()
+                headingParagraph.firstLineHeadIndent =
+                    markerGutterWidth - markerWidth(for: prefixString)
+
+                textStorage.addAttribute(
+                    .paragraphStyle,
+                    value: headingParagraph,
+                    range: styledLineRange
+                )
+                textStorage.addAttribute(
+                    .foregroundColor,
+                    value: Theme.syntaxColor,
+                    range: prefixRange
+                )
+            }
+
+            let nextLocation = NSMaxRange(lineRange)
+            location = nextLocation > location ? nextLocation : location + 1
+        }
+
+        textStorage.endEditing()
+    }
+
+    private static func resetParagraphGeometryIfNeeded(
+        in range: NSRange,
+        of textStorage: NSTextStorage
+    ) {
+        var needsReset = false
+        textStorage.enumerateAttribute(
+            .paragraphStyle,
+            in: range,
+            options: .longestEffectiveRangeNotRequired
+        ) { value, _, stop in
+            guard let paragraph = value as? NSParagraphStyle,
+                  paragraph.firstLineHeadIndent == markerGutterWidth,
+                  paragraph.headIndent == markerGutterWidth,
+                  paragraph.tailIndent == -markerGutterWidth,
+                  paragraph.defaultTabInterval == tabInterval else {
+                needsReset = true
+                stop.pointee = true
+                return
+            }
+        }
+
+        if needsReset {
+            textStorage.addAttribute(
+                .paragraphStyle,
+                value: paragraphStyle(),
+                range: range
+            )
+        }
+    }
+
+    static func affectedParagraphRange(
+        in text: String,
+        editedRange: NSRange,
+        replacementLength: Int
+    ) -> NSRange {
+        let nsText = text as NSString
+        let textLength = nsText.length
+        let safeLocation = max(0, min(editedRange.location, textLength))
+        let safeLength = max(
+            0,
+            min(replacementLength, textLength - safeLocation)
+        )
+
+        guard safeLocation == editedRange.location,
+              safeLength == replacementLength else {
+            return NSRange(location: 0, length: textLength)
+        }
+
+        let insertedRange = NSRange(
+            location: safeLocation,
+            length: safeLength
+        )
+        var paragraphRange = nsText.paragraphRange(for: insertedRange)
+
+        if safeLength > 0,
+           nsText.substring(with: insertedRange).contains("\n") {
+            let followingLocation = NSMaxRange(paragraphRange)
+            if followingLocation < textLength {
+                paragraphRange = NSUnionRange(
+                    paragraphRange,
+                    nsText.paragraphRange(
+                        for: NSRange(location: followingLocation, length: 1)
+                    )
+                )
+            }
+        }
+
+        return paragraphRange
+    }
+}
+
+/// Owns the TextKit 1 graph used by both Mac markdown editors.
+final class MarkdownTextSystem {
+    let textStorage: NSTextStorage
+    let layoutManager: MarkdownLayoutManager
+    let textContainer: NSTextContainer
+
+    init() {
+        textStorage = NSTextStorage()
+        layoutManager = MarkdownLayoutManager()
+        textContainer = NSTextContainer()
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+    }
+}
+
+/// Keeps the caret for an empty final paragraph at the body-text column.
+final class MarkdownLayoutManager: NSLayoutManager {
+    override func setExtraLineFragmentRect(
+        _ fragmentRect: NSRect,
+        usedRect: NSRect,
+        textContainer: NSTextContainer
+    ) {
+        let bodyIndent = MarkdownHeadingLayout.markerGutterWidth
+        var adjustedFragment = fragmentRect
+        let fragmentAdjustment = max(0, bodyIndent - adjustedFragment.minX)
+        adjustedFragment.origin.x += fragmentAdjustment
+        adjustedFragment.size.width = max(
+            0,
+            adjustedFragment.width - fragmentAdjustment
+        )
+
+        let desiredMaxX = max(
+            adjustedFragment.minX,
+            textContainer.size.width - bodyIndent
+        )
+        adjustedFragment.size.width = min(
+            adjustedFragment.width,
+            desiredMaxX - adjustedFragment.minX
+        )
+
+        var adjustedUsed = usedRect
+        let usedAdjustment = max(0, bodyIndent - adjustedUsed.minX)
+        adjustedUsed.origin.x += usedAdjustment
+        adjustedUsed.size.width = max(0, adjustedUsed.width - usedAdjustment)
+
+        super.setExtraLineFragmentRect(
+            adjustedFragment,
+            usedRect: adjustedUsed,
+            textContainer: textContainer
+        )
+    }
+}

--- a/Clearly/ScratchpadEditorView.swift
+++ b/Clearly/ScratchpadEditorView.swift
@@ -35,7 +35,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.autohidesScrollers = true
 
-        let textView = ScratchpadTextView()
+        let textView = ScratchpadTextView(markdownFrame: .zero)
         textView.isRichText = false
         textView.allowsUndo = true
         textView.usesFindPanel = true
@@ -49,9 +49,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         textView.backgroundColor = .clear
         textView.drawsBackground = false
 
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.minimumLineHeight = Theme.editorLineHeight
-        paragraph.maximumLineHeight = Theme.editorLineHeight
+        let paragraph = MarkdownHeadingLayout.paragraphStyle()
         textView.defaultParagraphStyle = paragraph
         textView.typingAttributes = [
             .font: Theme.editorFont,
@@ -60,7 +58,10 @@ struct ScratchpadEditorView: NSViewRepresentable {
             .baselineOffset: Theme.editorBaselineOffset
         ]
 
-        textView.textContainerInset = NSSize(width: 20, height: 8)
+        textView.textContainerInset = NSSize(
+            width: MarkdownHeadingLayout.containerInset(forContentInset: 20),
+            height: 8
+        )
         textView.textContainer?.lineFragmentPadding = 0
 
         textView.isVerticallyResizable = true
@@ -71,7 +72,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
 
         textView.insertionPointColor = Theme.textColor
 
-        let highlighter = MarkdownSyntaxHighlighter()
+        let highlighter = MarkdownEditorHighlighter()
         context.coordinator.highlighter = highlighter
         textView.string = text
         textView.delegate = context.coordinator
@@ -104,9 +105,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
             context.coordinator.lastFontSize = currentFontSize
             textView.font = Theme.editorFont
 
-            let paragraph = NSMutableParagraphStyle()
-            paragraph.minimumLineHeight = Theme.editorLineHeight
-            paragraph.maximumLineHeight = Theme.editorLineHeight
+            let paragraph = MarkdownHeadingLayout.paragraphStyle()
             textView.typingAttributes = [
                 .font: Theme.editorFont,
                 .foregroundColor: Theme.textColor,
@@ -137,7 +136,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         var parent: ScratchpadEditorView
         var isUpdating = false
         var isHighlighting = false
-        var highlighter: MarkdownSyntaxHighlighter?
+        var highlighter: MarkdownEditorHighlighter?
         weak var textView: NSTextView?
         var lastColorScheme: ColorScheme?
         var lastFontSize: CGFloat?

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/ATXHeadingPrefix.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/ATXHeadingPrefix.swift
@@ -1,4 +1,5 @@
-/// Recognizes the marker and separator at the start of an ATX heading.
+/// Recognizes the editable marker and separator at the start of an ATX
+/// heading. The heading content may still be empty while the user is typing.
 public enum ATXHeadingPrefix {
     public static func parse(in line: String) -> Substring? {
         var index = line.startIndex
@@ -19,11 +20,6 @@ public enum ATXHeadingPrefix {
             index = line.index(after: index)
         } while index < line.endIndex
             && (line[index] == " " || line[index] == "\t")
-
-        guard index < line.endIndex,
-              line[index] != "\n", line[index] != "\r" else {
-            return nil
-        }
 
         return line[..<index]
     }

--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/ATXHeadingPrefix.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/ATXHeadingPrefix.swift
@@ -1,0 +1,30 @@
+/// Recognizes the marker and separator at the start of an ATX heading.
+public enum ATXHeadingPrefix {
+    public static func parse(in line: String) -> Substring? {
+        var index = line.startIndex
+        var level = 0
+
+        while index < line.endIndex, line[index] == "#" {
+            level += 1
+            guard level <= 6 else { return nil }
+            index = line.index(after: index)
+        }
+
+        guard level > 0, index < line.endIndex,
+              line[index] == " " || line[index] == "\t" else {
+            return nil
+        }
+
+        repeat {
+            index = line.index(after: index)
+        } while index < line.endIndex
+            && (line[index] == " " || line[index] == "\t")
+
+        guard index < line.endIndex,
+              line[index] != "\n", line[index] != "\r" else {
+            return nil
+        }
+
+        return line[..<index]
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ATXHeadingPrefixTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ATXHeadingPrefixTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import ClearlyCore
+
+struct ATXHeadingPrefixTests {
+    @Test func recognizesEveryHeadingLevel() {
+        for level in 1...6 {
+            let marker = String(repeating: "#", count: level)
+            #expect(ATXHeadingPrefix.parse(in: "\(marker) Heading") == "\(marker) ")
+        }
+    }
+
+    @Test func includesTheCompleteSpaceOrTabSeparator() {
+        #expect(ATXHeadingPrefix.parse(in: "##   Heading") == "##   ")
+        #expect(ATXHeadingPrefix.parse(in: "##\tHeading") == "##\t")
+        #expect(ATXHeadingPrefix.parse(in: "# \t Heading") == "# \t ")
+    }
+
+    @Test func rejectsNonHeadingPrefixes() {
+        #expect(ATXHeadingPrefix.parse(in: "#") == nil)
+        #expect(ATXHeadingPrefix.parse(in: "# ") == nil)
+        #expect(ATXHeadingPrefix.parse(in: "###\t") == nil)
+        #expect(ATXHeadingPrefix.parse(in: "####### Heading") == nil)
+        #expect(ATXHeadingPrefix.parse(in: " # Heading") == nil)
+        #expect(ATXHeadingPrefix.parse(in: "#not-a-heading") == nil)
+        #expect(ATXHeadingPrefix.parse(in: "") == nil)
+    }
+}

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/ATXHeadingPrefixTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/ATXHeadingPrefixTests.swift
@@ -15,10 +15,13 @@ struct ATXHeadingPrefixTests {
         #expect(ATXHeadingPrefix.parse(in: "# \t Heading") == "# \t ")
     }
 
+    @Test func recognizesAHeadingBeforeContentIsTyped() {
+        #expect(ATXHeadingPrefix.parse(in: "# ") == "# ")
+        #expect(ATXHeadingPrefix.parse(in: "###\t") == "###\t")
+    }
+
     @Test func rejectsNonHeadingPrefixes() {
         #expect(ATXHeadingPrefix.parse(in: "#") == nil)
-        #expect(ATXHeadingPrefix.parse(in: "# ") == nil)
-        #expect(ATXHeadingPrefix.parse(in: "###\t") == nil)
         #expect(ATXHeadingPrefix.parse(in: "####### Heading") == nil)
         #expect(ATXHeadingPrefix.parse(in: " # Heading") == nil)
         #expect(ATXHeadingPrefix.parse(in: "#not-a-heading") == nil)


### PR DESCRIPTION
Thanks so much for making Clearly, it's exactly what I was looking for in a Markdown client! And thank you for making it open source.

This pull request adds one feature and one related feature:

* It moves the `#` marks into the gutter, as in iA Writer, since I really like the way it looks. Importantly however, the text remains editable as plain text, there's no "magic WYSIWIG" style editor feature here as in other Markdown editors - I love the plain text philosophy of the way Clearly works in general - it's purely about the positioning of the text.
* I tweaked the way that the Markdown is parsed so that `# ` (including the space character after) is already parsed as a heading before the first actual heading character. This makes editing feel a little nicer IMHO because the `#` characters already shift into the gutter before you start typing. I put this in a separate commit in case you don't agree with this specific point.

Demo gif:

<img width="800" height="591" alt="CleanShot 2026-07-24 at 14 43 18" src="https://github.com/user-attachments/assets/39166b9d-e300-44f9-adbd-f4cb8ccfbc2b" />

For transparency:

 * This is vibe-coded in Codex with 5.6 Sol, mostly on High. I barely looked at the code. After an initial implementation, I asked it to rewrite to follow your coding guidelines better.
 * I have zero emotional attachment to the code or this PR though - happy for it to be immediately rejected - I totally understand!
 * However I still think it would be cool if the feature (whether "my" code or yours) made it into the official app, because obviously I like it myself :) No problem if not though - I'm happy to stick to my own local build.
 * This PR description was written by a human (err clearly, after my first failed PR with typo in title, sorry!)

Thanks! ❤️