### PR TITLE
[mac] fix: cursor flicker over links in preview mode

### DIFF
--- a/Clearly/EditorView.swift
+++ b/Clearly/EditorView.swift
@@ -220,6 +220,10 @@ struct EditorView: NSViewRepresentable {
               let textView = scrollView.documentView as? ClearlyTextView else { return }
         let gutter = container.subviews.first(where: { $0 is LineNumberGutterView }) as? LineNumberGutterView
 
+        // SwiftUI .opacity(0) leaves the AppKit view live, so the text view's
+        // i-beam cursor rects would fight the preview's cursor (#388).
+        container.isHidden = mode != .edit
+
         // Keep coordinator's parent fresh so the binding never goes stale
         context.coordinator.parent = self
 


### PR DESCRIPTION
In preview mode the editor's NSTextView sat at SwiftUI opacity 0 but stayed live to AppKit, so its i-beam cursor rects fought the WKWebView's pointing-hand cursor on every mouse move. The preview already hides its webview in edit mode; this mirrors that by hiding the editor container when the mode is not edit.

Fixes #388