### PR TITLE
[mac] Export documents as Rich Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Export documents as Rich Text from the File menu
 
 ## [3.3.0] - 2026-08-23
 - Dropping markdown files on a document now opens them as window tabs instead of pasting the file path

--- a/Clearly/ClearlyApp.swift
+++ b/Clearly/ClearlyApp.swift
@@ -634,6 +634,10 @@ private struct ExportPDFActionKey: FocusedValueKey {
     typealias Value = () -> Void
 }
 
+private struct ExportRichTextActionKey: FocusedValueKey {
+    typealias Value = () -> Void
+}
+
 private struct PrintDocumentActionKey: FocusedValueKey {
     typealias Value = () -> Void
 }
@@ -655,6 +659,10 @@ extension FocusedValues {
         get { self[ExportPDFActionKey.self] }
         set { self[ExportPDFActionKey.self] = newValue }
     }
+    var exportRichTextAction: (() -> Void)? {
+        get { self[ExportRichTextActionKey.self] }
+        set { self[ExportRichTextActionKey.self] = newValue }
+    }
     var printDocumentAction: (() -> Void)? {
         get { self[PrintDocumentActionKey.self] }
         set { self[PrintDocumentActionKey.self] = newValue }
@@ -665,6 +673,7 @@ extension FocusedValues {
 
 struct ExportPrintCommands: View {
     @FocusedValue(\.exportPDFAction) var exportPDFAction
+    @FocusedValue(\.exportRichTextAction) var exportRichTextAction
     @FocusedValue(\.printDocumentAction) var printDocumentAction
 
     var body: some View {
@@ -673,6 +682,13 @@ struct ExportPrintCommands: View {
         }
         .keyboardShortcut("e", modifiers: [.command, .shift])
         .disabled(exportPDFAction == nil)
+
+        Button("Export as Rich Text…") {
+            exportRichTextAction?()
+        }
+        .disabled(exportRichTextAction == nil)
+
+        Divider()
 
         Button("Print…") {
             printDocumentAction?()

--- a/Clearly/ContentView.swift
+++ b/Clearly/ContentView.swift
@@ -114,6 +114,7 @@ struct ContentView: View {
         .focusedSceneValue(\.outlineState, outlineState)
         .focusedSceneValue(\.viewMode, $viewMode)
         .focusedSceneValue(\.exportPDFAction) { exportPDF() }
+        .focusedSceneValue(\.exportRichTextAction) { exportRichText() }
         .focusedSceneValue(\.printDocumentAction) { printDocument() }
         .onAppear {
             outlineState.parseHeadings(from: document.text)
@@ -229,6 +230,10 @@ struct ContentView: View {
             fontFamily: previewFontFamily,
             fileURL: fileURL
         )
+    }
+
+    private func exportRichText() {
+        DocumentExporter.exportRichText(markdown: document.text, sourceURL: fileURL)
     }
 
     private func printDocument() {

--- a/Clearly/DocumentExporter.swift
+++ b/Clearly/DocumentExporter.swift
@@ -1,0 +1,48 @@
+import AppKit
+import ClearlyCore
+import UniformTypeIdentifiers
+
+@MainActor
+enum DocumentExporter {
+    static func exportRichText(markdown: String, sourceURL: URL?) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.rtf]
+        let baseName = sourceURL?.deletingPathExtension().lastPathComponent ?? "Untitled"
+        panel.nameFieldStringValue = "\(baseName).rtf"
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try richTextData(for: markdown).write(to: url, options: .atomic)
+        } catch {
+            NSAlert(error: error).runModal()
+        }
+    }
+
+    private static func richTextData(for markdown: String) throws -> Data {
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head><meta charset="utf-8"></head>
+        <body>\(MarkdownRenderer.renderHTML(markdown))</body>
+        </html>
+        """
+
+        guard let attributed = NSAttributedString(html: Data(html.utf8), documentAttributes: nil),
+              let data = attributed.rtf(
+                from: NSRange(location: 0, length: attributed.length),
+                documentAttributes: [:]
+              ) else {
+            throw DocumentExportError.conversionFailed
+        }
+        return data
+    }
+}
+
+private enum DocumentExportError: LocalizedError {
+    case conversionFailed
+
+    var errorDescription: String? {
+        "Could not export this document as Rich Text."
+    }
+}


### PR DESCRIPTION
Adds File → Export as Rich Text for the focused document, with source-derived .rtf filenames and atomic writes. Converts rendered Markdown to RTF while preserving headings, emphasis, and lists, and surfaces conversion or write errors. Verified with a Debug build, 122 tests, and manual RTF round-trips including empty documents.

Fixes #339