### PR TITLE
[mac] Add highlight formatting command

### DIFF
--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -494,6 +494,7 @@ struct ClearlyApp: App {
                     .keyboardShortcut("i", modifiers: .command)
                 Button("Strikethrough") { performFormattingCommand(selector: #selector(ClearlyTextView.toggleStrikethrough(_:))) }
                     .keyboardShortcut("x", modifiers: [.command, .shift])
+                Button("Highlight") { performFormattingCommand(selector: #selector(ClearlyTextView.toggleHighlight(_:))) }
                 Button("Heading") { performFormattingCommand(selector: #selector(ClearlyTextView.insertHeading(_:))) }
                     .keyboardShortcut("h", modifiers: [.command, .shift])
                 Divider()

--- a/Clearly/ClearlyTextView.swift
+++ b/Clearly/ClearlyTextView.swift
@@ -368,6 +368,10 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         wrapSelection(prefix: "~~", suffix: "~~", placeholder: "strikethrough text")
     }
 
+    @objc func toggleHighlight(_ sender: Any?) {
+        wrapSelection(prefix: "==", suffix: "==", placeholder: "highlighted text")
+    }
+
     @objc func insertImage(_ sender: Any?) {
         let range = selectedRange()
         let selected = (string as NSString).substring(with: range)
@@ -502,6 +506,7 @@ final class ClearlyTextView: PersistentTextCheckingTextView {
         italicItem.keyEquivalentModifierMask = .command
         let strikeItem = formatMenu.addItem(withTitle: "Strikethrough", action: #selector(toggleStrikethrough(_:)), keyEquivalent: "x")
         strikeItem.keyEquivalentModifierMask = [.command, .shift]
+        formatMenu.addItem(withTitle: "Highlight", action: #selector(toggleHighlight(_:)), keyEquivalent: "")
         formatMenu.addItem(.separator())
 
         formatMenu.addItem(withTitle: "Insert Link", action: #selector(insertLink(_:)), keyEquivalent: "")


### PR DESCRIPTION
Adds Highlight to the macOS Format menu and editor context menu.

Selected text is wrapped with == markers using the existing formatting behavior.

Verified with the Debug macOS build, 122 passing tests, and the live Format → Highlight workflow.

Fixes #338