### PR TITLE
[mac] Open dropped and batch-opened markdown files in tabs

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -39,6 +39,14 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+        // Must be registered before AppKit finishes launching to win the
+        // 'odoc' handler slot from NSApplication's default routing.
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleOpenDocumentsEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kCoreEventClass),
+            andEventID: AEEventID(kAEOpenDocuments)
+        )
         // Avoid Dock-icon flash when the user launches with the toggle on.
         // The `didBecomeMain` observer flips us back to `.regular` once a
         // document window appears (Finder-open, untitled-on-launch, etc.).
@@ -119,6 +127,35 @@ final class ClearlyAppDelegate: NSObject, NSApplicationDelegate {
             isDocumentPanelPresented = true
             return false
         }
+    }
+
+    /// Finder "Open with", Dock drops, `open -a`. SwiftUI's `DocumentGroup`
+    /// routes these straight to its document controller (the delegate's
+    /// `application(_:open:)` never fires), so intercept the 'odoc' Apple
+    /// Event itself — registered in `applicationWillFinishLaunching` — and
+    /// land multi-file opens as tabs on one window instead of a window per
+    /// file.
+    @objc private func handleOpenDocumentsEvent(
+        _ event: NSAppleEventDescriptor,
+        withReplyEvent reply: NSAppleEventDescriptor
+    ) {
+        guard let direct = event.paramDescriptor(forKeyword: keyDirectObject) else { return }
+        var urls: [URL] = []
+        if direct.numberOfItems > 0 {
+            for i in 1...direct.numberOfItems {
+                if let url = direct.atIndex(i)?.fileURLValue { urls.append(url) }
+            }
+        } else if let url = direct.fileURLValue {
+            urls.append(url)
+        }
+        DiagnosticLog.log("odoc event: \(urls.count) urls")
+        guard urls.count > 1 else {
+            for url in urls {
+                NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in }
+            }
+            return
+        }
+        DroppedFileOpener.openBatch(urls)
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -92,6 +92,33 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         )
     }
 
+    // MARK: - File drops
+
+    /// Dropping markdown files opens them in tabs (see `DroppedFileOpener`)
+    /// instead of NSTextView's default insert-the-file-path behavior.
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return .copy }
+        return super.draggingEntered(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return .copy }
+        return super.draggingUpdated(sender)
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return true }
+        return super.prepareForDragOperation(sender)
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if let urls = DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard), let window {
+            DroppedFileOpener.open(urls, droppedOn: window)
+            return true
+        }
+        return super.performDragOperation(sender)
+    }
+
     // MARK: - Paste
 
     /// NSTextView's default validation rejects `paste:` when the clipboard

--- a/Clearly/DroppedFileOpener.swift
+++ b/Clearly/DroppedFileOpener.swift
@@ -35,8 +35,8 @@ enum DroppedFileOpener {
                   targetDoc.fileURL == nil, !targetDoc.isDocumentEdited else { return nil }
             return targetDoc
         }()
-        openSerially(urls, tabbingOnto: window) {
-            replaceableDoc?.close()
+        openSerially(urls, tabbingOnto: window) { openedDocument in
+            if openedDocument { replaceableDoc?.close() }
         }
     }
 
@@ -44,15 +44,31 @@ enum DroppedFileOpener {
     /// tabbed onto the frontmost document window when one exists, otherwise
     /// grouped together as tabs of the first file's window.
     static func openBatch(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
         if let front = NSApp.orderedWindows.first(where: { document(for: $0) != nil }) {
-            openSerially(urls, tabbingOnto: front) {}
+            openSerially(urls, tabbingOnto: front) { _ in }
             return
         }
-        NSDocumentController.shared.openDocument(withContentsOf: urls[0], display: true) { doc, _, error in
-            if let error { DiagnosticLog.log("openBatch first open failed: \(error.localizedDescription)") }
-            guard let doc else { return }
+        openBatchWithoutAnchor(urls)
+    }
+
+    /// Find the first URL that opens successfully, then use its window as the
+    /// anchor for the rest of the batch.
+    private static func openBatchWithoutAnchor(_ urls: [URL]) {
+        guard let url = urls.first else { return }
+        let rest = Array(urls.dropFirst())
+        NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { doc, _, error in
+            if let error { DiagnosticLog.log("openBatch failed for \(url.lastPathComponent): \(error.localizedDescription)") }
+            guard let doc else {
+                openBatchWithoutAnchor(rest)
+                return
+            }
             windowWhenReady(for: doc) { anchor in
-                if let anchor { openSerially(Array(urls.dropFirst()), tabbingOnto: anchor) {} }
+                guard let anchor else {
+                    openBatchWithoutAnchor(rest)
+                    return
+                }
+                openSerially(rest, tabbingOnto: anchor) { _ in }
             }
         }
     }
@@ -69,23 +85,33 @@ enum DroppedFileOpener {
     private static func openSerially(
         _ urls: [URL],
         tabbingOnto anchor: NSWindow,
-        completion: @escaping () -> Void
+        openedDocument: Bool = false,
+        completion: @escaping (Bool) -> Void
     ) {
-        guard let url = urls.first else { completion(); return }
+        guard let url = urls.first else { completion(openedDocument); return }
         let rest = Array(urls.dropFirst())
         NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { doc, alreadyOpen, error in
             if let error { DiagnosticLog.log("drop open failed for \(url.lastPathComponent): \(error.localizedDescription)") }
-            guard let doc, !alreadyOpen else {
-                openSerially(rest, tabbingOnto: anchor, completion: completion)
+            guard let doc else {
+                openSerially(rest, tabbingOnto: anchor, openedDocument: openedDocument, completion: completion)
+                return
+            }
+            guard !alreadyOpen else {
+                openSerially(rest, tabbingOnto: anchor, openedDocument: true, completion: completion)
                 return
             }
             windowWhenReady(for: doc) { newWindow in
                 if let newWindow, newWindow !== anchor {
                     anchor.addTabbedWindow(newWindow, ordered: .above)
                     newWindow.makeKeyAndOrderFront(nil)
-                    openSerially(rest, tabbingOnto: newWindow, completion: completion)
+                    openSerially(rest, tabbingOnto: newWindow, openedDocument: true, completion: completion)
                 } else {
-                    openSerially(rest, tabbingOnto: anchor, completion: completion)
+                    openSerially(
+                        rest,
+                        tabbingOnto: anchor,
+                        openedDocument: openedDocument || newWindow != nil,
+                        completion: completion
+                    )
                 }
             }
         }

--- a/Clearly/DroppedFileOpener.swift
+++ b/Clearly/DroppedFileOpener.swift
@@ -1,0 +1,112 @@
+import AppKit
+import UniformTypeIdentifiers
+import ClearlyCore
+
+/// Opens markdown files dragged onto a document window (or handed to the app
+/// by Finder in a batch) as native window tabs instead of scattered
+/// standalone windows.
+enum DroppedFileOpener {
+
+    /// File URLs on the pasteboard, but only when every dragged file is one
+    /// the app can open. Mixed or non-markdown drags return nil so the caller
+    /// falls through to the default behavior (e.g. image drops in the editor).
+    static func markdownFileURLs(from pasteboard: NSPasteboard) -> [URL]? {
+        guard let urls = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL], !urls.isEmpty else { return nil }
+        guard urls.allSatisfy(isOpenableFile) else { return nil }
+        return urls
+    }
+
+    static func isOpenableFile(_ url: URL) -> Bool {
+        guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
+        return type.conforms(to: .daringFireballMarkdown) || type.conforms(to: .plainText)
+    }
+
+    /// Open `urls` as tabs attached to the drop-target `window`. A single
+    /// file dropped on an untitled, unedited document replaces it — the
+    /// "empty tab" becomes the dropped document. Multiple files leave the
+    /// empty tab alone and just add tabs.
+    static func open(_ urls: [URL], droppedOn window: NSWindow) {
+        let targetDoc = document(for: window)
+        let replaceableDoc: NSDocument? = {
+            guard urls.count == 1, let targetDoc,
+                  targetDoc.fileURL == nil, !targetDoc.isDocumentEdited else { return nil }
+            return targetDoc
+        }()
+        openSerially(urls, tabbingOnto: window) {
+            replaceableDoc?.close()
+        }
+    }
+
+    /// Finder / Dock handed the app several files at once: open them all,
+    /// tabbed onto the frontmost document window when one exists, otherwise
+    /// grouped together as tabs of the first file's window.
+    static func openBatch(_ urls: [URL]) {
+        if let front = NSApp.orderedWindows.first(where: { document(for: $0) != nil }) {
+            openSerially(urls, tabbingOnto: front) {}
+            return
+        }
+        NSDocumentController.shared.openDocument(withContentsOf: urls[0], display: true) { doc, _, error in
+            if let error { DiagnosticLog.log("openBatch first open failed: \(error.localizedDescription)") }
+            guard let doc else { return }
+            windowWhenReady(for: doc) { anchor in
+                if let anchor { openSerially(Array(urls.dropFirst()), tabbingOnto: anchor) {} }
+            }
+        }
+    }
+
+    private static func document(for window: NSWindow) -> NSDocument? {
+        NSDocumentController.shared.documents.first { doc in
+            doc.windowControllers.contains { $0.window === window }
+        }
+    }
+
+    /// Opens one URL at a time so tab order matches the list order; each new
+    /// tab becomes the anchor for the next. Already-open documents are just
+    /// brought forward, not re-parented into the tab group.
+    private static func openSerially(
+        _ urls: [URL],
+        tabbingOnto anchor: NSWindow,
+        completion: @escaping () -> Void
+    ) {
+        guard let url = urls.first else { completion(); return }
+        let rest = Array(urls.dropFirst())
+        NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { doc, alreadyOpen, error in
+            if let error { DiagnosticLog.log("drop open failed for \(url.lastPathComponent): \(error.localizedDescription)") }
+            guard let doc, !alreadyOpen else {
+                openSerially(rest, tabbingOnto: anchor, completion: completion)
+                return
+            }
+            windowWhenReady(for: doc) { newWindow in
+                if let newWindow, newWindow !== anchor {
+                    anchor.addTabbedWindow(newWindow, ordered: .above)
+                    newWindow.makeKeyAndOrderFront(nil)
+                    openSerially(rest, tabbingOnto: newWindow, completion: completion)
+                } else {
+                    openSerially(rest, tabbingOnto: anchor, completion: completion)
+                }
+            }
+        }
+    }
+
+    /// SwiftUI's `DocumentGroup` can attach the window controller a runloop
+    /// turn after `openDocument`'s completion fires, so poll briefly.
+    private static func windowWhenReady(
+        for doc: NSDocument,
+        attempt: Int = 0,
+        _ completion: @escaping (NSWindow?) -> Void
+    ) {
+        if let window = doc.windowControllers.first?.window {
+            completion(window)
+        } else if attempt < 20 {
+            DispatchQueue.main.async {
+                windowWhenReady(for: doc, attempt: attempt + 1, completion)
+            }
+        } else {
+            DiagnosticLog.log("drop open: no window appeared for \(doc.fileURL?.lastPathComponent ?? "untitled")")
+            completion(nil)
+        }
+    }
+}

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -18,6 +18,33 @@ private final class DraggableWKWebView: WKWebView {
         }
         super.mouseDown(with: event)
     }
+
+    // MARK: - File drops
+
+    /// Dropping markdown files on the preview opens them in tabs instead of
+    /// letting WKWebView attempt a navigation to the dropped file.
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return .copy }
+        return super.draggingEntered(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return .copy }
+        return super.draggingUpdated(sender)
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard) != nil { return true }
+        return super.prepareForDragOperation(sender)
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if let urls = DroppedFileOpener.markdownFileURLs(from: sender.draggingPasteboard), let window {
+            DroppedFileOpener.open(urls, droppedOn: window)
+            return true
+        }
+        return super.performDragOperation(sender)
+    }
 }
 
 struct PreviewView: NSViewRepresentable {


### PR DESCRIPTION
Dropping one or more markdown files onto a Clearly window (editor or preview) now opens them as native window tabs instead of inserting the file path as text. A single file dropped on an untitled, unedited document replaces it, while multiple files leave the empty tab alone and just add tabs, matching browser/editor convention. Finder "Open with" and Dock drops of multiple files also land as tabs on the frontmost document window, via a kAEOpenDocuments Apple Event handler since SwiftUI's DocumentGroup bypasses the delegate's application(_:open:). Non-markdown drops keep their existing behavior.

Fixes #384