### PR TITLE
[mac] fix: avoid retaining external-change activation observers

### DIFF
--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -151,6 +151,9 @@ struct ContentView: View {
                 }
             }
             DispatchQueue.main.async(execute: clearIfUnchanged)
+            // A frontmost app has no activation pending, so keeping this
+            // observer would retain the document until a later app switch.
+            guard !NSApplication.shared.isActive else { return }
             var token: NSObjectProtocol?
             token = NotificationCenter.default.addObserver(
                 forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main


### PR DESCRIPTION
Follow-up to #401.

## Summary
- register the one-shot activation observer only while Clearly is inactive
- prevent foreground external writes from retaining document/view closures until a later app switch
- preserve the immediate foreground clear and deferred background activation clear

## Verification
- `xcodebuild -project Clearly.xcodeproj -scheme Clearly -configuration Debug -derivedDataPath ./.build/DerivedData build`
- `swift test --package-path Packages/ClearlyCore` (101 XCTest + 21 Swift Testing)
- live app: foreground external reload stayed clean
- live app: background external reload cleared on activation and closed without a save prompt