### PR TITLE
[mac] Render mermaid diagrams in PDF export and print

### DIFF
--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -40,6 +40,9 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(LocalImageSchemeHandler(), forURLScheme: LocalImageSupport.scheme)
         let wv = WKWebView(frame: NSRect(x: 0, y: 0, width: renderWidth, height: Self.pageSize.height), configuration: config)
+        // PDF/print output is always light — force light appearance so
+        // prefers-color-scheme JS (mermaid theme selection) matches.
+        wv.appearance = NSAppearance(named: .aqua)
         wv.navigationDelegate = self
         self.webView = wv
 
@@ -67,6 +70,7 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         \(MathSupport.scriptHTML(for: htmlBody))
         \(TableSupport.scriptHTML(for: htmlBody))
         \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
+        \(htmlBody.contains("language-mermaid") ? MermaidSupport.scriptHTML : "")
         </html>
         """
         wv.loadHTMLString(html, baseURL: documentURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
@@ -81,8 +85,9 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         Task { @MainActor in
             do {
                 try await waitForImages(in: webView)
+                try await waitForMermaid(in: webView)
             } catch {
-                // If image waiting JS fails, continue instead of blocking.
+                // If readiness-waiting JS fails, continue instead of blocking.
             }
 
             let isExport = !isPrint
@@ -186,6 +191,30 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
                 );
             }
             await new Promise(resolve => setTimeout(resolve, 50));
+            return true;
+            """,
+            arguments: [:],
+            in: nil,
+            contentWorld: .page
+        )
+    }
+
+    private func waitForMermaid(in webView: WKWebView) async throws {
+        _ = try await webView.callAsyncJavaScript(
+            """
+            if (window.mermaid && !window.__mermaidReady) {
+                await new Promise(resolve => {
+                    const timeout = setTimeout(resolve, 5000);
+                    window.addEventListener('mermaid-ready', () => {
+                        clearTimeout(timeout);
+                        resolve();
+                    }, { once: true });
+                    if (window.__mermaidReady) {
+                        clearTimeout(timeout);
+                        resolve();
+                    }
+                });
+            }
             return true;
             """,
             arguments: [:],


### PR DESCRIPTION
Fixes #392.

Exported PDFs (and print) showed the raw mermaid code block instead of the rendered diagram, because `PDFExporter` never injected the mermaid script that the live preview uses.

## Changes
- Inject `MermaidSupport.scriptHTML` into the export/print HTML when the document contains a mermaid block.
- Wait for mermaid rendering to finish (`mermaid-ready` event, 5s timeout) before running the print operation, alongside the existing image wait.
- Force light appearance on the export webview so mermaid picks its light (neutral) theme even when the system is in dark mode — PDF output is always light.

## Verification
Built the app, exported a document with a mermaid flowchart to PDF via the actual File → Export as PDF… flow (system in dark mode): the PDF contains the rendered diagram in the light theme, with surrounding text intact. Preview mode unaffected.