### PR TITLE
Fix mermaid/katex/highlight not rendering for files on external drives

### DIFF
--- a/Clearly/PDFExporter.swift
+++ b/Clearly/PDFExporter.swift
@@ -73,7 +73,9 @@ final class PDFExporter: NSObject, WKNavigationDelegate {
         \(htmlBody.contains("language-mermaid") ? MermaidSupport.scriptHTML : "")
         </html>
         """
-        wv.loadHTMLString(html, baseURL: documentURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
+        // Bundle resource dir, not the document dir: a baseURL on another volume
+        // blocks the bundled file: JS/CSS subresources (see PreviewView).
+        wv.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
     }
 
     // MARK: - WKNavigationDelegate

--- a/Clearly/PreviewView.swift
+++ b/Clearly/PreviewView.swift
@@ -345,7 +345,12 @@ struct PreviewView: NSViewRepresentable {
         \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
-        webView.loadHTMLString(html, baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
+        // Base URL must be the bundle's resource directory, not the document's
+        // directory: with a baseURL on another volume (external drive), WebKit
+        // refuses to load the bundled file: JS/CSS subresources (mermaid, katex,
+        // highlight). Local images don't need the document baseURL — they go
+        // through LocalImageSchemeHandler — and relative links resolve in Swift.
+        webView.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {

--- a/Clearly/iOS/PreviewExtension/PreviewViewController.swift
+++ b/Clearly/iOS/PreviewExtension/PreviewViewController.swift
@@ -40,7 +40,9 @@ final class PreviewViewController: UIViewController, QLPreviewingController {
             </html>
             """
 
-            webView.loadHTMLString(html, baseURL: url.deletingLastPathComponent())
+            // Bundle resource dir, not the document dir: a baseURL on another
+            // volume blocks the bundled file: JS/CSS subresources.
+            webView.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
             handler(nil)
         } catch {
             handler(error)

--- a/Clearly/iOS/PreviewView_iOS.swift
+++ b/Clearly/iOS/PreviewView_iOS.swift
@@ -200,7 +200,11 @@ struct PreviewView_iOS: UIViewRepresentable {
         \(SyntaxHighlightSupport.scriptHTML(for: htmlBody))
         </html>
         """
-        webView.loadHTMLString(html, baseURL: fileURL?.deletingLastPathComponent() ?? MermaidSupport.resourceBaseURL)
+        // Bundle resource dir, not the document dir: a baseURL on another volume
+        // (external drive / file provider) blocks the bundled file: JS/CSS
+        // subresources (mermaid, katex, highlight). Images use
+        // LocalImageSchemeHandler; relative links resolve in Swift.
+        webView.loadHTMLString(html, baseURL: MermaidSupport.resourceBaseURL)
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {


### PR DESCRIPTION
Fixes #409

The preview (Mac + iOS), PDF export, and iOS QuickLook extension loaded HTML with the document's directory as the WKWebView baseURL. When the document lives on a different volume (external drive, or a file provider on iOS), WebKit refuses to load the bundled `file:` JS/CSS subresources — mermaid, KaTeX, and highlight.js — so mermaid diagrams rendered as plain code blocks. Mac QuickLook already used the bundle resource directory as baseURL, which is why spacebar preview worked on the external drive.

Nothing actually needs the document-directory baseURL anymore: local images go through `LocalImageSchemeHandler`, and relative links resolve in Swift against `fileURL`. All four load sites now use `MermaidSupport.resourceBaseURL`.

## Verification
- Reproduced on a mounted APFS disk image (separate volume): diagram showed as a code block before the fix, renders after.
- Regression check: a document with a relative local image (`![red](red.png)`) plus a mermaid block renders both correctly.
- `swift test --package-path Packages/ClearlyCore` green; Mac and iOS targets build.