### PR TITLE
[shared] fix: KaTeX math mangled by superscript post-processing

### DIFF
--- a/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
+++ b/Packages/ClearlyCore/Sources/ClearlyCore/Rendering/MarkdownRenderer.swift
@@ -189,8 +189,10 @@ public enum MarkdownRenderer {
     }
 
     private static func protectCodeRegions(in html: String) -> (html: String, segments: [String]) {
+        // Also protects math spans/blocks produced by processMath so later
+        // post-processors (super/sub, marks, emoji) don't mangle LaTeX source.
         guard let codeRegex = try? NSRegularExpression(
-            pattern: #"<(pre|code)\b[^>]*>[\s\S]*?<\/\1>"#,
+            pattern: #"<(pre|code)\b[^>]*>[\s\S]*?<\/\1>|<span class="math-inline">[\s\S]*?<\/span>|<div class="math-block">[\s\S]*?<\/div>"#,
             options: [.caseInsensitive]
         ) else {
             return (html, [])

--- a/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownMathTests.swift
+++ b/Packages/ClearlyCore/Tests/ClearlyCoreTests/MarkdownMathTests.swift
@@ -85,6 +85,33 @@ final class MarkdownMathTests: XCTestCase {
         XCTAssertTrue(html.contains(#"<div class="math-block">"#), html)
     }
 
+    // MARK: - Math source must survive later post-processors (issue #389)
+
+    func testCaretsInInlineMathAreNotSuperscripted() {
+        let html = MarkdownRenderer.renderHTML(#"$\int\frac{x^2}{x^2 + 1} dx$"#)
+        XCTAssertTrue(html.contains(#"<span class="math-inline">"#), html)
+        XCTAssertFalse(html.contains("<sup>"), html)
+        XCTAssertTrue(html.contains(#"\frac{x^2}{x^2 + 1}"#), html)
+    }
+
+    func testCaretsInDisplayMathAreNotSuperscripted() {
+        let html = MarkdownRenderer.renderHTML(
+            """
+            $$
+            \\frac{1 + x^3}{x^3}
+            $$
+            """
+        )
+        XCTAssertTrue(html.contains(#"<div class="math-block">"#), html)
+        XCTAssertFalse(html.contains("<sup>"), html)
+    }
+
+    func testSuperscriptOutsideMathStillWorks() {
+        let html = MarkdownRenderer.renderHTML("E = mc^2^ and $x^2$")
+        XCTAssertTrue(html.contains("<sup>2</sup>"), html)
+        XCTAssertTrue(html.contains(#"<span class="math-inline">x^2</span>"#), html)
+    }
+
     func testDollarsInsideInlineCodeStayLiteral() {
         let html = MarkdownRenderer.renderHTML("`I paid $5 and $10.`")
         XCTAssertFalse(html.contains("math-inline"), html)


### PR DESCRIPTION
Math like `$\frac{x^2}{x^2 + 1}$` rendered exponents as plain text because the `^text^` superscript post-processor ran after math extraction and rewrote carets inside KaTeX source into `<sup>` tags. `protectCodeRegions` now also protects `math-inline` spans and `math-block` divs, so all downstream post-processors (super/sub, highlight marks, emoji) skip math content. Adds tests for both repro expressions plus a regression check that `x^2^` outside math still superscripts. Fix is in ClearlyCore, so it covers Mac, iOS, and QuickLook.

Fixes #389